### PR TITLE
Process BMO audit data into AUTH/AUTH_SESSION

### DIFF
--- a/src/main/java/com/mozilla/secops/parser/BmoAudit.java
+++ b/src/main/java/com/mozilla/secops/parser/BmoAudit.java
@@ -1,0 +1,180 @@
+package com.mozilla.secops.parser;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.maxmind.geoip2.model.CityResponse;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/** Payload parser for BMO Mozlog audit data */
+public class BmoAudit extends PayloadBase implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  private final String reLogin = "^successful login of (\\S+) from (\\S+) using \"([^\"]+)\",.*";
+
+  public enum AuditType {
+    /** Login event */
+    LOGIN
+  }
+
+  private String msg;
+  private String remoteIp;
+  private String remoteIpCity;
+  private String remoteIpCountry;
+  private String requestId;
+  private String user;
+  private String userAgent;
+  private AuditType type;
+
+  /**
+   * Get audito event type
+   *
+   * @return AuditType
+   */
+  public AuditType getAuditType() {
+    return type;
+  }
+
+  /**
+   * Get msg
+   *
+   * @return String
+   */
+  public String getMsg() {
+    return msg;
+  }
+
+  /**
+   * Get remote IP
+   *
+   * @return String
+   */
+  public String getRemoteIp() {
+    return remoteIp;
+  }
+
+  /**
+   * Get request ID
+   *
+   * @return String
+   */
+  public String getRequestId() {
+    return requestId;
+  }
+
+  /**
+   * Get user
+   *
+   * @return String
+   */
+  public String getUser() {
+    return user;
+  }
+
+  /**
+   * Get user agent
+   *
+   * @return String
+   */
+  public String getUserAgent() {
+    return userAgent;
+  }
+
+  private Map<String, String> convertInput(String input) {
+    ObjectMapper mapper = new ObjectMapper();
+    Map<String, String> fields = new HashMap<String, String>();
+    try {
+      fields = mapper.readValue(input, new TypeReference<Map<String, String>>() {});
+    } catch (IOException exc) {
+      return null;
+    }
+    return fields;
+  }
+
+  @Override
+  public Boolean matcher(String input, ParserState state) {
+    // There should always have an associated Mozlog hint
+    Mozlog hint = state.getMozlogHint();
+    if (hint == null) {
+      return false;
+    }
+    String type = hint.getType();
+    if ((type == null) || (!(type.equals("audit")))) {
+      return false;
+    }
+    Map<String, String> fields = convertInput(input);
+    if (fields == null) {
+      return false;
+    }
+    if ((fields.get("msg") != null)
+        && (fields.get("remote_ip") != null)
+        && (fields.get("request_id") != null)) {
+      String msg = fields.get("msg");
+      if (Pattern.compile(reLogin).matcher(msg).matches()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Override
+  @JsonProperty("type")
+  public Payload.PayloadType getType() {
+    return Payload.PayloadType.BMOAUDIT;
+  }
+
+  /** Construct matcher object. */
+  public BmoAudit() {}
+
+  /**
+   * Construct parser object.
+   *
+   * @param input Input string.
+   * @param e Parent {@link Event}.
+   * @param state State
+   */
+  public BmoAudit(String input, Event e, ParserState state) {
+    Map<String, String> fields = convertInput(input);
+    if (fields == null) {
+      return;
+    }
+    msg = fields.get("msg");
+    remoteIp = fields.get("remote_ip");
+    requestId = fields.get("request_id");
+
+    if ((msg == null) || (remoteIp == null) || (requestId == null)) {
+      return;
+    }
+
+    if (remoteIp != null) {
+      CityResponse cr = state.getParser().geoIp(remoteIp);
+      if (cr != null) {
+        remoteIpCity = cr.getCity().getName();
+        remoteIpCountry = cr.getCountry().getIsoCode();
+      }
+    }
+
+    Normalized n = e.getNormalized();
+
+    Matcher mat = Pattern.compile(reLogin).matcher(msg);
+    if (mat.matches()) {
+      type = AuditType.LOGIN;
+      user = mat.group(1);
+      // Prefer the source address in the fields to the msg entry, so just ignore that group
+      // here for now.
+      userAgent = mat.group(3);
+
+      n.addType(Normalized.Type.AUTH);
+      n.setSubjectUser(user);
+      n.setSourceAddress(remoteIp);
+      n.setSourceAddressCity(remoteIpCity);
+      n.setSourceAddressCountry(remoteIpCountry);
+      n.setObject("bugzilla"); // Just hardcode to application here
+    }
+  }
+}

--- a/src/main/java/com/mozilla/secops/parser/Parser.java
+++ b/src/main/java/com/mozilla/secops/parser/Parser.java
@@ -1,5 +1,7 @@
 package com.mozilla.secops.parser;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.client.json.JsonParser;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.logging.v2.model.LogEntry;
@@ -119,10 +121,37 @@ public class Parser {
     return input;
   }
 
-  private String stripMozlog(Event e, String input) {
+  private String stripMozlog(Event e, String input, ParserState state) {
+    LogEntry entry = state.getLogEntryHint();
+    if (entry != null) {
+      // If we have an existing LogEntry hint, attempt to treat a present jsonPayload
+      // as Mozlog
+      Map<String, Object> jsonPayload = entry.getJsonPayload();
+      String jbuf = null;
+      if (jsonPayload != null) {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(
+            com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+        try {
+          jbuf = mapper.writeValueAsString(jsonPayload);
+        } catch (JsonProcessingException exc) {
+          // pass
+        }
+      }
+      if (jbuf != null) {
+        Mozlog m = Mozlog.fromJSON(jbuf);
+        if (m != null) {
+          e.setMozlog(m);
+          state.setMozlogHint(m);
+          return m.getFieldsAsJson();
+        }
+      }
+    }
+
     Mozlog m = Mozlog.fromJSON(input);
     if (m != null) {
       e.setMozlog(m);
+      state.setMozlogHint(m);
       return m.getFieldsAsJson();
     }
     return input;
@@ -135,7 +164,7 @@ public class Parser {
     if (input == null) {
       return null;
     }
-    input = stripMozlog(e, input);
+    input = stripMozlog(e, input, state);
     return input;
   }
 
@@ -226,6 +255,7 @@ public class Parser {
     payloads.add(new SecEvent());
     payloads.add(new Cloudtrail());
     payloads.add(new GcpAudit());
+    payloads.add(new BmoAudit());
     payloads.add(new OpenSSH());
     payloads.add(new Duopull());
     payloads.add(new Raw());

--- a/src/main/java/com/mozilla/secops/parser/ParserState.java
+++ b/src/main/java/com/mozilla/secops/parser/ParserState.java
@@ -6,6 +6,7 @@ import com.google.api.services.logging.v2.model.LogEntry;
 class ParserState {
   private final Parser parser;
   private LogEntry logEntryHint;
+  private Mozlog mozLogHint;
 
   /**
    * Get LogEntry hint
@@ -23,6 +24,24 @@ class ParserState {
    */
   public void setLogEntryHint(LogEntry entry) {
     logEntryHint = entry;
+  }
+
+  /**
+   * Get Mozlog hint
+   *
+   * @return hint or null of it has not been set
+   */
+  public Mozlog getMozlogHint() {
+    return mozLogHint;
+  }
+
+  /**
+   * Set Mozlog hint
+   *
+   * @param entry Mozlog to store as hint
+   */
+  public void setMozlogHint(Mozlog entry) {
+    mozLogHint = entry;
   }
 
   /**

--- a/src/main/java/com/mozilla/secops/parser/Payload.java
+++ b/src/main/java/com/mozilla/secops/parser/Payload.java
@@ -22,6 +22,8 @@ public class Payload<T extends PayloadBase> implements Serializable {
     GCPAUDIT,
     /** Nginx */
     NGINX,
+    /** BmoAudit */
+    BMOAUDIT,
     /** Raw */
     RAW
   }

--- a/src/test/java/com/mozilla/secops/parser/ParserTest.java
+++ b/src/test/java/com/mozilla/secops/parser/ParserTest.java
@@ -303,6 +303,40 @@ public class ParserTest {
   }
 
   @Test
+  public void testParseBmoAuditStackdriver() {
+    String buf =
+        "{\"insertId\":\"AAAAAAAAAAAAAAA\",\"jsonPayload\":{\"EnvVersion\":2,\"Fields\":{\"msg\""
+            + ":\"successful login of spock@mozilla.com from 216.160.83.56 using \\\"Mozilla/5.0\\\", auth"
+            + "enticated by Bugzilla::Auth::Login::CGI\",\"remote_ip\":\"216.160.83.56\",\"request_id\""
+            + ":\"00000000\"},\"Hostname\":\"ip-172.us-west-2.compute.internal\",\"Logger\":\"CEREAL\","
+            + "\"Pid\":\"282\",\"Severity\":5,\"Timestamp\":1.548956727e+18,\"Type\":\"audit\"},\"label"
+            + "s\":{\"application\":\"bugzilla\",\"ec2.amazonaws.com/resource_name\":\"ip-172.us-west-2"
+            + ".compute.internal\",\"env\":\"prod\",\"stack\":\"app\",\"type\":\"app\"},\"logName\":\"p"
+            + "rojects/prod/logs/docker.bugzilla\",\"receiveTimestamp\":\"2019-01-31T17:45:27.655836432"
+            + "Z\",\"resource\":{\"labels\":{\"aws_account\":\"000000000000\",\"instance_id\":\"i-0\","
+            + "\"project_id\":\"prod\",\"region\":\"aws:us-west-2a\"},\"type\":\"aws_ec2_instance\"},\""
+            + "timestamp\":\"2019-01-31T17:45:27.478007784Z\"}";
+    Parser p = new Parser();
+    assertNotNull(p);
+    Event e = p.parse(buf);
+    assertNotNull(e);
+    assertEquals(Payload.PayloadType.BMOAUDIT, e.getPayloadType());
+    BmoAudit b = e.getPayload();
+    assertEquals("216.160.83.56", b.getRemoteIp());
+    assertEquals("00000000", b.getRequestId());
+    assertEquals(BmoAudit.AuditType.LOGIN, b.getAuditType());
+    assertEquals("spock@mozilla.com", b.getUser());
+    assertEquals("Mozilla/5.0", b.getUserAgent());
+    Normalized n = e.getNormalized();
+    assertNotNull(n);
+    assertTrue(n.isOfType(Normalized.Type.AUTH));
+    assertEquals("spock@mozilla.com", n.getSubjectUser());
+    assertEquals("216.160.83.56", n.getSourceAddress());
+    assertEquals("Milton", n.getSourceAddressCity());
+    assertEquals("US", n.getSourceAddressCountry());
+  }
+
+  @Test
   public void testParseMozlogDuopullBypass() {
     String buf =
         "{\"EnvVersion\": \"2.0\", \"Severity\": 6, \"Fields\": "

--- a/src/test/java/com/mozilla/secops/parser/ParserTest.java
+++ b/src/test/java/com/mozilla/secops/parser/ParserTest.java
@@ -337,6 +337,40 @@ public class ParserTest {
   }
 
   @Test
+  public void testParseBmoAuditCreateBugStackdriver() {
+    String buf =
+        "{\"insertId\":\"AAAAAAAAAAAAA\",\"jsonPayload\":{\"EnvVersion\":2,\"Field"
+            + "s\":{\"msg\":\"spock@mozilla.com <216.160.83.56> created bug 0000000\",\""
+            + "remote_ip\":\"216.160.83.56\",\"request_id\":\"AAAAAAAA\",\"user_id\":\"0"
+            + "00000\"},\"Hostname\":\"ip-172.us-west-2.compute.internal\",\"Logger\":\""
+            + "CEREAL\",\"Pid\":\"264\",\"Severity\":5,\"Timestamp\":1.548956906e+18,\"T"
+            + "ype\":\"audit\"},\"labels\":{\"application\":\"bugzilla\",\"ec2.amazonaws"
+            + ".com/resource_name\":\"ip-172.us-west-2.compute.internal\",\"env\":\"prod"
+            + "\",\"stack\":\"app\",\"type\":\"app\"},\"logName\":\"projects/prod/logs/d"
+            + "ocker.bugzilla\",\"receiveTimestamp\":\"2019-01-31T17:48:29.488536026Z\",\""
+            + "resource\":{\"labels\":{\"aws_account\":\"000000000000\",\"instance_id\":\""
+            + "i-0\",\"project_id\":\"prod\",\"region\":\"aws:us-west-2a\"},\"type\":\"aws"
+            + "_ec2_instance\"},\"timestamp\":\"2019-01-31T17:48:26.593764735Z\"}";
+    Parser p = new Parser();
+    assertNotNull(p);
+    Event e = p.parse(buf);
+    assertNotNull(e);
+    assertEquals(Payload.PayloadType.BMOAUDIT, e.getPayloadType());
+    BmoAudit b = e.getPayload();
+    assertEquals("216.160.83.56", b.getRemoteIp());
+    assertEquals("AAAAAAAA", b.getRequestId());
+    assertEquals(BmoAudit.AuditType.CREATEBUG, b.getAuditType());
+    assertEquals("spock@mozilla.com", b.getUser());
+    Normalized n = e.getNormalized();
+    assertNotNull(n);
+    assertTrue(n.isOfType(Normalized.Type.AUTH_SESSION));
+    assertEquals("spock@mozilla.com", n.getSubjectUser());
+    assertEquals("216.160.83.56", n.getSourceAddress());
+    assertEquals("Milton", n.getSourceAddressCity());
+    assertEquals("US", n.getSourceAddressCountry());
+  }
+
+  @Test
   public void testParseMozlogDuopullBypass() {
     String buf =
         "{\"EnvVersion\": \"2.0\", \"Severity\": 6, \"Fields\": "


### PR DESCRIPTION
Process BMO audit data, add normalized field tags for auth event and existing session event for inclusion in authprofile

This also adds support for including a mozlog entry hint in parser state so individual parsers can inspect details of the encapsulation