### PR TITLE
store alert template name as metadata

### DIFF
--- a/src/main/java/com/mozilla/secops/alert/Alert.java
+++ b/src/main/java/com/mozilla/secops/alert/Alert.java
@@ -37,7 +37,6 @@ public class Alert implements Serializable {
   private DateTime timestamp;
   private ArrayList<AlertMeta> metadata;
   private AlertSeverity severity;
-  private String templateName;
 
   /** Construct new alert object */
   public Alert() {
@@ -247,7 +246,7 @@ public class Alert implements Serializable {
    * @param templateName Freemarker template name with file extension
    */
   public void setTemplateName(String templateName) {
-    this.templateName = templateName;
+    addMetadata("template_name", templateName);
   }
 
   /**
@@ -255,9 +254,9 @@ public class Alert implements Serializable {
    *
    * @return Freemarker template name with file extension or null if not set.
    */
-  @JsonProperty("template_name")
+  @JsonIgnore
   public String getTemplateName() {
-    return templateName;
+    return getMetadataValue("template_name");
   }
 
   /**

--- a/src/test/java/com/mozilla/secops/alert/TestAlert.java
+++ b/src/test/java/com/mozilla/secops/alert/TestAlert.java
@@ -39,7 +39,8 @@ public class TestAlert {
         "{\"severity\":\"info\",\"id\":\"d14277bb-8d69-4cd8-b83d-3ccdaf17c7b9\","
             + "\"summary\":\"test alert\""
             + ",\"category\":\"test\",\"payload\":\"first line\\n\\nsecond line\","
-            + "\"timestamp\":\"1970-01-01T00:00:00.000Z\",\"template_name\":\"test.fthl\"}";
+            + "\"timestamp\":\"1970-01-01T00:00:00.000Z\","
+            + "\"metadata\":[{\"key\":\"template_name\",\"value\":\"test.fthl\"}]}";
 
     Alert a = new Alert();
     assertNotNull(a);


### PR DESCRIPTION
Store the alert template name as metadata in the alert instead of in a
dedicated field to avoid the field needing to be present in the BQ alert
output schema.