### PR TITLE
use Count transform instead of sending events to RateLimitCriterion

### DIFF
--- a/src/main/java/com/mozilla/secops/customs/RateLimitAnalyzer.java
+++ b/src/main/java/com/mozilla/secops/customs/RateLimitAnalyzer.java
@@ -3,6 +3,7 @@ package com.mozilla.secops.customs;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.GroupByKey;
 import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.Count;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
 import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.transforms.windowing.Repeatedly;
@@ -54,7 +55,7 @@ public class RateLimitAnalyzer implements Serializable {
                         SlidingWindows.of(analyzer.getWindowLength())
                         .every(analyzer.getWindowSlideLength()))
                     )
-                    .apply("analysis gbk", GroupByKey.<String, Event>create())
+                    .apply(Count.<String, Event>perKey())
                     .apply(ParDo.of(new RateLimitCriterion(analyzer.getAlertCriteriaSeverity(),
                         analyzer.getIdentifier(), analyzer.getAlertCriteriaLimit())))
                     .apply("suppression windows",

--- a/src/main/java/com/mozilla/secops/customs/RateLimitCriterion.java
+++ b/src/main/java/com/mozilla/secops/customs/RateLimitCriterion.java
@@ -17,7 +17,7 @@ import java.util.Collection;
  * Operate in conjunction with {@link RateLimitAnalyzer} to apply analysis criterion
  * to incoming event stream.
  */
-public class RateLimitCriterion extends DoFn<KV<String, Iterable<Event>>, KV<String, Alert>> {
+public class RateLimitCriterion extends DoFn<KV<String, Long>, KV<String, Alert>> {
     private static final long serialVersionUID = 1L;
 
     private final Alert.AlertSeverity severity;
@@ -47,16 +47,11 @@ public class RateLimitCriterion extends DoFn<KV<String, Iterable<Event>>, KV<Str
 
     @ProcessElement
     public void processElement(ProcessContext c) {
-        KV<String, Iterable<Event>> e = c.element();
+        KV<String, Long> e = c.element();
 
         String key = e.getKey();
-        Iterable<Event> values = e.getValue();
-        if (!(values instanceof Collection)) {
-            log.warn("value was not instance of collection");
-            return;
-        }
-        Event[] events = ((Collection<Event>) values).toArray(new Event[0]);
-        if (events.length < limit) {
+        Long valueCount = e.getValue();
+        if (valueCount < limit) {
             return;
         }
 


### PR DESCRIPTION
This results in a significant performance improvement in this phase of
the pipeline.