### PR TITLE
support preprocessing in httprequest prior to analysis

### DIFF
--- a/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
+++ b/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
@@ -95,6 +95,69 @@ public class HTTPRequest implements Serializable {
   }
 
   /**
+   * Additional event preprocessing for {@link HTTPRequest} analysis components
+   *
+   * <p>DoFn to apply additional processing to the event stream prior to events being pushed into
+   * the analysis components of the pipeline.
+   */
+  public static class Preprocessor extends DoFn<Event, Event> {
+    private static final long serialVersionUID = 1L;
+
+    private String[] filterRequestPath;
+
+    /** Static initializer for {@link Preprocessor} */
+    public Preprocessor() {
+      filterRequestPath = null;
+    }
+
+    /**
+     * Static initializer for {@link Preprocessor}
+     *
+     * @param options Pipeline options
+     */
+    public Preprocessor(HTTPRequestOptions options) {
+      this();
+      filterRequestPath = options.getFilterRequestPath();
+    }
+
+    @ProcessElement
+    public void processElement(ProcessContext c) {
+      if (filterRequestPath == null) {
+        c.output(c.element());
+        return;
+      }
+      Event e = c.element();
+      GLB g = e.getPayload();
+      Integer status = g.getStatus();
+      if (status == null || status != 200) {
+        // Always emit errors
+        c.output(e);
+      }
+      String method = g.getRequestMethod();
+      URL u = g.getParsedUrl();
+      if (u == null) {
+        c.output(e);
+      }
+      String path = u.getPath();
+      if (path == null) {
+        c.output(e);
+      }
+      for (String s : filterRequestPath) {
+        String[] parts = s.split(":");
+        if (parts.length != 2) {
+          throw new IllegalArgumentException(
+              "invalid format for filter path, must be <method>:<path>");
+        }
+        if (parts[0].equals(method) && parts[1].equals(path)) {
+          // Match, so just drop the event
+          return;
+        }
+      }
+      c.output(e);
+    }
+  }
+
+  /**
    * Composite transform which given a set of windowed {@link Event} types, emits a set of {@link
    * KV} objects where the key is the source address of the request and the value is the number of
    * requests for that source within the window.
@@ -580,6 +643,11 @@ public class HTTPRequest implements Serializable {
     String[] getEndpointAbusePath();
 
     void setEndpointAbusePath(String[] value);
+
+    @Description("Filter successful requests for path before analysis; e.g., method:/path")
+    String[] getFilterRequestPath();
+
+    void setFilterRequestPath(String[] value);
   }
 
   private static void runHTTPRequest(HTTPRequestOptions options) {
@@ -590,7 +658,9 @@ public class HTTPRequest implements Serializable {
       pw.withStackdriverProjectFilter(options.getStackdriverProjectFilter());
     }
     PCollection<Event> events =
-        p.apply("input", options.getInputType().read(p, options)).apply("parse and window", pw);
+        p.apply("input", options.getInputType().read(p, options))
+            .apply("parse and window", pw)
+            .apply("preprocess", ParDo.of(new Preprocessor(options)));
 
     PCollectionView<Map<String, Boolean>> natView = null;
     if (options.getNatDetection()) {

--- a/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
+++ b/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
@@ -132,15 +132,18 @@ public class HTTPRequest implements Serializable {
       if (status == null || status != 200) {
         // Always emit errors
         c.output(e);
+        return;
       }
       String method = g.getRequestMethod();
       URL u = g.getParsedUrl();
       if (u == null) {
         c.output(e);
+        return;
       }
       String path = u.getPath();
       if (path == null) {
         c.output(e);
+        return;
       }
       for (String s : filterRequestPath) {
         String[] parts = s.split(":");

--- a/src/test/java/com/mozilla/secops/httprequest/TestEndpointAbuse1.java
+++ b/src/test/java/com/mozilla/secops/httprequest/TestEndpointAbuse1.java
@@ -12,6 +12,7 @@ import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Combine;
 import org.apache.beam.sdk.transforms.Count;
+import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionView;
@@ -86,6 +87,33 @@ public class TestEndpointAbuse1 {
 
     PCollection<Alert> results =
         events.apply(new HTTPRequest.EndpointAbuseAnalysis(options, natView));
+
+    PCollection<Long> count =
+        results.apply(Combine.globally(Count.<Alert>combineFn()).withoutDefaults());
+
+    PAssert.that(count).inWindow(new IntervalWindow(new Instant(0L), new Instant(60000))).empty();
+
+    p.run().waitUntilFinish();
+  }
+
+  @Test
+  public void endpointAbuseTestPreprocessFilter() throws Exception {
+    PCollection<String> input = TestUtil.getTestInput("/testdata/httpreq_endpointabuse1.txt", p);
+
+    HTTPRequest.HTTPRequestOptions options = getTestOptions();
+    String v[] = new String[1];
+    v[0] = "8:GET:/test";
+    options.setEndpointAbusePath(v);
+    String w[] = new String[1];
+    w[0] = "GET:/test";
+    options.setFilterRequestPath(w);
+
+    PCollection<Event> events =
+        input
+            .apply(new HTTPRequest.ParseAndWindow(true))
+            .apply(ParDo.of(new HTTPRequest.Preprocessor(options)));
+
+    PCollection<Alert> results = events.apply(new HTTPRequest.EndpointAbuseAnalysis(options));
 
     PCollection<Long> count =
         results.apply(Combine.globally(Count.<Alert>combineFn()).withoutDefaults());

--- a/src/test/java/com/mozilla/secops/httprequest/TestEndpointAbuse1.java
+++ b/src/test/java/com/mozilla/secops/httprequest/TestEndpointAbuse1.java
@@ -42,6 +42,7 @@ public class TestEndpointAbuse1 {
     PCollection<Alert> results =
         input
             .apply(new HTTPRequest.ParseAndWindow(true))
+            .apply(ParDo.of(new HTTPRequest.Preprocessor()))
             .apply(new HTTPRequest.EndpointAbuseAnalysis(options));
 
     PCollection<Long> count =
@@ -77,7 +78,10 @@ public class TestEndpointAbuse1 {
     options.setEndpointAbusePath(v);
     options.setNatDetection(true);
 
-    PCollection<Event> events = input.apply(new HTTPRequest.ParseAndWindow(true));
+    PCollection<Event> events =
+        input
+            .apply(new HTTPRequest.ParseAndWindow(true))
+            .apply(ParDo.of(new HTTPRequest.Preprocessor()));
     PCollectionView<Map<String, Boolean>> natView = DetectNat.getView(events);
 
     PCollection<Alert> results =

--- a/src/test/java/com/mozilla/secops/httprequest/TestErrorRate1.java
+++ b/src/test/java/com/mozilla/secops/httprequest/TestErrorRate1.java
@@ -36,7 +36,10 @@ public class TestErrorRate1 {
   public void countRequestsTest() throws Exception {
     PCollection<String> input = TestUtil.getTestInput("/testdata/httpreq_errorrate1.txt.gz", p);
 
-    PCollection<Event> events = input.apply(new HTTPRequest.ParseAndWindow(true));
+    PCollection<Event> events =
+        input
+            .apply(new HTTPRequest.ParseAndWindow(true))
+            .apply(ParDo.of(new HTTPRequest.Preprocessor()));
     PCollection<Long> count =
         events.apply(Combine.globally(Count.<Event>combineFn()).withoutDefaults());
 
@@ -60,6 +63,7 @@ public class TestErrorRate1 {
     PCollection<KV<String, Long>> counts =
         input
             .apply(new HTTPRequest.ParseAndWindow(true))
+            .apply(ParDo.of(new HTTPRequest.Preprocessor()))
             .apply(new HTTPRequest.CountErrorsInWindow());
 
     PAssert.that(counts)
@@ -76,6 +80,7 @@ public class TestErrorRate1 {
     PCollection<Alert> results =
         input
             .apply(new HTTPRequest.ParseAndWindow(true))
+            .apply(ParDo.of(new HTTPRequest.Preprocessor()))
             .apply(new HTTPRequest.CountErrorsInWindow())
             .apply(ParDo.of(new HTTPRequest.ErrorRateAnalysis(30L)));
 

--- a/src/test/java/com/mozilla/secops/httprequest/TestProjectFilter.java
+++ b/src/test/java/com/mozilla/secops/httprequest/TestProjectFilter.java
@@ -40,10 +40,9 @@ public class TestProjectFilter {
   public void withFilterTest() throws Exception {
     PCollection<String> input = TestUtil.getTestInput("/testdata/httpreq_projectfilter.txt", p);
 
-    HTTPRequest.ParseAndWindow pw =
-        new HTTPRequest.ParseAndWindow(true).apply(ParDo.of(new HTTPRequest.Preprocessor()));
+    HTTPRequest.ParseAndWindow pw = new HTTPRequest.ParseAndWindow(true);
     pw.withStackdriverProjectFilter("test");
-    PCollection<Event> events = input.apply(pw);
+    PCollection<Event> events = input.apply(pw).apply(ParDo.of(new HTTPRequest.Preprocessor()));
     PCollection<Long> count =
         events.apply(Combine.globally(Count.<Event>combineFn()).withoutDefaults());
 

--- a/src/test/java/com/mozilla/secops/httprequest/TestProjectFilter.java
+++ b/src/test/java/com/mozilla/secops/httprequest/TestProjectFilter.java
@@ -6,6 +6,7 @@ import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Combine;
 import org.apache.beam.sdk.transforms.Count;
+import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
 import org.apache.beam.sdk.values.PCollection;
 import org.joda.time.Instant;
@@ -21,7 +22,10 @@ public class TestProjectFilter {
   public void noFilterTest() throws Exception {
     PCollection<String> input = TestUtil.getTestInput("/testdata/httpreq_projectfilter.txt", p);
 
-    PCollection<Event> events = input.apply(new HTTPRequest.ParseAndWindow(true));
+    PCollection<Event> events =
+        input
+            .apply(new HTTPRequest.ParseAndWindow(true))
+            .apply(ParDo.of(new HTTPRequest.Preprocessor()));
     PCollection<Long> count =
         events.apply(Combine.globally(Count.<Event>combineFn()).withoutDefaults());
 
@@ -36,7 +40,8 @@ public class TestProjectFilter {
   public void withFilterTest() throws Exception {
     PCollection<String> input = TestUtil.getTestInput("/testdata/httpreq_projectfilter.txt", p);
 
-    HTTPRequest.ParseAndWindow pw = new HTTPRequest.ParseAndWindow(true);
+    HTTPRequest.ParseAndWindow pw =
+        new HTTPRequest.ParseAndWindow(true).apply(ParDo.of(new HTTPRequest.Preprocessor()));
     pw.withStackdriverProjectFilter("test");
     PCollection<Event> events = input.apply(pw);
     PCollection<Long> count =

--- a/src/test/java/com/mozilla/secops/httprequest/TestThresholdAnalysis1.java
+++ b/src/test/java/com/mozilla/secops/httprequest/TestThresholdAnalysis1.java
@@ -17,6 +17,7 @@ import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Combine;
 import org.apache.beam.sdk.transforms.Count;
+import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
@@ -47,7 +48,10 @@ public class TestThresholdAnalysis1 {
     PCollection<String> input =
         TestUtil.getTestInput("/testdata/httpreq_thresholdanalysis1.txt.gz", p);
 
-    PCollection<Event> events = input.apply(new HTTPRequest.ParseAndWindow(true));
+    PCollection<Event> events =
+        input
+            .apply(new HTTPRequest.ParseAndWindow(true))
+            .apply(ParDo.of(new HTTPRequest.Preprocessor()));
     PCollection<Long> count =
         events.apply(Combine.globally(Count.<Event>combineFn()).withoutDefaults());
 
@@ -82,7 +86,10 @@ public class TestThresholdAnalysis1 {
         TestUtil.getTestInput("/testdata/httpreq_thresholdanalysis1.txt.gz", p);
 
     PCollection<KV<String, Long>> counts =
-        input.apply(new HTTPRequest.ParseAndWindow(true)).apply(new HTTPRequest.CountInWindow());
+        input
+            .apply(new HTTPRequest.ParseAndWindow(true))
+            .apply(ParDo.of(new HTTPRequest.Preprocessor()))
+            .apply(new HTTPRequest.CountInWindow());
 
     PAssert.that(counts)
         .inWindow(new IntervalWindow(new Instant(0L), new Instant(60000)))
@@ -99,6 +106,7 @@ public class TestThresholdAnalysis1 {
     PCollection<Alert> results =
         input
             .apply(new HTTPRequest.ParseAndWindow(true))
+            .apply(ParDo.of(new HTTPRequest.Preprocessor()))
             .apply(new HTTPRequest.CountInWindow())
             .apply(new HTTPRequest.ThresholdAnalysis(getTestOptions()));
 
@@ -133,7 +141,10 @@ public class TestThresholdAnalysis1 {
     PCollection<String> input =
         TestUtil.getTestInput("/testdata/httpreq_thresholdanalysisnatdetect1.txt.gz", p);
 
-    PCollection<Event> events = input.apply(new HTTPRequest.ParseAndWindow(true));
+    PCollection<Event> events =
+        input
+            .apply(new HTTPRequest.ParseAndWindow(true))
+            .apply(ParDo.of(new HTTPRequest.Preprocessor()));
 
     PCollectionView<Map<String, Boolean>> natView = DetectNat.getView(events);
 
@@ -173,7 +184,10 @@ public class TestThresholdAnalysis1 {
     PCollection<String> input =
         TestUtil.getTestInput("/testdata/httpreq_thresholdanalysisnatdetect1.txt.gz", p);
 
-    PCollection<Event> events = input.apply(new HTTPRequest.ParseAndWindow(true));
+    PCollection<Event> events =
+        input
+            .apply(new HTTPRequest.ParseAndWindow(true))
+            .apply(ParDo.of(new HTTPRequest.Preprocessor()));
 
     PCollectionView<Map<String, Boolean>> natView = DetectNat.getView(events);
 
@@ -223,7 +237,10 @@ public class TestThresholdAnalysis1 {
     PCollection<String> input =
         TestUtil.getTestInput("/testdata/httpreq_thresholdanalysisnatdetect1.txt.gz", p);
 
-    PCollection<Event> events = input.apply(new HTTPRequest.ParseAndWindow(true));
+    PCollection<Event> events =
+        input
+            .apply(new HTTPRequest.ParseAndWindow(true))
+            .apply(ParDo.of(new HTTPRequest.Preprocessor()));
 
     PCollectionView<Map<String, Boolean>> natView = DetectNat.getView(events);
 


### PR DESCRIPTION
Add a generic preprocessing `DoFn`, initially used to apply event filtering based on pipeline configuration