### PR TITLE
Additions to customs pipeline output

### DIFF
--- a/src/main/java/com/mozilla/secops/customs/RateLimitCriterion.java
+++ b/src/main/java/com/mozilla/secops/customs/RateLimitCriterion.java
@@ -151,6 +151,21 @@ public class RateLimitCriterion extends DoFn<KV<String, Long>, KV<String, Alert>
       alert.addMetadata(
           "customs_unique_source_address",
           sample.get(0).<SecEvent>getPayload().getSecEventData().getSourceAddress());
+
+      // Since we had a unique source address, also see if we can pull in unique country and city
+      // values as well
+      if (uniqueAttribute(
+          eventList, le -> le.<SecEvent>getPayload().getSecEventData().getSourceAddressCity())) {
+        alert.addMetadata(
+            "customs_unique_source_address_city",
+            sample.get(0).<SecEvent>getPayload().getSecEventData().getSourceAddressCity());
+      }
+      if (uniqueAttribute(
+          eventList, le -> le.<SecEvent>getPayload().getSecEventData().getSourceAddressCountry())) {
+        alert.addMetadata(
+            "customs_unique_source_address_country",
+            sample.get(0).<SecEvent>getPayload().getSecEventData().getSourceAddressCountry());
+      }
     }
 
     // If object account ID was unique for all events, store that as metadata

--- a/src/main/java/com/mozilla/secops/customs/RateLimitCriterion.java
+++ b/src/main/java/com/mozilla/secops/customs/RateLimitCriterion.java
@@ -88,12 +88,14 @@ public class RateLimitCriterion extends DoFn<KV<String, Long>, KV<String, Alert>
     // Take a arbitrary sample of any events that were included in the detection window to be added
     // to the alert as metadata
     ArrayList<Event> sample = new ArrayList<Event>();
+    Boolean sampleTruncated = false;
     Iterable<Event> eventList = eventMap.get(key);
     int i = 0;
     if (eventList != null) {
       for (Event ev : eventList) {
         sample.add(ev);
         if (++i >= MAX_SAMPLE) {
+          sampleTruncated = true;
           break;
         }
       }
@@ -110,6 +112,7 @@ public class RateLimitCriterion extends DoFn<KV<String, Long>, KV<String, Alert>
     }
     if (sample.size() > 0) {
       alert.addMetadata("customs_sample", Event.iterableToJson(sample));
+      alert.addMetadata("customs_sample_truncated", sampleTruncated.toString());
     }
     alert.setSeverity(severity);
     c.output(KV.of(key, alert));

--- a/src/main/java/com/mozilla/secops/customs/RateLimitCriterion.java
+++ b/src/main/java/com/mozilla/secops/customs/RateLimitCriterion.java
@@ -63,6 +63,9 @@ public class RateLimitCriterion extends DoFn<KV<String, Long>, KV<String, Alert>
       return true;
     }
     String comp = fn.apply(events[0]);
