### PR TITLE
idmanager parser access, translate account ids

### DIFF
--- a/src/main/java/com/mozilla/secops/identity/IdentityManager.java
+++ b/src/main/java/com/mozilla/secops/identity/IdentityManager.java
@@ -12,10 +12,14 @@ import java.util.Iterator;
 
 /**
  * {@link IdentityManager} supports translations from values such as user names
- * to a global identifier for a user
+ * to a global identifier
+ *
+ * <p>In addition to username identity translation, this class can also handle translations
+ * from values such as AWS account IDs to a more description account name.
  */
 public class IdentityManager {
     private Map<String, Identity> identities;
+    private Map<String, String> awsAccountMap;
     private Notify defaultNotification;
 
     /**
@@ -31,6 +35,16 @@ public class IdentityManager {
         }
         ObjectMapper mapper = new ObjectMapper();
         return mapper.readValue(in, IdentityManager.class);
+    }
+
+    /**
+     * Get AWS account map
+     *
+     * @return Map of AWS account identifiers to descriptive names
+     */
+    @JsonProperty("aws_account_map")
+    public Map<String, String> getAwsAccountMap() {
+        return awsAccountMap;
     }
 
     /**
@@ -86,5 +100,6 @@ public class IdentityManager {
      */
     public IdentityManager() {
         identities = new HashMap<String, Identity>();
+        awsAccountMap = new HashMap<String, String>();
     }
 }

