### PR TITLE
Additional validation checks for threshold analysis

### DIFF
--- a/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
+++ b/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
@@ -309,13 +309,14 @@ public class HTTPRequest implements Serializable {
 
     void setAnalysisThresholdModifier(Double value);
 
-    @Description("Required minimum average for threshold analysis")
+    @Description(
+        "Required minimum average number of requests per client/window for threshold analysis")
     @Default.Double(5.0)
     Double getRequiredMinimumAverage();
 
     void setRequiredMinimumAverage(Double value);
 
-    @Description("Required minimum number of unique clients for threshold analysis")
+    @Description("Required minimum number of unique clients per window for threshold analysis")
     @Default.Long(5L)
     Long getRequiredMinimumClients();
 


### PR DESCRIPTION
Adds two new checks that are intended to suppress result emission under certain circumstances, being:

* The calculated mean in-window is below what we would typically expect
* The observed number of unique clients in-window is less than what we would typically expect