### PR TITLE
Changes HTTPRequest EPA to make use of early firings

### DIFF
--- a/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
+++ b/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
@@ -79,6 +79,11 @@ public class HTTPRequest implements Serializable {
       stackdriverProjectFilter = project;
     }
 
+    /**
+     * Static initializer for {@link Parse} transform
+     *
+     * @param emitEventTimestamps If true, attempt to use the timestamp in the Event
+     */
     public Parse(Boolean emitEventTimestamps) {
       this.emitEventTimestamps = emitEventTimestamps;
     }
@@ -107,7 +112,11 @@ public class HTTPRequest implements Serializable {
     }
   }
 
-  /** Window events into fixed one minute windows with early firings */
+  /**
+   * Window events into fixed one minute windows with early firings
+   *
+   * <p>Panes are accumulated.
+   */
   public static class WindowForFixedFireEarly
       extends PTransform<PCollection<Event>, PCollection<Event>> {
     private static final long serialVersionUID = 1L;
@@ -739,12 +748,10 @@ public class HTTPRequest implements Serializable {
     }
 
     if (options.getEnableEndpointAbuseAnalysis()) {
-      PCollection<String> epaOutput =
-          efEvents
-              .apply("endpoint abuse analysis", new EndpointAbuseAnalysis(options))
-              .apply("output format", ParDo.of(new AlertFormatter(options)));
-
-      epaOutput.apply("output", OutputOptions.compositeOutput(options));
+      efEvents
+          .apply("endpoint abuse analysis", new EndpointAbuseAnalysis(options))
+          .apply("output format", ParDo.of(new AlertFormatter(options)))
+          .apply("output", OutputOptions.compositeOutput(options));
     }
 
     PCollection<String> results = resultsList.apply(Flatten.<String>pCollections());

--- a/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
+++ b/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
@@ -333,8 +333,12 @@ public class HTTPRequest implements Serializable {
 
                       String sourceAddress = g.getSourceAddress();
                       String requestMethod = g.getRequestMethod();
+                      String userAgent = g.getUserAgent();
                       if (sourceAddress == null || requestMethod == null) {
                         return;
+                      }
+                      if (userAgent == null) {
+                        userAgent = "unknown";
                       }
                       URL u = g.getParsedUrl();
                       if (u == null) {
@@ -343,6 +347,7 @@ public class HTTPRequest implements Serializable {
                       ArrayList<String> v = new ArrayList<>();
                       v.add(requestMethod);
                       v.add(u.getPath());
+                      v.add(userAgent);
                       c.output(KV.of(sourceAddress, v));
                     }
                   }))