--- a/src/main/java/com/mozilla/secops/parser/Normalized.java
+++ b/src/main/java/com/mozilla/secops/parser/Normalized.java
@@ -24,6 +24,10 @@ public class Normalized implements Serializable {
     private String sourceAddressCountry;
     private String object;
 
+    /* Following can typically only be set if the parser has been configured
+     * to use an identity manager for lookups */
+    private String subjectUserIdentity;
+
     Normalized() {
     }
 
@@ -79,6 +83,24 @@ public class Normalized implements Serializable {
      */
     public String getSubjectUser() {
         return subjectUser;
+    }
+
+    /**
+     * Get subject user identity field
+     *
+     * @return Subject user identity
+     */
+    public String getSubjectUserIdentity() {
+        return subjectUserIdentity;
+    }
+
+    /**
+     * Set subject user identity field
+     *
+     * @param subjectUserIdentity Resolved identity value
+     */
+    public void setSubjectUserIdentity(String subjectUserIdentity) {
+        this.subjectUserIdentity = subjectUserIdentity;
     }
 
     /**

--- a/src/main/java/com/mozilla/secops/parser/OpenSSH.java
+++ b/src/main/java/com/mozilla/secops/parser/OpenSSH.java
@@ -2,6 +2,8 @@ package com.mozilla.secops.parser;
 
 import com.maxmind.geoip2.model.CityResponse;
 
+import com.mozilla.secops.identity.IdentityManager;
+
 import java.io.Serializable;
 import java.util.regex.Pattern;
 import java.util.regex.Matcher;
@@ -67,6 +69,16 @@ public class OpenSSH extends PayloadBase implements Serializable {
             n.setSubjectUser(user);
             n.setSourceAddress(sourceAddress);
             n.setObject(hostname);
+
+            // If we have an instance of IdentityManager in the parser, see if we can
+            // also set the resolved subject identity
+            IdentityManager mgr = p.getIdentityManager();
+            if (mgr != null) {
+                String resId = mgr.lookupAlias(user);
+                if (resId != null) {
+                    n.setSubjectUserIdentity(resId);
+                }
+            }
 
             if (sourceAddress != null) {
                 CityResponse cr = p.geoIp(sourceAddress);

--- a/src/main/java/com/mozilla/secops/parser/Parser.java
+++ b/src/main/java/com/mozilla/secops/parser/Parser.java
@@ -13,6 +13,8 @@ import org.joda.time.format.ISODateTimeFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.mozilla.secops.identity.IdentityManager;
+
 import java.util.List;
 import java.util.Map;
 import java.util.ArrayList;
@@ -36,6 +38,8 @@ public class Parser {
     private final JacksonFactory jf;
     private final Logger log;
     private final GeoIP geoip;
+
+    private IdentityManager idmanager;
 
     /**
      * Parse an ISO8601 date string and return a {@link DateTime} object.
@@ -105,6 +109,24 @@ public class Parser {
      */
     public Boolean geoIpUsingTest() {
         return geoip.usingTest();
+    }
+
+    /**
+     * Set an identity manager in the parser that can be used for lookups
+     *
+     * @param idmanager Initialized {@link IdentityManager}
+     */
+    public void setIdentityManager(IdentityManager idmanager) {
+        this.idmanager = idmanager;
+    }
+
+    /**
+     * Get any configured identity manager from the parser
+     *
+     * @return {@link IdentityManager} or null if no manager has been set in the parser
+     */
+    public IdentityManager getIdentityManager() {
+        return idmanager;
     }
 
     /**

--- a/src/test/java/com/mozilla/secops/identity/TestIdentityManager.java
+++ b/src/test/java/com/mozilla/secops/identity/TestIdentityManager.java
@@ -6,6 +6,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertEquals;
 
+import java.util.Map;
+
 public class TestIdentityManager {
     public TestIdentityManager() {
     }
@@ -49,5 +51,17 @@ public class TestIdentityManager {
         assertEquals("holodeck-riker@mozilla.com",
             id.getEmailNotifyDirect(mgr.getDefaultNotification()));
         assertEquals("riker", id.getFragment());
+    }
+
+    @Test
+    public void identityManagerAwsAccountMapLookupTest() throws Exception {
+        IdentityManager mgr = IdentityManager.loadFromResource("/testdata/identitymanager.json");
+        assertNotNull(mgr);
+
+        Map<String, String> m = mgr.getAwsAccountMap();
+        assertNull(m.get("000000000"));
+        String ret = m.get("123456789");
+        assertNotNull(ret);
+        assertEquals("riker-vacationing-on-risa", ret);
     }
 }

--- a/src/test/java/com/mozilla/secops/parser/ParserIdentityTest.java
+++ b/src/test/java/com/mozilla/secops/parser/ParserIdentityTest.java
@@ -1,0 +1,49 @@
+package com.mozilla.secops.parser;
+
+import org.junit.Test;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.maxmind.geoip2.model.CityResponse;
+
+import org.joda.time.DateTime;
+
+import com.mozilla.secops.identity.IdentityManager;
+
+public class ParserIdentityTest {
+    public ParserIdentityTest() {
+    }
+
+    @Test
+    public void testOpenSSHStackdriverWithIdentity() throws Exception {
+        String buf = "{\"insertId\":\"f8p4mz1a3ldcos1xz\",\"labels\":{\"compute.googleapis.com/resource_" +
+            "name\":\"emit-bastion\"},\"logName\":\"projects/sandbox-00/logs/syslog\",\"receiveTimestamp\"" +
+            ":\"2018-09-20T18:43:38.318580313Z\",\"resource\":{\"labels\":{\"instance_id\":\"9999999999999" +
+            "999999\",\"project_id\":\"sandbox-00\",\"zone\":\"us-east1-b\"},\"type\":\"gce_instance\"},\"" +
+            "textPayload\":\"Sep 18 22:15:38 emit-bastion sshd[2644]: Accepted publickey for riker from 12" +
+            "7.0.0.1 port 58530 ssh2: RSA SHA256:dd/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\",\"timestamp" +
+            "\":\"2018-09-18T22:15:38Z\"}";
+        IdentityManager mgr = IdentityManager.loadFromResource("/testdata/identitymanager.json");
+        Parser p = new Parser();
+        p.setIdentityManager(mgr);
+        assertNotNull(p);
+        Event e = p.parse(buf);
+        assertNotNull(e);
+        assertEquals(Payload.PayloadType.OPENSSH, e.getPayloadType());
+        OpenSSH o = e.getPayload();
+        assertNotNull(o);
+        assertEquals("riker", o.getUser());
+        assertEquals("publickey", o.getAuthMethod());
+        assertEquals("127.0.0.1", o.getSourceAddress());
+        assertNull(o.getSourceAddressCity());
+        assertNull(o.getSourceAddressCountry());
+        Normalized n = e.getNormalized();
+        assertNotNull(n);
+        assertEquals(Normalized.Type.AUTH, n.getType());
+        assertEquals("riker", n.getSubjectUser());
+        assertEquals("wriker@mozilla.com", n.getSubjectUserIdentity());
+        assertEquals("127.0.0.1", n.getSourceAddress());
+    }
+}

--- a/src/test/resources/testdata/identitymanager.json
+++ b/src/test/resources/testdata/identitymanager.json
@@ -20,5 +20,8 @@
     "default_notify": {
         "direct_email_notify": true,
         "direct_email_notify_format": "testing-%s@mozilla.com"
+    },
+    "aws_account_map": {
+        "123456789": "riker-vacationing-on-risa"
     }
 }


### PR DESCRIPTION
Add support to IdentityManager for AWS account ID translation.

This also adds support to Parser to set an IdentityManager within a
parser instance so it can be called by individual parsers to set various
fields if an identity manager is present.

Closes #2