### PR TITLE
Initial framework around customs implementation

### DIFF
--- a/src/main/java/com/mozilla/secops/alert/AlertFormatter.java
+++ b/src/main/java/com/mozilla/secops/alert/AlertFormatter.java
@@ -1,0 +1,15 @@
+package com.mozilla.secops.alert;
+
+import org.apache.beam.sdk.transforms.DoFn;
+
+/**
+ * {@link DoFn} for conversion of {@link Alert} objects into JSON strings
+ */
+public class AlertFormatter extends DoFn<Alert, String> {
+    private static final long serialVersionUID = 1L;
+
+    @ProcessElement
+    public void processElement(ProcessContext c) {
+        c.output(c.element().toJSON());
+    }
+}

--- a/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
+++ b/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
@@ -25,6 +25,7 @@ import org.joda.time.Duration;
 import com.mozilla.secops.InputOptions;
 import com.mozilla.secops.OutputOptions;
 import com.mozilla.secops.alert.Alert;
+import com.mozilla.secops.alert.AlertFormatter;
 import com.mozilla.secops.parser.Event;
 import com.mozilla.secops.parser.Normalized;
 import com.mozilla.secops.parser.Parser;
@@ -254,19 +255,6 @@ public class AuthProfile implements Serializable {
     }
 
     /**
-     * {@link DoFn} to transform any generated {@link Alert} objects into JSON for
-     * consumption by output transforms.
-     */
-    public static class OutputFormat extends DoFn<Alert, String> {
-        private static final long serialVersionUID = 1L;
-
-        @ProcessElement
-        public void processElement(ProcessContext c) {
-            c.output(c.element().toJSON());
-        }
-    }
-
-    /**
      * Runtime options for {@link AuthProfile} pipeline.
      */
     public interface AuthProfileOptions extends PipelineOptions, InputOptions, OutputOptions {
@@ -300,7 +288,7 @@ public class AuthProfile implements Serializable {
             .apply("parse and window", new ParseAndWindow());
 
         PCollection<String> alerts = events.apply(ParDo.of(new Analyze(options)))
-            .apply("output format", ParDo.of(new OutputFormat()));
+            .apply("output format", ParDo.of(new AlertFormatter()));
 
         alerts.apply("output", OutputOptions.compositeOutput(options));
 

--- a/src/main/java/com/mozilla/secops/customs/Customs.java
+++ b/src/main/java/com/mozilla/secops/customs/Customs.java
@@ -68,12 +68,12 @@ public class Customs implements Serializable {
             return col.apply(ParDo.of(new ActionFilter("loginFailure")))
                 .apply(ParDo.of(new ElementExtractor(ElementExtractor.ExtractElement.SOURCEADDRESS)))
                 .apply("Sliding window", Window.<KV<String, Event>>into(
-                    SlidingWindows.of(Duration.standardMinutes(15))
+                    SlidingWindows.of(Duration.standardSeconds(windowLength))
                     .every(Duration.standardSeconds(5)))
                 )
                 .apply("GBK event", GroupByKey.<String, Event>create())
                 .apply(ParDo.of(new LimitCriterion(Alert.AlertSeverity.INFORMATIONAL,
-                    "rl_login_failure_source_address", 3L)))
+                    "rl_login_failure_source_address", threshold)))
                 .apply("Fixed window",
                     Window.<KV<String, Alert>>into(FixedWindows.of(Duration.standardMinutes(15)))
                         .triggering(Repeatedly.forever(

--- a/src/main/java/com/mozilla/secops/customs/Customs.java
+++ b/src/main/java/com/mozilla/secops/customs/Customs.java
@@ -1,0 +1,363 @@
+package com.mozilla.secops.customs;
+
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.options.Default;
+import org.apache.beam.sdk.options.Description;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.options.Validation.Required;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.GroupByKey;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.windowing.FixedWindows;
+import org.apache.beam.sdk.transforms.windowing.Window;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.transforms.windowing.Repeatedly;
+import org.apache.beam.sdk.transforms.windowing.AfterProcessingTime;
+import org.apache.beam.sdk.transforms.windowing.AfterWatermark;
+import org.apache.beam.sdk.transforms.windowing.AfterPane;
+import org.apache.beam.sdk.transforms.windowing.SlidingWindows;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.state.StateSpec;
+import org.apache.beam.sdk.state.StateSpecs;
+import org.apache.beam.sdk.state.ValueState;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.mozilla.secops.InputOptions;
+import com.mozilla.secops.OutputOptions;
+import com.mozilla.secops.parser.Event;
+import com.mozilla.secops.parser.Parser;
+import com.mozilla.secops.parser.Payload;
+import com.mozilla.secops.parser.SecEvent;
+import com.mozilla.secops.alert.Alert;
+import com.mozilla.secops.alert.AlertFormatter;
+
+import org.joda.time.DateTime;
+import org.joda.time.Duration;
+
+import java.io.Serializable;
+import java.util.Collection;
+
+/**
+ * Implements various rate limiting and analysis heuristics on {@link SecEvent} streams
+ */
+public class Customs implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Detect limit violations on login failure based on source address
+     */
+    public static class RlLoginFailureSourceAddress extends PTransform<PCollection<Event>,
+        PCollection<Alert>> {
+        private static final long serialVersionUID = 1L;
+
+        private final Long threshold;
+        private final Long windowLength;
+
+        public RlLoginFailureSourceAddress(Long threshold, Long windowLength) {
+            this.threshold = threshold;
+            this.windowLength = windowLength;
+        }
+
+        @Override
+        public PCollection<Alert> expand(PCollection<Event> col) {
+            return col.apply(ParDo.of(new ActionFilter("loginFailure")))
+                .apply(ParDo.of(new ElementExtractor(ElementExtractor.ExtractElement.SOURCEADDRESS)))
+                .apply("Sliding window", Window.<KV<String, Event>>into(
+                    SlidingWindows.of(Duration.standardMinutes(15))
+                    .every(Duration.standardSeconds(5)))
+                )
+                .apply("GBK event", GroupByKey.<String, Event>create())
+                .apply(ParDo.of(new LimitCriterion(Alert.AlertSeverity.INFORMATIONAL,
+                    "rl_login_failure_source_address", 3L)))
+                .apply("Fixed window",
+                    Window.<KV<String, Alert>>into(FixedWindows.of(Duration.standardMinutes(15)))
+                        .triggering(Repeatedly.forever(
+                            AfterWatermark.pastEndOfWindow()
+                            .withEarlyFirings(AfterPane.elementCountAtLeast(1))
+                        ))
+                        .withAllowedLateness(Duration.ZERO)
+                        .discardingFiredPanes()
+                    )
+                .apply("GBK alert", GroupByKey.<String, Alert>create())
+                .apply(ParDo.of(new Suppressor()));
+        }
+    }
+
+    /**
+     * Suppress duplicate in-window alerts based on key
+     */
+    public static class Suppressor extends DoFn<KV<String, Iterable<Alert>>, Alert> {
+        private static final long serialVersionUID = 1L;
+
+        private Logger log;
+
+        @StateId("suppression")
+        private final StateSpec<ValueState<Boolean>> suppression =
+            StateSpecs.value();
+
+        public Suppressor() {
+            log = LoggerFactory.getLogger(Suppressor.class);
+        }
+
+        @ProcessElement
+        public void processElement(ProcessContext c, BoundedWindow w,
+            @StateId("suppression") ValueState<Boolean> suppress) {
+            KV<String, Iterable<Alert>> el = c.element();
+            String key = el.getKey();
+            Iterable<Alert> alertval = el.getValue();
+
+            if (!(alertval instanceof Collection)) {
+                return;
+            }
+            Alert[] alerts = ((Collection<Alert>) alertval).toArray(new Alert[0]);
+            if (alerts.length == 0) {
+                return;
+            }
+
+            Boolean sflag = suppress.read();
+            if (sflag != null && sflag) {
+                log.info("suppressing additional in-window alert for {}", key);
+                return;
+            }
+            suppress.write(true);
+            log.info("emitting alert for {} in window {} [{}]", key, w.maxTimestamp(),
+                w.maxTimestamp().getMillis());
+
+            // Write the earlist timestamp for the alert set we can find
+            DateTime min = null;
+            int idx = -1;
+            for (int i = 0; i < alerts.length; i++) {
+                if (min == null) {
+                    min = alerts[i].getTimestamp();
+                    idx = i;
+                    continue;
+                }
+                if (alerts[i].getTimestamp().isBefore(min)) {
+                    min = alerts[i].getTimestamp();
+                    idx = i;
+                }
+            }
+            log.info("emit {} {} {}", alerts[idx].getAlertId(), alerts[idx].getCategory(),
+                alerts[idx].getTimestamp());
+            c.output(alerts[idx]);
+        }
+    }
+
+    /**
+     * Generate alerts based on comparison of iterable with supplied limit criterion
+     */
+    public static class LimitCriterion extends DoFn<KV<String, Iterable<Event>>, KV<String, Alert>> {
+        private static final long serialVersionUID = 1L;
+
+        private final Alert.AlertSeverity severity;
+        private final String customsMeta;
+        private final long limit;
+
+        private Logger log;
+
+        /**
+         * {@link LimitCriterion} static initializer
+         */
+        public LimitCriterion(Alert.AlertSeverity severity, String customsMeta, long limit) {
+            this.severity = severity;
+            this.customsMeta = customsMeta;
+            this.limit = limit;
+        }
+
+        @Setup
+        public void setup() {
+            log = LoggerFactory.getLogger(LimitCriterion.class);
+            log.info("initialized new limit criterion analyzer, {} {} {}", severity, customsMeta, limit);
+        }
+
+        @ProcessElement
+        public void processElement(ProcessContext c) {
+            KV<String, Iterable<Event>> e = c.element();
+
+            String key = e.getKey();
+            Iterable<Event> values = e.getValue();
+            if (!(values instanceof Collection)) {
+                return;
+            }
+            Event[] events = ((Collection<Event>) values).toArray(new Event[0]);
+            if (events.length < limit) {
+                return;
+            }
+
+            Alert alert = new Alert();
+            alert.setCategory("customs");
+            alert.addMetadata("customs_category", customsMeta);
+            alert.addMetadata("customs_suspected", key);
+            alert.setSeverity(severity);
+            c.output(KV.of(key, alert));
+        }
+    }
+
+    /**
+     * {@link DoFn} to convert an {@link Event} into a {@link KV} where the key is a
+     * specific known field in the event, and the value is the event itself.
+     */
+    public static class ElementExtractor extends DoFn<Event, KV<String, Event>> {
+        private static final long serialVersionUID = 1L;
+
+        /**
+         * Possible elements for extraction
+         */
+        public enum ExtractElement {
+            /** SecEvent source address */
+            SOURCEADDRESS
+        }
+
+        private final ExtractElement etype;
+
+        public ElementExtractor(ExtractElement etype) {
+            this.etype = etype;
+        }
+
+        @ProcessElement
+        public void processElement(ProcessContext c) {
+            Event e = c.element();
+            if (e == null) {
+                return;
+            }
+            SecEvent s = e.getPayload();
+            if (s == null) {
+                return;
+            }
+            String k;
+            switch (etype) {
+                case SOURCEADDRESS:
+                    k = s.getSecEventData().getSourceAddress();
+                    break;
+                default:
+                    throw new IllegalArgumentException("invalid extraction element");
+            }
+            if (k == null) {
+                return;
+            }
+            c.output(KV.of(k, e));
+        }
+    }
+
+    /**
+     * Filter input {@link PCollection} based on the specified action, returning only events
+     * that match the specified action
+     */
+    public static class ActionFilter extends DoFn<Event, Event> {
+        private static final long serialVersionUID = 1L;
+
+        private String match;
+
+        public ActionFilter(String match) {
+            this.match = match;
+        }
+
+        @ProcessElement
+        public void processElement(ProcessContext c) {
+            Event e = c.element();
+            if (e != null && e.getPayloadType() == Payload.PayloadType.SECEVENT) {
+                SecEvent s = e.getPayload();
+                String action = s.getSecEventData().getAction();
+                if (action != null && action.equals(match)) {
+                    c.output(e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Parse input event strings, returning any parsed SECEVENT
+     */
+    public static class Parse extends DoFn<String, Event> {
+        private static final long serialVersionUID = 1L;
+
+        private Logger log;
+        private Parser ep;
+        private Long parseCount;
+
+        private final Boolean emitEventTimestamps;
+
+        public Parse(Boolean emitEventTimestamps) {
+            this.emitEventTimestamps = emitEventTimestamps;
+        }
+
+        @Setup
+        public void setup() {
+            ep = new Parser();
+            log = LoggerFactory.getLogger(Parse.class);
+            log.info("initialized new parser");
+        }
+
+        @StartBundle
+        public void StartBundle() {
+            log.info("processing new bundle");
+            parseCount = 0L;
+        }
+
+        @FinishBundle
+        public void FinishBundle() {
+            log.info("{} events processed in bundle", parseCount);
+        }
+
+        @ProcessElement
+        public void processElement(ProcessContext c) {
+            Event e = ep.parse(c.element());
+            if (e != null && e.getPayloadType() == Payload.PayloadType.SECEVENT) {
+                parseCount++;
+                if (emitEventTimestamps) {
+                    c.outputWithTimestamp(e, e.getTimestamp().toInstant());
+                } else {
+                    c.output(e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Runtime options for {@link Customs} pipeline.
+     */
+    public interface CustomsOptions extends PipelineOptions, InputOptions, OutputOptions {
+        @Description("login failure by source address; rate limit threshold")
+        @Default.Long(3L)
+        Long getLoginFailureBySourceAddressLimitThreshold();
+        void setLoginFailureBySourceAddressLimitThreshold(Long value);
+
+        @Description("login failure by source address; analysis window length")
+        @Default.Long(900L)
+        Long getLoginFailureBySourceAddressLimitWindowLength();
+        void setLoginFailureBySourceAddressLimitWindowLength(Long value);
+    }
+
+    private static void runCustoms(CustomsOptions options) {
+        Pipeline p = Pipeline.create(options);
+
+        PCollection<Alert> rlalerts = p.apply("input", options.getInputType().read(p, options))
+            .apply("parse", ParDo.of(new Parse(false)))
+            .apply(new RlLoginFailureSourceAddress(
+                options.getLoginFailureBySourceAddressLimitThreshold(),
+                options.getLoginFailureBySourceAddressLimitWindowLength()
+            ));
+
+        rlalerts.apply(ParDo.of(new AlertFormatter()))
+            .apply("output", OutputOptions.compositeOutput(options));
+
+        p.run();
+    }
+
+    /**
+     * Entry point for Beam pipeline.
+     *
+     * @param args Runtime arguments.
+     */
+    public static void main(String[] args) {
+        PipelineOptionsFactory.register(CustomsOptions.class);
+        CustomsOptions options =
+            PipelineOptionsFactory.fromArgs(args).withValidation().as(CustomsOptions.class);
+        runCustoms(options);
+    }
+}

--- a/src/main/java/com/mozilla/secops/parser/EventFilter.java
+++ b/src/main/java/com/mozilla/secops/parser/EventFilter.java
@@ -1,0 +1,87 @@
+package com.mozilla.secops.parser;
+
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.DoFn;
+
+import java.util.ArrayList;
+import java.io.Serializable;
+
+/**
+ * Event filtering and matching
+ */
+public class EventFilter implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private ArrayList<Payload.PayloadType> wantSubtypes;
+
+    /**
+     * Get composite transform to apply filter to event stream
+     *
+     * @param filter Event filter
+     * @return Transform
+     */
+    public static PTransform<PCollection<Event>, PCollection<Event>> getTransform(EventFilter filter) {
+        return new PTransform<PCollection<Event>, PCollection<Event>>() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public PCollection<Event> expand(PCollection<Event> input) {
+                return input.apply(ParDo.of(
+                    new DoFn<Event, Event>() {
+                        private static final long serialVersionUID = 1L;
+
+                        @ProcessElement
+                        public void processElement(ProcessContext c) {
+                            Event e = c.element();
+                            if (filter.matches(e)) {
+                                c.output(e);
+                            }
+                        }
+                    }
+                ));
+            }
+        };
+    }
+
+    /**
+     * Test if event matches filter
+     *
+     * @param e Event to match against filter
+     * @return True if filter matches
+     */
+    public Boolean matches(Event e) {
+        if (!wantSubtypes.isEmpty()) {
+            Boolean haveMatch = false;
+            for (Payload.PayloadType p : wantSubtypes) {
+                if (e.getPayloadType() == p) {
+                    haveMatch = true;
+                    break;
+                }
+            }
+            if (!haveMatch) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Add a match rule for a payload subtype
+     *
+     * @param p Payload type
+     * @return EventFilter for chaining
+     */
+    public EventFilter wantSubtype(Payload.PayloadType p) {
+        wantSubtypes.add(p);
+        return this;
+    }
+
+    /**
+     * Create new {@link EventFilter}
+     */
+    public EventFilter() {
+        wantSubtypes = new ArrayList<Payload.PayloadType>();
+    }
+}

--- a/src/main/java/com/mozilla/secops/parser/EventFilterPayload.java
+++ b/src/main/java/com/mozilla/secops/parser/EventFilterPayload.java
@@ -16,8 +16,10 @@ import java.io.Serializable;
 public class EventFilterPayload implements Serializable {
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Properties match strings from various payload event types
+     */
     public enum StringProperty {
-        /** RAW event, RAW field */
         RAW_RAW
     }
 

--- a/src/main/java/com/mozilla/secops/parser/EventFilterPayload.java
+++ b/src/main/java/com/mozilla/secops/parser/EventFilterPayload.java
@@ -1,0 +1,65 @@
+package com.mozilla.secops.parser;
+
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.DoFn;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.io.Serializable;
+
+/**
+ * Can be associated with {@link EventFilterRule} for payload matching
+ */
+public class EventFilterPayload implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    public enum StringProperty {
+        /** RAW event, RAW field */
+        RAW_RAW
+    }
+
+    private Class<? extends PayloadBase> ptype;
+    private Map<StringProperty, String> stringMatchers;
+
+    /**
+     * Return true if payload criteria matches
+     *
+     * @return True on match
+     */
+    public Boolean matches(Event e) {
+        if (!(ptype.isInstance(e.getPayload()))) {
+            return false;
+        }
+        for (Map.Entry<StringProperty, String> entry : stringMatchers.entrySet()) {
+            if (!(e.getPayload().eventStringFilter(entry.getKey(), entry.getValue()))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Add a new simple string match to the payload filter
+     *
+     * @param property {@link EventFilterPayload#StringProperty}
+     * @param s String to match against
+     * @return EventFilterPayload for chaining
+     */
+    public EventFilterPayload withStringMatch(StringProperty property, String s) {
+        stringMatchers.put(property, s);
+        return this;
+    }
+
+    /**
+     * Create new payload filter that matches against specified payload class
+     *
+     * @param ptype Payload class
+     */
+    public EventFilterPayload(Class<? extends PayloadBase> ptype) {
+        this.ptype = ptype;
+        stringMatchers = new HashMap<StringProperty, String>();
+    }
+}

--- a/src/main/java/com/mozilla/secops/parser/EventFilterPayload.java
+++ b/src/main/java/com/mozilla/secops/parser/EventFilterPayload.java
@@ -20,6 +20,8 @@ public class EventFilterPayload implements Serializable {
      * Properties match strings from various payload event types
      */
     public enum StringProperty {
+        SECEVENT_ACTION,
+
         RAW_RAW
     }
 

--- a/src/main/java/com/mozilla/secops/parser/EventFilterRule.java
+++ b/src/main/java/com/mozilla/secops/parser/EventFilterRule.java
@@ -1,0 +1,68 @@
+package com.mozilla.secops.parser;
+
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.DoFn;
+
+import java.util.ArrayList;
+import java.io.Serializable;
+
+/**
+ * Rule within an event filter
+ */
+public class EventFilterRule implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Payload.PayloadType wantSubtype;
+    private ArrayList<EventFilterPayload> payloadFilters;
+
+    /**
+     * Test if event matches rule
+     *
+     * @param e Event to match against rule
+     * @return True if event matches
+     */
+    public Boolean matches(Event e) {
+        if (wantSubtype != null) {
+            if (e.getPayloadType() != wantSubtype) {
+                return false;
+            }
+        }
+        for (EventFilterPayload p : payloadFilters) {
+            if (!p.matches(e)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Add payload filter
+     *
+     * @param p Payload filter criteria
+     * @return EventFilterRule for chaining
+     */
+    public EventFilterRule addPayloadFilter(EventFilterPayload p) {
+        payloadFilters.add(p);
+        return this;
+    }
+
+    /**
+     * Add match criteria for a payload subtype
+     *
+     * @param p Payload type
+     * @return EventFilterRule for chaining
+     */
+    public EventFilterRule wantSubtype(Payload.PayloadType p) {
+        wantSubtype = p;
+        return this;
+    }
+
+    /**
+     * Create new empty {@link EventFilterRule}
+     */
+    public EventFilterRule() {
+        payloadFilters = new ArrayList<EventFilterPayload>();
+    }
+}

--- a/src/main/java/com/mozilla/secops/parser/EventFilterRule.java
+++ b/src/main/java/com/mozilla/secops/parser/EventFilterRule.java
@@ -65,6 +65,12 @@ public class EventFilterRule implements Serializable {
         return this;
     }
 
+    /**
+     * Add match criteria for a normalized event type
+     *
+     * @param n Normalized event type
+     * @return EventFilterRule for chaining
+     */
     public EventFilterRule wantNormalizedType(Normalized.Type n) {
         wantNormalizedType = n;
         return this;

--- a/src/main/java/com/mozilla/secops/parser/EventFilterRule.java
+++ b/src/main/java/com/mozilla/secops/parser/EventFilterRule.java
@@ -15,6 +15,7 @@ public class EventFilterRule implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private Payload.PayloadType wantSubtype;
+    private Normalized.Type wantNormalizedType;
     private ArrayList<EventFilterPayload> payloadFilters;
 
     /**
@@ -26,6 +27,11 @@ public class EventFilterRule implements Serializable {
     public Boolean matches(Event e) {
         if (wantSubtype != null) {
             if (e.getPayloadType() != wantSubtype) {
+                return false;
+            }
+        }
+        if (wantNormalizedType != null) {
+            if (!(e.getNormalized().isOfType(wantNormalizedType))) {
                 return false;
             }
         }
@@ -56,6 +62,11 @@ public class EventFilterRule implements Serializable {
      */
     public EventFilterRule wantSubtype(Payload.PayloadType p) {
         wantSubtype = p;
+        return this;
+    }
+
+    public EventFilterRule wantNormalizedType(Normalized.Type n) {
+        wantNormalizedType = n;
         return this;
     }
 

--- a/src/main/java/com/mozilla/secops/parser/Parser.java
+++ b/src/main/java/com/mozilla/secops/parser/Parser.java
@@ -169,6 +169,7 @@ public class Parser {
         jf = new JacksonFactory();
         payloads = new ArrayList<PayloadBase>();
         payloads.add(new GLB());
+        payloads.add(new SecEvent());
         payloads.add(new Cloudtrail());
         payloads.add(new OpenSSH());
         payloads.add(new Duopull());

--- a/src/main/java/com/mozilla/secops/parser/ParserDoFn.java
+++ b/src/main/java/com/mozilla/secops/parser/ParserDoFn.java
@@ -1,0 +1,47 @@
+package com.mozilla.secops.parser;
+
+import org.apache.beam.sdk.transforms.DoFn;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.mozilla.secops.parser.Event;
+import com.mozilla.secops.parser.Parser;
+
+/**
+ * {@link DoFn} applying simple event parsing operations
+ */
+public class ParserDoFn extends DoFn<String, Event> {
+    private static final long serialVersionUID = 1L;
+
+    private Logger log;
+    private Parser ep;
+    private Long parseCount;
+
+    @Setup
+    public void setup() {
+        ep = new Parser();
+        log = LoggerFactory.getLogger(ParserDoFn.class);
+        log.info("initialized new parser");
+    }
+
+    @StartBundle
+    public void StartBundle() {
+        log.info("processing new bundle");
+        parseCount = 0L;
+    }
+
+    @FinishBundle
+    public void FinishBundle() {
+        log.info("{} events processed in bundle", parseCount);
+    }
+
+    @ProcessElement
+    public void processElement(ProcessContext c) {
+        Event e = ep.parse(c.element());
+        if (e != null) {
+            parseCount++;
+            c.output(e);
+        }
+    }
+}

--- a/src/main/java/com/mozilla/secops/parser/Payload.java
+++ b/src/main/java/com/mozilla/secops/parser/Payload.java
@@ -20,6 +20,8 @@ public class Payload<T extends PayloadBase> implements Serializable {
         OPENSSH,
         /** Duopull */
         DUOPULL,
+        /** SecEvent */
+        SECEVENT,
         /** Raw */
         RAW
     }

--- a/src/main/java/com/mozilla/secops/parser/PayloadBase.java
+++ b/src/main/java/com/mozilla/secops/parser/PayloadBase.java
@@ -38,4 +38,15 @@ public abstract class PayloadBase {
     public Payload.PayloadType getType() {
         return null;
     }
+
+    /**
+     * Test if string filter matches event payload
+     *
+     * @param property {@link EventFilterPayload#StringProperty}
+     * @param s Match string
+     * @return True if match is found
+     */
+    public Boolean eventStringFilter(EventFilterPayload.StringProperty property, String s) {
+        return false;
+    }
 }

--- a/src/main/java/com/mozilla/secops/parser/Raw.java
+++ b/src/main/java/com/mozilla/secops/parser/Raw.java
@@ -50,4 +50,16 @@ public class Raw extends PayloadBase implements Serializable {
     public String getRaw() {
         return raw;
     }
+
+    @Override
+    public Boolean eventStringFilter(EventFilterPayload.StringProperty property, String s) {
+        switch (property) {
+            case RAW_RAW:
+                if (raw != null && raw.equals(s)) {
+                    return true;
+                }
+                break;
+        }
+        return false;
+    }
 }

--- a/src/main/java/com/mozilla/secops/parser/SecEvent.java
+++ b/src/main/java/com/mozilla/secops/parser/SecEvent.java
@@ -52,6 +52,21 @@ public class SecEvent extends PayloadBase implements Serializable {
         return Payload.PayloadType.SECEVENT;
     }
 
+    @Override
+    public Boolean eventStringFilter(EventFilterPayload.StringProperty property, String s) {
+        if (secEventData == null) {
+            return false;
+        }
+        switch (property) {
+            case SECEVENT_ACTION:
+                if (secEventData.getAction() != null && secEventData.getAction().equals(s)) {
+                    return true;
+                }
+                break;
+        }
+        return false;
+    }
+
     /**
      * Fetch parsed secevent data
      *

--- a/src/main/java/com/mozilla/secops/parser/SecEvent.java
+++ b/src/main/java/com/mozilla/secops/parser/SecEvent.java
@@ -26,13 +26,18 @@ public class SecEvent extends PayloadBase implements Serializable {
 
     private com.mozilla.secops.parser.models.secevent.SecEvent secEventData;
 
-    @Override
-    public Boolean matcher(String input) {
+    private ObjectMapper getObjectMapper() {
         ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new JodaModule());
         mapper.configure(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS,
             false);
         mapper.configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true);
+        return mapper;
+    }
+
+    @Override
+    public Boolean matcher(String input) {
+        ObjectMapper mapper = getObjectMapper();
         com.mozilla.secops.parser.models.secevent.SecEvent d;
         try {
             d = mapper.readValue(input,
@@ -90,11 +95,7 @@ public class SecEvent extends PayloadBase implements Serializable {
      * @param p Parser instance.
      */
     public SecEvent(String input, Event e, Parser p) {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.registerModule(new JodaModule());
-        mapper.configure(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS,
-            false);
-        mapper.configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true);
+        ObjectMapper mapper = getObjectMapper();
         try {
             secEventData = mapper.readValue(input,
                 com.mozilla.secops.parser.models.secevent.SecEvent.class);

--- a/src/main/java/com/mozilla/secops/parser/SecEvent.java
+++ b/src/main/java/com/mozilla/secops/parser/SecEvent.java
@@ -29,6 +29,10 @@ public class SecEvent extends PayloadBase implements Serializable {
     @Override
     public Boolean matcher(String input) {
         ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JodaModule());
+        mapper.configure(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS,
+            false);
+        mapper.configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true);
         com.mozilla.secops.parser.models.secevent.SecEvent d;
         try {
             d = mapper.readValue(input,
@@ -72,11 +76,24 @@ public class SecEvent extends PayloadBase implements Serializable {
      */
     public SecEvent(String input, Event e, Parser p) {
         ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JodaModule());
+        mapper.configure(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS,
+            false);
+        mapper.configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true);
         try {
             secEventData = mapper.readValue(input,
                 com.mozilla.secops.parser.models.secevent.SecEvent.class);
+            if (secEventData == null) {
+                return;
+            }
         } catch (IOException exc) {
             return;
+        }
+
+        // If a timestamp value is set in the event body, use that for the event timestamp
+        DateTime ts = secEventData.getTimestamp();
+        if (ts != null) {
+            e.setTimestamp(ts);
         }
     }
 }

--- a/src/main/java/com/mozilla/secops/parser/SecEvent.java
+++ b/src/main/java/com/mozilla/secops/parser/SecEvent.java
@@ -1,0 +1,82 @@
+package com.mozilla.secops.parser;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+import org.joda.time.DateTime;
+
+import java.io.Serializable;
+import java.io.IOException;
+import java.util.Map;
+import java.util.HashMap;
+
+/**
+ * Payload parser for SecEvent log data
+ */
+public class SecEvent extends PayloadBase implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private com.mozilla.secops.parser.models.secevent.SecEvent secEventData;
+
+    @Override
+    public Boolean matcher(String input) {
+        ObjectMapper mapper = new ObjectMapper();
+        com.mozilla.secops.parser.models.secevent.SecEvent d;
+        try {
+            d = mapper.readValue(input,
+                com.mozilla.secops.parser.models.secevent.SecEvent.class);
+        } catch (IOException exc) {
+            return false;
+        }
+        String msg = d.getSecEventVersion();
+        if (msg != null && msg.equals("secevent.model.1")) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public Payload.PayloadType getType() {
+        return Payload.PayloadType.SECEVENT;
+    }
+
+    /**
+     * Fetch parsed secevent data
+     *
+     * @return SecEvent data
+     */
+    public com.mozilla.secops.parser.models.secevent.SecEvent getSecEventData() {
+        return secEventData;
+    }
+
+    /**
+     * Construct matcher object.
+     */
+    public SecEvent() {
+    }
+
+    /**
+     * Construct parser object.
+     *
+     * @param input Input string.
+     * @param e Parent {@link Event}.
+     * @param p Parser instance.
+     */
+    public SecEvent(String input, Event e, Parser p) {
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            secEventData = mapper.readValue(input,
+                com.mozilla.secops.parser.models.secevent.SecEvent.class);
+        } catch (IOException exc) {
+            return;
+        }
+    }
+}

--- a/src/main/java/com/mozilla/secops/parser/models/secevent/SecEvent.java
+++ b/src/main/java/com/mozilla/secops/parser/models/secevent/SecEvent.java
@@ -1,0 +1,99 @@
+package com.mozilla.secops.parser.models.secevent;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.io.Serializable;
+
+/**
+ * Generic Security Event
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SecEvent implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private String secEventVersion;
+
+    // Fields describing information about the subject that is undertaking a given
+    // event
+    private String actorAccountId;
+    private String action;
+    private String sourceAddress;
+
+    private String emailRecipient;
+    private String smsRecipient;
+    private String destinationAccountId;
+
+    /**
+     * Get SecEvent version string
+     *
+     * @return Version string
+     */
+    @JsonProperty("secevent_version")
+    public String getSecEventVersion() {
+        return secEventVersion;
+    }
+
+    /**
+     * Get actor account ID
+     *
+     * @return Actor account ID
+     */
+    @JsonProperty("account_id")
+    public String getActorAccountId() {
+        return actorAccountId;
+    }
+
+    /**
+     * Get action
+     *
+     * @return Action
+     */
+    @JsonProperty("action")
+    public String getAction() {
+        return action;
+    }
+
+    /**
+     * Get source address
+     *
+     * @return Source address
+     */
+    @JsonProperty("source_address")
+    public String getSourceAddress()  {
+        return sourceAddress;
+    }
+
+    /**
+     * Get email recipient
+     *
+     * @return Email recipient
+     */
+    @JsonProperty("email_recipient")
+    public String getEmailRecipient() {
+        return emailRecipient;
+    }
+
+    /**
+     * Get SMS recipient
+     *
+     * @return SMS recipient
+     */
+    @JsonProperty("sms_recipient")
+    public String getSmsRecipient() {
+        return smsRecipient;
+    }
+
+    /**
+     * Get destination account ID
+     *
+     * @return Destination account ID
+     */
+    @JsonProperty("destination_account_id")
+    public String getDestinationAccountId() {
+        return destinationAccountId;
+    }
+
+    public SecEvent() {
+    }
+}

--- a/src/main/java/com/mozilla/secops/parser/models/secevent/SecEvent.java
+++ b/src/main/java/com/mozilla/secops/parser/models/secevent/SecEvent.java
@@ -3,6 +3,8 @@ package com.mozilla.secops.parser.models.secevent;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
+import org.joda.time.DateTime;
+
 import java.io.Serializable;
 
 /**
@@ -23,6 +25,8 @@ public class SecEvent implements Serializable {
     private String emailRecipient;
     private String smsRecipient;
     private String destinationAccountId;
+
+    private DateTime timestamp;
 
     /**
      * Get SecEvent version string
@@ -82,6 +86,16 @@ public class SecEvent implements Serializable {
     @JsonProperty("sms_recipient")
     public String getSmsRecipient() {
         return smsRecipient;
+    }
+
+    /**
+     * Get timestamp
+     *
+     * @return Timestamp
+     */
+    @JsonProperty("timestamp")
+    public DateTime getTimestamp() {
+        return timestamp;
     }
 
     /**

--- a/src/test/java/com/mozilla/secops/customs/TestCustoms.java
+++ b/src/test/java/com/mozilla/secops/customs/TestCustoms.java
@@ -67,7 +67,7 @@ public class TestCustoms {
             .apply(Combine.globally(Count.<Event>combineFn()).withoutDefaults());
 
         PAssert.that(count)
-            .containsInAnyOrder(7L);
+            .containsInAnyOrder(13L);
 
         p.run().waitUntilFinish();
     }

--- a/src/test/java/com/mozilla/secops/customs/TestCustoms.java
+++ b/src/test/java/com/mozilla/secops/customs/TestCustoms.java
@@ -1,0 +1,120 @@
+package com.mozilla.secops.customs;
+
+import org.junit.Test;
+import org.junit.Rule;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalTo;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindows;
+import org.apache.beam.sdk.transforms.windowing.Window;
+import org.apache.beam.sdk.transforms.Combine;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.Count;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+
+import org.joda.time.Instant;
+
+import com.mozilla.secops.alert.Alert;
+import com.mozilla.secops.parser.Event;
+import com.mozilla.secops.parser.Normalized;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Scanner;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+
+public class TestCustoms {
+    @Rule public final transient TestPipeline p = TestPipeline.create();
+
+    public TestCustoms() {
+    }
+
+    private PCollection<String> getInput(String resource) {
+        ArrayList<String> inputData = new ArrayList<String>();
+        InputStream in = TestCustoms.class.getResourceAsStream(resource);
+        Scanner scanner = new Scanner(in);
+        while (scanner.hasNextLine()) {
+            inputData.add(scanner.nextLine());
+        }
+        scanner.close();
+        return p.apply(Create.of(inputData));
+    }
+
+    @Test
+    public void noopPipelineTest() throws Exception {
+        p.run().waitUntilFinish();
+    }
+
+    @Test
+    public void parseTest() throws Exception {
+        PCollection<String> input = getInput("/testdata/customs_rl_badlogin_simple1.txt");
+
+        PCollection<Long> count = input.apply(ParDo.of(new Customs.Parse(true)))
+            .apply(Combine.globally(Count.<Event>combineFn()).withoutDefaults());
+
+        PAssert.that(count)
+            .containsInAnyOrder(7L);
+
+        p.run().waitUntilFinish();
+    }
+
+    @Test
+    public void rlLoginFailureSourceAddressTest() throws Exception {
+        PCollection<String> input = getInput("/testdata/customs_rl_badlogin_simple1.txt");
+
+        PCollection<Alert> alerts = input.apply(ParDo.of(new Customs.Parse(true)))
+            .apply(new Customs.RlLoginFailureSourceAddress(3L, 15L));
+
+        ArrayList<IntervalWindow> windows = new ArrayList<IntervalWindow>();
+        windows.add(new IntervalWindow(new Instant(1800000L), new Instant(2700000L)));
+        windows.add(new IntervalWindow(new Instant(2700000L), new Instant(3600000L)));
+        windows.add(new IntervalWindow(new Instant(11700000L), new Instant(12600000L)));
+        windows.add(new IntervalWindow(new Instant(12600000L), new Instant(13500000L)));
+
+        PCollection<Long> count = alerts.apply(
+            Combine.globally(Count.<Alert>combineFn()).withoutDefaults());
+        PAssert.that(count)
+            .satisfies(
+                x -> {
+                    int cnt = 0;
+                    for (Long l : x) {
+                        cnt += l;
+                    }
+                    assertEquals(4L, cnt);
+                    return null;
+                }
+            );
+
+        for (IntervalWindow w : windows) {
+            PAssert.that(alerts)
+                .inWindow(w)
+                .satisfies(
+                    x -> {
+                        int cnt = 0;
+                        for (Alert a : x) {
+                            assertEquals("customs", a.getCategory());
+                            cnt++;
+                        }
+                        assertEquals(1, cnt);
+                        return null;
+                    }
+                );
+        }
+
+        p.run().waitUntilFinish();
+    }
+}

--- a/src/test/java/com/mozilla/secops/customs/TestCustoms.java
+++ b/src/test/java/com/mozilla/secops/customs/TestCustoms.java
@@ -29,6 +29,7 @@ import org.joda.time.Instant;
 import com.mozilla.secops.alert.Alert;
 import com.mozilla.secops.parser.Event;
 import com.mozilla.secops.parser.Normalized;
+import com.mozilla.secops.parser.ParserDoFn;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -63,7 +64,7 @@ public class TestCustoms {
     public void parseTest() throws Exception {
         PCollection<String> input = getInput("/testdata/customs_rl_badlogin_simple1.txt");
 
-        PCollection<Long> count = input.apply(ParDo.of(new Customs.Parse()))
+        PCollection<Long> count = input.apply(ParDo.of(new ParserDoFn()))
             .apply(Combine.globally(Count.<Event>combineFn()).withoutDefaults());
 
         PAssert.that(count)
@@ -76,7 +77,7 @@ public class TestCustoms {
     public void rlLoginFailureSourceAddressTest() throws Exception {
         PCollection<String> input = getInput("/testdata/customs_rl_badlogin_simple1.txt");
 
-        PCollection<Alert> alerts = input.apply(ParDo.of(new Customs.Parse()))
+        PCollection<Alert> alerts = input.apply(ParDo.of(new ParserDoFn()))
             .apply(new Customs.RlLoginFailureSourceAddress(true, 3L, 900L));
 
         ArrayList<IntervalWindow> windows = new ArrayList<IntervalWindow>();

--- a/src/test/java/com/mozilla/secops/customs/TestCustoms.java
+++ b/src/test/java/com/mozilla/secops/customs/TestCustoms.java
@@ -63,7 +63,7 @@ public class TestCustoms {
     public void parseTest() throws Exception {
         PCollection<String> input = getInput("/testdata/customs_rl_badlogin_simple1.txt");
 
-        PCollection<Long> count = input.apply(ParDo.of(new Customs.Parse(true)))
+        PCollection<Long> count = input.apply(ParDo.of(new Customs.Parse()))
             .apply(Combine.globally(Count.<Event>combineFn()).withoutDefaults());
 
         PAssert.that(count)
@@ -76,8 +76,8 @@ public class TestCustoms {
     public void rlLoginFailureSourceAddressTest() throws Exception {
         PCollection<String> input = getInput("/testdata/customs_rl_badlogin_simple1.txt");
 
-        PCollection<Alert> alerts = input.apply(ParDo.of(new Customs.Parse(true)))
-            .apply(new Customs.RlLoginFailureSourceAddress(3L, 900L));
+        PCollection<Alert> alerts = input.apply(ParDo.of(new Customs.Parse()))
+            .apply(new Customs.RlLoginFailureSourceAddress(true, 3L, 900L));
 
         ArrayList<IntervalWindow> windows = new ArrayList<IntervalWindow>();
         windows.add(new IntervalWindow(new Instant(1800000L), new Instant(2700000L)));

--- a/src/test/java/com/mozilla/secops/customs/TestCustoms.java
+++ b/src/test/java/com/mozilla/secops/customs/TestCustoms.java
@@ -77,7 +77,7 @@ public class TestCustoms {
         PCollection<String> input = getInput("/testdata/customs_rl_badlogin_simple1.txt");
 
         PCollection<Alert> alerts = input.apply(ParDo.of(new Customs.Parse(true)))
-            .apply(new Customs.RlLoginFailureSourceAddress(3L, 15L));
+            .apply(new Customs.RlLoginFailureSourceAddress(3L, 900L));
 
         ArrayList<IntervalWindow> windows = new ArrayList<IntervalWindow>();
         windows.add(new IntervalWindow(new Instant(1800000L), new Instant(2700000L)));

--- a/src/test/java/com/mozilla/secops/parser/EventFilterTest.java
+++ b/src/test/java/com/mozilla/secops/parser/EventFilterTest.java
@@ -1,0 +1,33 @@
+package com.mozilla.secops.parser;
+
+import org.junit.Test;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+public class EventFilterTest {
+    public EventFilterTest() {
+    }
+
+    @Test
+    public void testEventFilterRaw() throws Exception {
+        EventFilter pFilter = new EventFilter();
+        assertNotNull(pFilter);
+        pFilter.wantSubtype(Payload.PayloadType.RAW);
+
+        EventFilter nFilter = new EventFilter();
+        assertNotNull(nFilter);
+        nFilter.wantSubtype(Payload.PayloadType.CLOUDTRAIL);
+
+        Parser p = new Parser();
+        assertNotNull(p);
+        Event e = p.parse("test");
+        assertNotNull(e);
+        assertEquals(Payload.PayloadType.RAW, e.getPayloadType());
+
+        assertTrue(pFilter.matches(e));
+        assertFalse(nFilter.matches(e));
+    }
+}

--- a/src/test/java/com/mozilla/secops/parser/EventFilterTest.java
+++ b/src/test/java/com/mozilla/secops/parser/EventFilterTest.java
@@ -66,4 +66,24 @@ public class EventFilterTest {
         assertFalse(nFilter.matches(e));
         assertFalse(icFilter.matches(e));
     }
+
+    @Test
+    public void testEventFilterNormalized() throws Exception {
+        String buf = "Sep 18 22:15:38 emit-bastion sshd[2644]: Accepted publickey for riker from 12" +
+            "7.0.0.1 port 58530 ssh2: RSA SHA256:dd/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        Parser p = new Parser();
+        assertNotNull(p);
+        Event e = p.parse(buf);
+        assertNotNull(e);
+        assertEquals(Payload.PayloadType.OPENSSH, e.getPayloadType());
+        Normalized n = e.getNormalized();
+        assertNotNull(n);
+        assertTrue(n.isOfType(Normalized.Type.AUTH));
+
+        EventFilter filter = new EventFilter();
+        assertNotNull(filter);
+        filter.addRule(new EventFilterRule()
+            .wantNormalizedType(Normalized.Type.AUTH));
+        assertTrue(filter.matches(e));
+    }
 }

--- a/src/test/java/com/mozilla/secops/parser/EventFilterTest.java
+++ b/src/test/java/com/mozilla/secops/parser/EventFilterTest.java
@@ -15,11 +15,13 @@ public class EventFilterTest {
     public void testEventFilterRaw() throws Exception {
         EventFilter pFilter = new EventFilter();
         assertNotNull(pFilter);
-        pFilter.wantSubtype(Payload.PayloadType.RAW);
+        pFilter.addRule(new EventFilterRule()
+            .wantSubtype(Payload.PayloadType.RAW));
 
         EventFilter nFilter = new EventFilter();
         assertNotNull(nFilter);
-        nFilter.wantSubtype(Payload.PayloadType.CLOUDTRAIL);
+        nFilter.addRule(new EventFilterRule()
+            .wantSubtype(Payload.PayloadType.CLOUDTRAIL));
 
         Parser p = new Parser();
         assertNotNull(p);
@@ -29,5 +31,39 @@ public class EventFilterTest {
 
         assertTrue(pFilter.matches(e));
         assertFalse(nFilter.matches(e));
+    }
+
+    @Test
+    public void testEventFilterRawPayload() throws Exception {
+        EventFilter pFilter = new EventFilter();
+        assertNotNull(pFilter);
+        pFilter.addRule(new EventFilterRule()
+            .wantSubtype(Payload.PayloadType.RAW)
+            .addPayloadFilter(new EventFilterPayload(Raw.class)
+                .withStringMatch(EventFilterPayload.StringProperty.RAW_RAW, "test")));
+
+        EventFilter icFilter = new EventFilter();
+        assertNotNull(icFilter);
+        icFilter.addRule(new EventFilterRule()
+            .wantSubtype(Payload.PayloadType.RAW)
+            .addPayloadFilter(new EventFilterPayload(GLB.class) // Wrong payload type
+                .withStringMatch(EventFilterPayload.StringProperty.RAW_RAW, "test")));
+
+        EventFilter nFilter = new EventFilter();
+        assertNotNull(nFilter);
+        nFilter.addRule(new EventFilterRule()
+            .wantSubtype(Payload.PayloadType.RAW)
+            .addPayloadFilter(new EventFilterPayload(Raw.class)
+                .withStringMatch(EventFilterPayload.StringProperty.RAW_RAW, "nomatch")));
+
+        Parser p = new Parser();
+        assertNotNull(p);
+        Event e = p.parse("test");
+        assertNotNull(e);
+        assertEquals(Payload.PayloadType.RAW, e.getPayloadType());
+
+        assertTrue(pFilter.matches(e));
+        assertFalse(nFilter.matches(e));
+        assertFalse(icFilter.matches(e));
     }
 }

--- a/src/test/java/com/mozilla/secops/parser/EventFilterTransformTest.java
+++ b/src/test/java/com/mozilla/secops/parser/EventFilterTransformTest.java
@@ -1,0 +1,53 @@
+package com.mozilla.secops.parser;
+
+import org.junit.Test;
+import org.junit.Rule;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
+import org.apache.beam.sdk.transforms.Combine;
+import org.apache.beam.sdk.transforms.Count;
+import org.apache.beam.sdk.values.KV;
+
+public class EventFilterTransformTest {
+    public EventFilterTransformTest() {
+    }
+
+    @Rule public final transient TestPipeline pipeline = TestPipeline.create();
+
+    @Test
+    public void testTransformPayloadMatch() throws Exception {
+        Parser p = new Parser();
+        Event e = p.parse("picard");
+        assertNotNull(e);
+        PCollection<Event> input = pipeline.apply(Create.of(e));
+
+        EventFilter pFilter = new EventFilter();
+        assertNotNull(pFilter);
+        pFilter.wantSubtype(Payload.PayloadType.RAW);
+
+        EventFilter nFilter = new EventFilter();
+        assertNotNull(nFilter);
+        nFilter.wantSubtype(Payload.PayloadType.GLB);
+
+        PCollection<Event> pfiltered = input.apply("positive", EventFilter.getTransform(pFilter));
+        PCollection<Event> nfiltered = input.apply("negative", EventFilter.getTransform(nFilter));
+
+        PCollection<Long> pcount = pfiltered.apply("pcount", Count.globally());
+        PAssert.that(pcount).containsInAnyOrder(1L);
+
+        PCollection<Long> ncount = nfiltered.apply("ncount", Count.globally());
+        PAssert.that(ncount).containsInAnyOrder(0L);
+
+        pipeline.run().waitUntilFinish();
+    }
+}

--- a/src/test/java/com/mozilla/secops/parser/ParserTest.java
+++ b/src/test/java/com/mozilla/secops/parser/ParserTest.java
@@ -513,7 +513,7 @@ public class ParserTest {
     @Test
     public void testParseSecEvent() {
         String buf = "{\"secevent_version\":\"secevent.model.1\",\"action\":\"loginFailure\"" +
-            ",\"account_id\":\"q@the-q-continuum\"}";
+            ",\"account_id\":\"q@the-q-continuum\",\"timestamp\":\"1970-01-01T00:00:00+00:00\"}";
         Parser p = new Parser();
         assertNotNull(p);
         Event e = p.parse(buf);
@@ -525,6 +525,10 @@ public class ParserTest {
         assertNotNull(data);
         assertEquals("loginFailure", data.getAction());
         assertEquals("q@the-q-continuum", data.getActorAccountId());
+
+        DateTime ts = e.getTimestamp();
+        assertNotNull(ts);
+        assertEquals(0L, ts.getMillis());
     }
 
     @Test

--- a/src/test/java/com/mozilla/secops/parser/ParserTest.java
+++ b/src/test/java/com/mozilla/secops/parser/ParserTest.java
@@ -511,6 +511,23 @@ public class ParserTest {
     }
 
     @Test
+    public void testParseSecEvent() {
+        String buf = "{\"secevent_version\":\"secevent.model.1\",\"action\":\"loginFailure\"" +
+            ",\"account_id\":\"q@the-q-continuum\"}";
+        Parser p = new Parser();
+        assertNotNull(p);
+        Event e = p.parse(buf);
+        assertNotNull(e);
+        assertEquals(Payload.PayloadType.SECEVENT, e.getPayloadType());
+        SecEvent d = e.getPayload();
+        com.mozilla.secops.parser.models.secevent.SecEvent data =
+            d.getSecEventData();
+        assertNotNull(data);
+        assertEquals("loginFailure", data.getAction());
+        assertEquals("q@the-q-continuum", data.getActorAccountId());
+    }
+
+    @Test
     public void testGeoIp() throws Exception {
         Parser p = new Parser();
         assertNotNull(p);

--- a/src/test/resources/testdata/customs_rl_badlogin_simple1.txt
+++ b/src/test/resources/testdata/customs_rl_badlogin_simple1.txt
@@ -1,0 +1,13 @@
+{"secevent_version":"secevent.model.1","action":"loginFailure","account_id":"q@the-q-continuum","timestamp":"1970-01-01T00:00:00+00:00","source_address":"127.0.0.1"}
+{"secevent_version":"secevent.model.1","action":"loginFailure","account_id":"q@the-q-continuum","timestamp":"1970-01-01T00:16:00+00:00","source_address":"127.0.0.1"}
+{"secevent_version":"secevent.model.1","action":"loginFailure","account_id":"q@the-q-continuum","timestamp":"1970-01-01T00:31:00+00:00","source_address":"127.0.0.1"}
+{"secevent_version":"secevent.model.1","action":"loginFailure","account_id":"q@the-q-continuum","timestamp":"1970-01-01T00:38:00+00:00","source_address":"127.0.0.1"}
+{"secevent_version":"secevent.model.1","action":"loginFailure","account_id":"q@the-q-continuum","timestamp":"1970-01-01T00:39:00+00:00","source_address":"127.0.0.1"}
+{"secevent_version":"secevent.model.1","action":"loginFailure","account_id":"q@the-q-continuum","timestamp":"1970-01-01T01:00:00+00:00","source_address":"127.0.0.1"}
+{"secevent_version":"secevent.model.1","action":"loginFailure","account_id":"q@the-q-continuum","timestamp":"1970-01-01T01:16:00+00:00","source_address":"127.0.0.1"}
+{"secevent_version":"secevent.model.1","action":"loginFailure","account_id":"q@the-q-continuum","timestamp":"1970-01-01T03:16:00+00:00","source_address":"127.0.0.1"}
+{"secevent_version":"secevent.model.1","action":"loginFailure","account_id":"q@the-q-continuum","timestamp":"1970-01-01T03:17:00+00:00","source_address":"127.0.0.1"}
+{"secevent_version":"secevent.model.1","action":"loginFailure","account_id":"q@the-q-continuum","timestamp":"1970-01-01T03:18:00+00:00","source_address":"127.0.0.1"}
+{"secevent_version":"secevent.model.1","action":"loginFailure","account_id":"q@the-q-continuum","timestamp":"1970-01-01T03:19:00+00:00","source_address":"127.0.0.1"}
+{"secevent_version":"secevent.model.1","action":"loginFailure","account_id":"q@the-q-continuum","timestamp":"1970-01-01T03:20:00+00:00","source_address":"127.0.0.1"}
+{"secevent_version":"secevent.model.1","action":"loginFailure","account_id":"q@the-q-continuum","timestamp":"1970-01-01T03:21:00+00:00","source_address":"127.0.0.1"}


### PR DESCRIPTION
This adds an initial pipeline for customs/rate-limiting logic, in addition to other supporting changes.

Additional code is required in the `Customs` class, but PR'ing now before the diff gets larger.

* Add Customs class
* Add a new event filtering class to create a stream filtering transform
* Factor out duplicate parsing classes