@@ -371,12 +376,14 @@ public class HTTPRequest implements Serializable {
                       Integer foundThreshold = null;
                       String compareMethod = null;
                       String comparePath = null;
+                      String userAgent = null;
                       int count = 0;
                       for (ArrayList<String> i : paths) {
                         if (foundThreshold == null) {
                           foundThreshold = getEndpointThreshold(i.get(1), i.get(0));
                           compareMethod = i.get(0);
                           comparePath = i.get(1);
+                          userAgent = i.get(2);
                         } else {
                           if (!(compareMethod.equals(i.get(0)))
                               || !(comparePath.equals(i.get(1)))) {
@@ -432,6 +439,7 @@ public class HTTPRequest implements Serializable {
                         a.addMetadata("endpoint", comparePath);
                         a.addMetadata("method", compareMethod);
                         a.addMetadata("count", Integer.toString(count));
+                        a.addMetadata("useragent", userAgent);
                         a.addMetadata(
                             "window_timestamp", (new DateTime(w.maxTimestamp())).toString());
                         c.output(a);

--- a/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
+++ b/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
@@ -113,7 +113,7 @@ public class HTTPRequest implements Serializable {
   }
 
   /**
-   * Window events into fixed one minute windows with early firings
+   * Window events into fixed ten minute windows with early firings
    *
    * <p>Panes are accumulated.
    */
@@ -124,13 +124,13 @@ public class HTTPRequest implements Serializable {
     @Override
     public PCollection<Event> expand(PCollection<Event> input) {
       return input.apply(
-          Window.<Event>into(FixedWindows.of(Duration.standardMinutes(1)))
+          Window.<Event>into(FixedWindows.of(Duration.standardMinutes(10)))
               .triggering(
                   Repeatedly.forever(
                       AfterWatermark.pastEndOfWindow()
                           .withEarlyFirings(
                               AfterProcessingTime.pastFirstElementInPane()
-                                  .plusDelayOf(Duration.standardSeconds(5L)))))
+                                  .plusDelayOf(Duration.standardSeconds(10L)))))
               .withAllowedLateness(Duration.ZERO)
               .accumulatingFiredPanes());
     }

--- a/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
+++ b/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
@@ -708,15 +708,15 @@ public class HTTPRequest implements Serializable {
     }
 
     if (options.getEnableEndpointAbuseAnalysis()) {
-      resultsList =
-          resultsList.and(
-              efEvents
-                  .apply("endpoint abuse analysis", new EndpointAbuseAnalysis(options))
-                  .apply("output format", ParDo.of(new AlertFormatter(options))));
+      PCollection<String> epaOutput =
+          efEvents
+              .apply("endpoint abuse analysis", new EndpointAbuseAnalysis(options))
+              .apply("output format", ParDo.of(new AlertFormatter(options)));
+
+      epaOutput.apply("output", OutputOptions.compositeOutput(options));
     }
 
     PCollection<String> results = resultsList.apply(Flatten.<String>pCollections());
-
     results.apply("output", OutputOptions.compositeOutput(options));
 
     p.run();

--- a/src/test/java/com/mozilla/secops/httprequest/TestEndpointAbuse1.java
+++ b/src/test/java/com/mozilla/secops/httprequest/TestEndpointAbuse1.java
@@ -58,6 +58,7 @@ public class TestEndpointAbuse1 {
               for (Alert a : i) {
                 assertEquals("192.168.1.2", a.getMetadataValue("sourceaddress"));
                 assertEquals("endpoint_abuse", a.getMetadataValue("category"));
+                assertEquals("Mozilla", a.getMetadataValue("useragent"));
                 assertEquals(10L, Long.parseLong(a.getMetadataValue("count"), 10));
                 assertEquals("1970-01-01T00:00:59.999Z", a.getMetadataValue("window_timestamp"));
               }

--- a/src/test/java/com/mozilla/secops/httprequest/TestEndpointAbuse1.java
+++ b/src/test/java/com/mozilla/secops/httprequest/TestEndpointAbuse1.java
@@ -42,8 +42,9 @@ public class TestEndpointAbuse1 {
 
     PCollection<Alert> results =
         input
-            .apply(new HTTPRequest.ParseAndWindow(true))
+            .apply(new HTTPRequest.Parse(true))
             .apply(ParDo.of(new HTTPRequest.Preprocessor()))
+            .apply(new HTTPRequest.WindowForFixed())
             .apply(new HTTPRequest.EndpointAbuseAnalysis(options));
 
     PCollection<Long> count =
@@ -81,8 +82,9 @@ public class TestEndpointAbuse1 {
 
     PCollection<Event> events =
         input
-            .apply(new HTTPRequest.ParseAndWindow(true))
-            .apply(ParDo.of(new HTTPRequest.Preprocessor()));
+            .apply(new HTTPRequest.Parse(true))
+            .apply(ParDo.of(new HTTPRequest.Preprocessor()))
+            .apply(new HTTPRequest.WindowForFixed());
     PCollectionView<Map<String, Boolean>> natView = DetectNat.getView(events);
 
     PCollection<Alert> results =
@@ -110,8 +112,9 @@ public class TestEndpointAbuse1 {
 
     PCollection<Event> events =
         input
-            .apply(new HTTPRequest.ParseAndWindow(true))
-            .apply(ParDo.of(new HTTPRequest.Preprocessor(options)));
+            .apply(new HTTPRequest.Parse(true))
+            .apply(ParDo.of(new HTTPRequest.Preprocessor(options)))
+            .apply(new HTTPRequest.WindowForFixed());
 
     PCollection<Alert> results = events.apply(new HTTPRequest.EndpointAbuseAnalysis(options));
 

--- a/src/test/java/com/mozilla/secops/httprequest/TestEndpointAbuse1.java
+++ b/src/test/java/com/mozilla/secops/httprequest/TestEndpointAbuse1.java
@@ -48,11 +48,11 @@ public class TestEndpointAbuse1 {
         results.apply(Combine.globally(Count.<Alert>combineFn()).withoutDefaults());
 
     PAssert.that(count)
-        .inWindow(new IntervalWindow(new Instant(0L), new Instant(60000)))
+        .inWindow(new IntervalWindow(new Instant(0L), new Instant(600000)))
         .containsInAnyOrder(1L);
 
     PAssert.that(results)
-        .inWindow(new IntervalWindow(new Instant(0L), new Instant(60000)))
+        .inWindow(new IntervalWindow(new Instant(0L), new Instant(600000)))
         .satisfies(
             i -> {
               for (Alert a : i) {
@@ -60,7 +60,7 @@ public class TestEndpointAbuse1 {
                 assertEquals("endpoint_abuse", a.getMetadataValue("category"));
                 assertEquals("Mozilla", a.getMetadataValue("useragent"));
                 assertEquals(10L, Long.parseLong(a.getMetadataValue("count"), 10));
-                assertEquals("1970-01-01T00:00:59.999Z", a.getMetadataValue("window_timestamp"));
+                assertEquals("1970-01-01T00:09:59.999Z", a.getMetadataValue("window_timestamp"));
               }
               return null;
             });
@@ -91,7 +91,7 @@ public class TestEndpointAbuse1 {
     PCollection<Long> count =
         results.apply(Combine.globally(Count.<Alert>combineFn()).withoutDefaults());
 
-    PAssert.that(count).inWindow(new IntervalWindow(new Instant(0L), new Instant(60000))).empty();
+    PAssert.that(count).inWindow(new IntervalWindow(new Instant(0L), new Instant(600000))).empty();
 
     p.run().waitUntilFinish();
   }

--- a/src/test/java/com/mozilla/secops/httprequest/TestErrorRate1.java
+++ b/src/test/java/com/mozilla/secops/httprequest/TestErrorRate1.java
@@ -38,8 +38,9 @@ public class TestErrorRate1 {
 
     PCollection<Event> events =
         input
-            .apply(new HTTPRequest.ParseAndWindow(true))
-            .apply(ParDo.of(new HTTPRequest.Preprocessor()));
+            .apply(new HTTPRequest.Parse(true))
+            .apply(ParDo.of(new HTTPRequest.Preprocessor()))
+            .apply(new HTTPRequest.WindowForFixed());
     PCollection<Long> count =
         events.apply(Combine.globally(Count.<Event>combineFn()).withoutDefaults());
 
@@ -62,8 +63,9 @@ public class TestErrorRate1 {
 
     PCollection<KV<String, Long>> counts =
         input
-            .apply(new HTTPRequest.ParseAndWindow(true))
+            .apply(new HTTPRequest.Parse(true))
             .apply(ParDo.of(new HTTPRequest.Preprocessor()))
+            .apply(new HTTPRequest.WindowForFixed())
             .apply(new HTTPRequest.CountErrorsInWindow());
 
     PAssert.that(counts)
@@ -79,8 +81,9 @@ public class TestErrorRate1 {
 
     PCollection<Alert> results =
         input
-            .apply(new HTTPRequest.ParseAndWindow(true))
+            .apply(new HTTPRequest.Parse(true))
             .apply(ParDo.of(new HTTPRequest.Preprocessor()))
+            .apply(new HTTPRequest.WindowForFixed())
             .apply(new HTTPRequest.CountErrorsInWindow())
             .apply(ParDo.of(new HTTPRequest.ErrorRateAnalysis(30L)));
 

--- a/src/test/java/com/mozilla/secops/httprequest/TestProjectFilter.java
+++ b/src/test/java/com/mozilla/secops/httprequest/TestProjectFilter.java
@@ -24,8 +24,9 @@ public class TestProjectFilter {
 
     PCollection<Event> events =
         input
-            .apply(new HTTPRequest.ParseAndWindow(true))
-            .apply(ParDo.of(new HTTPRequest.Preprocessor()));
+            .apply(new HTTPRequest.Parse(true))
+            .apply(ParDo.of(new HTTPRequest.Preprocessor()))
+            .apply(new HTTPRequest.WindowForFixed());
     PCollection<Long> count =
         events.apply(Combine.globally(Count.<Event>combineFn()).withoutDefaults());
 
@@ -40,9 +41,13 @@ public class TestProjectFilter {
   public void withFilterTest() throws Exception {
     PCollection<String> input = TestUtil.getTestInput("/testdata/httpreq_projectfilter.txt", p);
 
-    HTTPRequest.ParseAndWindow pw = new HTTPRequest.ParseAndWindow(true);
+    HTTPRequest.Parse pw = new HTTPRequest.Parse(true);
     pw.withStackdriverProjectFilter("test");
-    PCollection<Event> events = input.apply(pw).apply(ParDo.of(new HTTPRequest.Preprocessor()));
+    PCollection<Event> events =
+        input
+            .apply(pw)
+            .apply(ParDo.of(new HTTPRequest.Preprocessor()))
+            .apply(new HTTPRequest.WindowForFixed());
     PCollection<Long> count =
         events.apply(Combine.globally(Count.<Event>combineFn()).withoutDefaults());
 

--- a/src/test/java/com/mozilla/secops/httprequest/TestThresholdAnalysis1.java
+++ b/src/test/java/com/mozilla/secops/httprequest/TestThresholdAnalysis1.java
@@ -50,8 +50,9 @@ public class TestThresholdAnalysis1 {
 
     PCollection<Event> events =
         input
-            .apply(new HTTPRequest.ParseAndWindow(true))
-            .apply(ParDo.of(new HTTPRequest.Preprocessor()));
+            .apply(new HTTPRequest.Parse(true))
+            .apply(ParDo.of(new HTTPRequest.Preprocessor()))
+            .apply(new HTTPRequest.WindowForFixed());
     PCollection<Long> count =
         events.apply(Combine.globally(Count.<Event>combineFn()).withoutDefaults());
 
@@ -87,8 +88,9 @@ public class TestThresholdAnalysis1 {
 
     PCollection<KV<String, Long>> counts =
         input
-            .apply(new HTTPRequest.ParseAndWindow(true))
+            .apply(new HTTPRequest.Parse(true))
             .apply(ParDo.of(new HTTPRequest.Preprocessor()))
+            .apply(new HTTPRequest.WindowForFixed())
             .apply(new HTTPRequest.CountInWindow());
 
     PAssert.that(counts)
@@ -105,8 +107,9 @@ public class TestThresholdAnalysis1 {
 
     PCollection<Alert> results =
         input
-            .apply(new HTTPRequest.ParseAndWindow(true))
+            .apply(new HTTPRequest.Parse(true))
             .apply(ParDo.of(new HTTPRequest.Preprocessor()))
+            .apply(new HTTPRequest.WindowForFixed())
             .apply(new HTTPRequest.CountInWindow())
             .apply(new HTTPRequest.ThresholdAnalysis(getTestOptions()));
 
@@ -143,8 +146,9 @@ public class TestThresholdAnalysis1 {
 
     PCollection<Event> events =
         input
-            .apply(new HTTPRequest.ParseAndWindow(true))
-            .apply(ParDo.of(new HTTPRequest.Preprocessor()));
+            .apply(new HTTPRequest.Parse(true))
+            .apply(ParDo.of(new HTTPRequest.Preprocessor()))
+            .apply(new HTTPRequest.WindowForFixed());
 
     PCollectionView<Map<String, Boolean>> natView = DetectNat.getView(events);
 
@@ -186,8 +190,9 @@ public class TestThresholdAnalysis1 {
 
     PCollection<Event> events =
         input
-            .apply(new HTTPRequest.ParseAndWindow(true))
-            .apply(ParDo.of(new HTTPRequest.Preprocessor()));
+            .apply(new HTTPRequest.Parse(true))
+            .apply(ParDo.of(new HTTPRequest.Preprocessor()))
+            .apply(new HTTPRequest.WindowForFixed());
 
     PCollectionView<Map<String, Boolean>> natView = DetectNat.getView(events);
 
@@ -212,7 +217,11 @@ public class TestThresholdAnalysis1 {
     PCollection<String> input =
         TestUtil.getTestInput("/testdata/httpreq_thresholdanalysisnatdetect1.txt.gz", p);
 
-    PCollection<Event> events = input.apply(new HTTPRequest.ParseAndWindow(true));
+    PCollection<Event> events =
+        input
+            .apply(new HTTPRequest.Parse(true))
+            .apply(ParDo.of(new HTTPRequest.Preprocessor()))
+            .apply(new HTTPRequest.WindowForFixed());
 
     PCollectionView<Map<String, Boolean>> natView = DetectNat.getView(events);
 
@@ -239,8 +248,9 @@ public class TestThresholdAnalysis1 {
 
     PCollection<Event> events =
         input
-            .apply(new HTTPRequest.ParseAndWindow(true))
-            .apply(ParDo.of(new HTTPRequest.Preprocessor()));
+            .apply(new HTTPRequest.Parse(true))
+            .apply(ParDo.of(new HTTPRequest.Preprocessor()))
+            .apply(new HTTPRequest.WindowForFixed());
 
     PCollectionView<Map<String, Boolean>> natView = DetectNat.getView(events);
 


### PR DESCRIPTION
Handle early pane firings and treat them as supplemental alerting components, rather then wait for the entire fixed window.