+    if (comp == null) {
+      return false;
+    }
     for (Event e : events) {
       if (!(fn.apply(e).equals(comp))) {
         return false;
@@ -124,6 +127,38 @@ public class RateLimitCriterion extends DoFn<KV<String, Long>, KV<String, Alert>
       alert.addMetadata(
           "customs_unique_actor_accountid",
           sample.get(0).<SecEvent>getPayload().getSecEventData().getActorAccountId());
+    }
+
+    // If SMS recipient was the same for all events, store that as metadata
+    if (uniqueAttribute(
+        eventList, le -> le.<SecEvent>getPayload().getSecEventData().getSmsRecipient())) {
+      alert.addMetadata(
+          "customs_unique_sms_recipient",
+          sample.get(0).<SecEvent>getPayload().getSecEventData().getSmsRecipient());
+    }
+
+    // If email recipient was the same for all events, store that as metadata
+    if (uniqueAttribute(
+        eventList, le -> le.<SecEvent>getPayload().getSecEventData().getEmailRecipient())) {
+      alert.addMetadata(
+          "customs_unique_email_recipient",
+          sample.get(0).<SecEvent>getPayload().getSecEventData().getEmailRecipient());
+    }
+
+    // If source address was unique for all events, store that as metadata
+    if (uniqueAttribute(
+        eventList, le -> le.<SecEvent>getPayload().getSecEventData().getSourceAddress())) {
+      alert.addMetadata(
+          "customs_unique_source_address",
+          sample.get(0).<SecEvent>getPayload().getSecEventData().getSourceAddress());
+    }
+
+    // If object account ID was unique for all events, store that as metadata
+    if (uniqueAttribute(
+        eventList, le -> le.<SecEvent>getPayload().getSecEventData().getDestinationAccountId())) {
+      alert.addMetadata(
+          "customs_unique_object_accountid",
+          sample.get(0).<SecEvent>getPayload().getSecEventData().getDestinationAccountId());
     }
 
     // Finally, store a sample of events that were part of this detection as metadata in the

--- a/src/main/java/com/mozilla/secops/customs/RateLimitCriterion.java
+++ b/src/main/java/com/mozilla/secops/customs/RateLimitCriterion.java
@@ -108,7 +108,7 @@ public class RateLimitCriterion extends DoFn<KV<String, Long>, KV<String, Alert>
     alert.addMetadata("customs_count", valueCount.toString());
     alert.addMetadata("customs_threshold", limit.toString());
     if (uniqueActorAccountId(eventList)) {
-      alert.addMetadata("customs_actor_accountid", extractActorAccountId(sample.get(0)));
+      alert.addMetadata("customs_unique_actor_accountid", extractActorAccountId(sample.get(0)));
     }
     if (sample.size() > 0) {
       alert.addMetadata("customs_sample", Event.iterableToJson(sample));

--- a/src/main/java/com/mozilla/secops/parser/SecEvent.java
+++ b/src/main/java/com/mozilla/secops/parser/SecEvent.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
+import com.maxmind.geoip2.model.CityResponse;
 import java.io.IOException;
 import java.io.Serializable;
 import org.joda.time.DateTime;
@@ -101,6 +102,15 @@ public class SecEvent extends PayloadBase implements Serializable {
     DateTime ts = secEventData.getTimestamp();
     if (ts != null) {
       e.setTimestamp(ts);
+    }
+
+    String sa = secEventData.getSourceAddress();
+    if (sa != null) {
+      CityResponse cr = p.geoIp(sa);
+      if (cr != null) {
+        secEventData.setSourceAddressCity(cr.getCity().getName());
+        secEventData.setSourceAddressCountry(cr.getCountry().getIsoCode());
+      }
     }
   }
 }

--- a/src/main/java/com/mozilla/secops/parser/models/secevent/SecEvent.java
+++ b/src/main/java/com/mozilla/secops/parser/models/secevent/SecEvent.java
@@ -17,6 +17,8 @@ public class SecEvent implements Serializable {
   private String actorAccountId;
   private String action;
   private String sourceAddress;
+  private String sourceAddressCity;
+  private String sourceAddressCountry;
 
   private String emailRecipient;
   private String smsRecipient;
@@ -62,6 +64,44 @@ public class SecEvent implements Serializable {
   @JsonProperty("source_address")
   public String getSourceAddress() {
     return sourceAddress;
+  }
+
+  /**
+   * Get source address city
+   *
+   * @return Source address city
+   */
+  @JsonProperty("source_address_city")
+  public String getSourceAddressCity() {
+    return sourceAddressCity;
+  }
+
+  /**
+   * Set source address city
+   *
+   * @param value City value
+   */
+  public void setSourceAddressCity(String value) {
+    sourceAddressCity = value;
+  }
+
+  /**
+   * Get source address country
+   *
+   * @return Source address country
+   */
+  @JsonProperty("source_address_country")
+  public String getSourceAddressCountry() {
+    return sourceAddressCountry;
+  }
+
+  /**
+   * Set source address country
+   *
+   * @param value Country value
+   */
+  public void setSourceAddressCountry(String value) {
+    sourceAddressCountry = value;
   }
 
   /**

--- a/src/test/java/com/mozilla/secops/customs/TestCustoms.java
+++ b/src/test/java/com/mozilla/secops/customs/TestCustoms.java
@@ -77,7 +77,8 @@ public class TestCustoms {
                 assertEquals("3", a[0].getMetadataValue("customs_threshold"));
                 assertEquals("3", a[0].getMetadataValue("customs_count"));
                 assertEquals(
-                    "picard@uss.enterprise", a[0].getMetadataValue("customs_actor_accountid"));
+                    "picard@uss.enterprise",
+                    a[0].getMetadataValue("customs_unique_actor_accountid"));
 
                 Iterable<Event> samples =
                     Event.jsonToIterable(a[0].getMetadataValue("customs_sample"));

--- a/src/test/java/com/mozilla/secops/customs/TestCustoms.java
+++ b/src/test/java/com/mozilla/secops/customs/TestCustoms.java
@@ -79,6 +79,7 @@ public class TestCustoms {
                 assertEquals(
                     "picard@uss.enterprise",
                     a[0].getMetadataValue("customs_unique_actor_accountid"));
+                assertEquals("10.0.0.1", a[0].getMetadataValue("customs_unique_source_address"));
 
                 Iterable<Event> samples =
                     Event.jsonToIterable(a[0].getMetadataValue("customs_sample"));
@@ -110,10 +111,16 @@ public class TestCustoms {
                   String cc = ta.getMetadataValue("customs_category");
                   if (cc.equals("rl_sms_recipient")) {
                     assertEquals("00000000000", ta.getMetadataValue("customs_suspected"));
+                    assertEquals(
+                        "00000000000", ta.getMetadataValue("customs_unique_sms_recipient"));
                   } else if (cc.equals("rl_sms_sourceaddress")) {
                     assertEquals("10.0.0.2", ta.getMetadataValue("customs_suspected"));
+                    assertEquals("10.0.0.2", ta.getMetadataValue("customs_unique_source_address"));
                   } else if (cc.equals("rl_sms_accountid")) {
                     assertEquals("worf@uss.enterprise", ta.getMetadataValue("customs_suspected"));
+                    assertEquals(
+                        "worf@uss.enterprise",
+                        ta.getMetadataValue("customs_unique_actor_accountid"));
                   } else {
                     fail("invalid customs category: " + cc);
                   }
@@ -166,6 +173,9 @@ public class TestCustoms {
                   assertEquals("customs", a.getCategory());
                   assertEquals(
                       "127.0.0.1+q@the-q-continuum", a.getMetadataValue("customs_suspected"));
+                  assertEquals("127.0.0.1", a.getMetadataValue("customs_unique_source_address"));
+                  assertEquals(
+                      "q@the-q-continuum", a.getMetadataValue("customs_unique_actor_accountid"));
                   cnt++;
                 }
                 assertEquals(1, cnt);

--- a/src/test/java/com/mozilla/secops/customs/TestCustoms.java
+++ b/src/test/java/com/mozilla/secops/customs/TestCustoms.java
@@ -76,6 +76,8 @@ public class TestCustoms {
                     a[0].getMetadataValue("customs_category"));
                 assertEquals("3", a[0].getMetadataValue("customs_threshold"));
                 assertEquals("3", a[0].getMetadataValue("customs_count"));
+                assertEquals(
+                    "picard@uss.enterprise", a[0].getMetadataValue("customs_actor_accountid"));
 
                 Iterable<Event> samples =
                     Event.jsonToIterable(a[0].getMetadataValue("customs_sample"));

--- a/src/test/java/com/mozilla/secops/customs/TestCustoms.java
+++ b/src/test/java/com/mozilla/secops/customs/TestCustoms.java
@@ -82,6 +82,7 @@ public class TestCustoms {
                 Iterable<Event> samples =
                     Event.jsonToIterable(a[0].getMetadataValue("customs_sample"));
                 assertNotNull(samples);
+                assertEquals("false", a[0].getMetadataValue("customs_sample_truncated"));
                 Event[] elist = ((Collection<Event>) samples).toArray(new Event[0]);
                 assertNotNull(elist);
                 assertEquals(3, elist.length);

--- a/src/test/resources/testdata/customs_geo1.txt
+++ b/src/test/resources/testdata/customs_geo1.txt
@@ -1,0 +1,10 @@
+{"secevent_version":"secevent.model.1","action":"accountStatusCheck","destination_account_id":"quark1@uss.enterprise","timestamp":"1970-01-01T00:00:00+00:00","source_address":"216.160.83.56"}
+{"secevent_version":"secevent.model.1","action":"accountStatusCheck","destination_account_id":"quark2@uss.enterprise","timestamp":"1970-01-01T00:00:00+00:00","source_address":"216.160.83.56"}
+{"secevent_version":"secevent.model.1","action":"accountStatusCheck","destination_account_id":"quark3@uss.enterprise","timestamp":"1970-01-01T00:00:00+00:00","source_address":"216.160.83.56"}
+{"secevent_version":"secevent.model.1","action":"accountStatusCheck","destination_account_id":"quark4@uss.enterprise","timestamp":"1970-01-01T00:00:00+00:00","source_address":"216.160.83.56"}
+{"secevent_version":"secevent.model.1","action":"accountStatusCheck","destination_account_id":"quark5@uss.enterprise","timestamp":"1970-01-01T00:00:00+00:00","source_address":"216.160.83.56"}
+{"secevent_version":"secevent.model.1","action":"accountStatusCheck","destination_account_id":"quark6@uss.enterprise","timestamp":"1970-01-01T00:00:00+00:00","source_address":"216.160.83.56"}
+{"secevent_version":"secevent.model.1","action":"accountStatusCheck","destination_account_id":"quark7@uss.enterprise","timestamp":"1970-01-01T00:00:00+00:00","source_address":"216.160.83.56"}
+{"secevent_version":"secevent.model.1","action":"accountStatusCheck","destination_account_id":"quark8@uss.enterprise","timestamp":"1970-01-01T00:00:00+00:00","source_address":"216.160.83.56"}
+{"secevent_version":"secevent.model.1","action":"accountStatusCheck","destination_account_id":"quark9@uss.enterprise","timestamp":"1970-01-01T00:00:00+00:00","source_address":"216.160.83.56"}
+{"secevent_version":"secevent.model.1","action":"accountStatusCheck","destination_account_id":"quark10@uss.enterprise","timestamp":"1970-01-01T00:00:00+00:00","source_address":"216.160.83.56"}


### PR DESCRIPTION
When a set of events that triggers a customs detector has consistent attributes, specifically surface these unique attributes as metadata in the resulting alert. In addition, add GeoIP information to the metadata if possible.