### PR TITLE
AuthProfile refactor, dont store state for unmapped identities, optionally ignore unmapped

### DIFF
--- a/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
+++ b/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
@@ -61,6 +61,7 @@ public class AuthProfile implements Serializable {
     private Logger log;
     private final String idmanagerPath;
     private final String[] ignoreUserRegex;
+    private final Boolean ignoreUnknownIdentities;
 
     /**
      * Static initializer for {@link ParseAndWindow} using specified pipeline options
@@ -71,6 +72,7 @@ public class AuthProfile implements Serializable {
       idmanagerPath = options.getIdentityManagerPath();
       log = LoggerFactory.getLogger(ParseAndWindow.class);
       ignoreUserRegex = options.getIgnoreUserRegex();
+      ignoreUnknownIdentities = options.getIgnoreUnknownIdentities();
     }
 
     @Override
@@ -133,6 +135,9 @@ public class AuthProfile implements Serializable {
                         log.info(
                             "{}: username does not map to any known identity or alias",
                             n.getSubjectUser());
+                        if (ignoreUnknownIdentities) {
+                          return;
+                        }
                         c.output(KV.of(n.getSubjectUser(), e));
                       }
                     }
@@ -395,6 +400,12 @@ public class AuthProfile implements Serializable {
     String[] getIgnoreUserRegex();
 
     void setIgnoreUserRegex(String[] value);
+
+    @Description("If true, never create informational alerts for unknown identities")
+    @Default.Boolean(false)
+    Boolean getIgnoreUnknownIdentities();
+
+    void setIgnoreUnknownIdentities(Boolean value);
   }
 
   private static void runAuthProfile(AuthProfileOptions options) throws IllegalArgumentException {

--- a/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
+++ b/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
@@ -204,130 +204,161 @@ public class AuthProfile implements Serializable {
       state.done();
     }
 
+    /**
+     * Create a base {@link Alert} using information from the event
+     *
+     * @param e Event
+     * @return Base alert object
+     */
+    private Alert createBaseAlert(Event e) {
+      Alert a = new Alert();
+
+      Normalized n = e.getNormalized();
+      a.addMetadata("object", n.getObject());
+      a.addMetadata("username", n.getSubjectUser());
+      a.addMetadata("sourceaddress", n.getSourceAddress());
+      a.setCategory("authprofile");
+
+      String city = n.getSourceAddressCity();
+      if (city != null) {
+        a.addMetadata("sourceaddress_city", city);
+      } else {
+        a.addMetadata("sourceaddress_city", "unknown");
+      }
+      String country = n.getSourceAddressCountry();
+      if (city != null) {
+        a.addMetadata("sourceaddress_country", country);
+      } else {
+        a.addMetadata("sourceaddress_country", "unknown");
+      }
+
+      return a;
+    }
+
+    private Boolean ignoreDuplicateSourceAddress(Event e, ArrayList<String> list) {
+      for (String s : list) {
+        if (s.equals(e.getNormalized().getSourceAddress())) {
+          return true;
+        }
+      }
+      list.add(e.getNormalized().getSourceAddress());
+      return false;
+    }
+
+    private void addEscalationMetadata(Alert a, Identity identity) {
+      String dnote = identity.getEmailNotifyDirect(idmanager.getDefaultNotification());
+      if (dnote != null) {
+        log.info(
+            "{}: adding direct email notification metadata route to {}",
+            a.getMetadataValue("identity_key"),
+            dnote);
+        a.addMetadata("notify_email_direct", dnote);
+      }
+    }
+
+    private void buildAlertSummary(Event e, Alert a) {
+      String summary =
+          String.format(
+              "authentication event observed %s [%s] to %s, ",
+              e.getNormalized().getSubjectUser(),
+              a.getMetadataValue("identity_key") != null
+                  ? a.getMetadataValue("identity_key")
+                  : "untracked",
+              e.getNormalized().getObject());
+      if (a.getSeverity().equals(Alert.AlertSeverity.WARNING)) {
+        summary = summary + "new source ";
+      }
+      summary =
+          summary
+              + String.format(
+                  "%s [%s/%s]",
+                  a.getMetadataValue("sourceaddress"),
+                  a.getMetadataValue("sourceaddress_city"),
+                  a.getMetadataValue("sourceaddress_country"));
+      a.setSummary(summary);
+    }
+
+    private void buildAlertPayload(Alert a) {
+      String payload =
+          String.format(
+              "An authentication event for user %s was detected to access %s.",
+              a.getMetadataValue("username"), a.getMetadataValue("object"));
+      if (a.getMetadataValue("identity_key") != null) {
+        if (a.getSeverity().equals(Alert.AlertSeverity.WARNING)) {
+          payload = payload + " This occurred from a source address unknown to the system.";
+        } else {
+          payload = payload + " This occurred from a known source address.";
+        }
+      } else {
+        payload = payload = " This event occurred for an untracked identity.";
+      }
+      a.addToPayload(payload);
+    }
+
     @ProcessElement
     public void processElement(ProcessContext c) throws StateException {
       Iterable<Event> events = c.element().getValue();
       String userIdentity = c.element().getKey();
       Identity identity = idmanager.getIdentity(userIdentity);
 
-      ArrayList<String> seenNew = new ArrayList<>();
-      ArrayList<String> seenKnown = new ArrayList<>();
+      ArrayList<String> seenNewAddresses = new ArrayList<>();
+      ArrayList<String> seenKnownAddresses = new ArrayList<>();
 
       for (Event e : events) {
-        Normalized n = e.getNormalized();
-        String address = n.getSourceAddress();
-        String destination = n.getObject();
-        // The element key will be the possibly resolved identity of the user if we were able
-        // to look the user up using identity manager. Grab the original username from the source
-        // event as well.
-        String eventUsername = n.getSubjectUser();
-        Boolean isUnknown = false;
+        Alert a = createBaseAlert(e);
 
-        StateModel sm = StateModel.get(userIdentity, state);
-        if (sm == null) {
-          sm = new StateModel(userIdentity);
-        }
-
-        String city = n.getSourceAddressCity();
-        String country = n.getSourceAddressCountry();
-        String summaryIndicator = address;
-        if (city != null && country != null) {
-          summaryIndicator = summaryIndicator + String.format(" [%s/%s]", city, country);
-        }
-
-        Alert alert = new Alert();
-
-        String summary =
-            String.format("authentication event observed %s to %s", eventUsername, destination);
-        if (sm.updateEntry(address)) {
-          // Address was new
-          Boolean wasSeen = false;
-          for (String s : seenNew) {
-            if (s.equals(address)) {
-              wasSeen = true;
-            }
-          }
-          // If we have already reported this as new once during this window, just ignore
-          // this event
-          if (wasSeen) {
+        if (identity == null) {
+          a.addMetadata("identity_untracked", "true");
+          // New/known do not apply for untracked, but just use the new address ignore list here
+          if (ignoreDuplicateSourceAddress(e, seenNewAddresses)) {
             continue;
           }
-          seenNew.add(address);
-
-          isUnknown = true;
-          log.info("{}: escalating alert criteria for new source: {}", userIdentity, address);
-          summary = summary + ", new source " + summaryIndicator;
-          alert.setSeverity(Alert.AlertSeverity.WARNING);
-          alert.setTemplateName("authprofile.ftlh");
-
-          alert.addToPayload(
-              String.format(
-                  "An authentication event for user %s was detected "
-                      + "to access %s, and this event occurred from a source address unknown to the system.",
-                  eventUsername, destination));
         } else {
-          // Known source
-          Boolean wasSeen = false;
-          for (String s : seenKnown) {
-            if (s.equals(address)) {
-              wasSeen = true;
+          a.addMetadata("identity_key", userIdentity);
+          // The event was for a tracked identity, initialize the state model
+          StateModel sm = StateModel.get(userIdentity, state);
+          if (sm == null) {
+            sm = new StateModel(userIdentity);
+          }
+
+          if (sm.updateEntry(e.getNormalized().getSourceAddress())) {
+            // Check new address ignore list
+            if (ignoreDuplicateSourceAddress(e, seenNewAddresses)) {
+              continue;
             }
-          }
-          // If we have already reported this as new once during this window, just ignore
-          // this event
-          if (wasSeen) {
-            continue;
-          }
-          seenKnown.add(address);
-
-          log.info("{}: access from known source: {}", userIdentity, address);
-          summary = summary + ", known source " + summaryIndicator;
-          alert.setSeverity(Alert.AlertSeverity.INFORMATIONAL);
-          alert.addToPayload(
-              String.format(
-                  "An authentication event for user %s was detected "
-                      + "to access %s. This occurred from a known source address.",
-                  eventUsername, destination));
-        }
-        alert.setSummary(summary);
-        alert.setCategory("authprofile");
-
-        alert.addMetadata("object", destination);
-        alert.addMetadata("sourceaddress", address);
-        alert.addMetadata("username", eventUsername);
-        if (identity != null) {
-          alert.addMetadata("identity_key", userIdentity);
-          // If new, set direct notification in the metadata so the alert is also forwarded
-          // to the user.
-          if (isUnknown) {
-            String dnot = identity.getEmailNotifyDirect(idmanager.getDefaultNotification());
-            if (dnot != null) {
-              log.info(
-                  "{}: adding direct email notification metadata route to {}", userIdentity, dnot);
-              alert.addMetadata("notify_email_direct", dnot);
+            // Address was new
+            log.info(
+                "{}: escalating alert criteria for new source: {} {}",
+                userIdentity,
+                e.getNormalized().getSubjectUser(),
+                e.getNormalized().getSourceAddress());
+            a.setSeverity(Alert.AlertSeverity.WARNING);
+            a.setTemplateName("authprofile.ftlh");
+            addEscalationMetadata(a, identity);
+          } else {
+            // Check known address ignore list
+            if (ignoreDuplicateSourceAddress(e, seenKnownAddresses)) {
+              continue;
             }
+            // Address was known
+            log.info(
+                "{}: access from known source: {} {}",
+                userIdentity,
+                e.getNormalized().getSubjectUser(),
+                e.getNormalized().getSourceAddress());
+          }
+
+          // Update persistent state with new information
+          try {
+            sm.set(state);
+          } catch (StateException exc) {
+            log.error("{}: error updating state: {}", userIdentity, exc.getMessage());
           }
         }
-        if (city != null) {
-          alert.addMetadata("sourceaddress_city", city);
-        } else {
-          alert.addMetadata("sourceaddress_city", "unknown");
-        }
-        if (country != null) {
-          alert.addMetadata("sourceaddress_country", country);
-        } else {
-          alert.addMetadata("sourceaddress_country", "unknown");
-        }
 
-        try {
-          sm.set(state);
-        } catch (StateException exc) {
-          log.error("{}: error updating state: {}", userIdentity, exc.getMessage());
-        }
-        if (!alert.hasCorrectFields()) {
-          throw new IllegalArgumentException("alert has invalid field configuration");
-        }
-        c.output(alert);
+        buildAlertSummary(e, a);
+        buildAlertPayload(a);
+        c.output(a);
       }
     }
   }

--- a/src/test/java/com/mozilla/secops/authprofile/TestAuthProfile.java
+++ b/src/test/java/com/mozilla/secops/authprofile/TestAuthProfile.java
@@ -1,8 +1,10 @@
 package com.mozilla.secops.authprofile;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import com.mozilla.secops.TestUtil;
@@ -107,14 +109,14 @@ public class TestAuthProfile {
                 assertEquals("authprofile", a.getCategory());
                 String actualSummary = a.getSummary();
                 if (actualSummary.equals(
-                    "authentication event observed riker to emit-bastion, "
-                        + "known source 216.160.83.56 [Milton/US]")) {
+                    "authentication event observed riker [wriker@mozilla.com] to emit-bastion, "
+                        + "216.160.83.56 [Milton/US]")) {
                   infoCnt++;
                   assertEquals(Alert.AlertSeverity.INFORMATIONAL, a.getSeverity());
                   assertNull(a.getTemplateName());
                   assertNull(a.getMetadataValue("notify_email_direct"));
                 } else if (actualSummary.equals(
-                    "authentication event observed riker to emit-bastion, "
+                    "authentication event observed riker [wriker@mozilla.com] to emit-bastion, "
                         + "new source 216.160.83.56 [Milton/US]")) {
                   newCnt++;
                   assertEquals(Alert.AlertSeverity.WARNING, a.getSeverity());
@@ -170,9 +172,11 @@ public class TestAuthProfile {
                   assertNull(iKey);
                   assertNull(a.getMetadataValue("notify_email_direct"));
 
-                  assertEquals(Alert.AlertSeverity.WARNING, a.getSeverity());
+                  // Severity should be informational since it is an untracked identity
+                  assertEquals(Alert.AlertSeverity.INFORMATIONAL, a.getSeverity());
                   assertEquals("127.0.0.1", a.getMetadataValue("sourceaddress"));
                   assertEquals("laforge@mozilla.com", a.getMetadataValue("username"));
+                  assertThat(a.getSummary(), containsString("untracked"));
                 } else if ((iKey != null) && (iKey.equals("wriker@mozilla.com"))) {
                   if (a.getMetadataValue("username").equals("riker@mozilla.com")) {
                     // GcpAudit event should have generated a warning
@@ -183,10 +187,10 @@ public class TestAuthProfile {
                   }
                 }
               }
-              assertEquals(3L, newCnt);
-              // Should have one informational since the rest of the duplicates will be
+              assertEquals(2L, newCnt);
+              // Should have two informational since the rest of the duplicates will be
               // filtered in window since they were already seen
-              assertEquals(1L, infoCnt);
+              assertEquals(2L, infoCnt);
               return null;
             });
 

--- a/src/test/java/com/mozilla/secops/authprofile/TestAuthProfile.java
+++ b/src/test/java/com/mozilla/secops/authprofile/TestAuthProfile.java
@@ -231,4 +231,39 @@ public class TestAuthProfile {
             });
     p.run().waitUntilFinish();
   }
+
+  @Test
+  public void analyzeMixedIgnoreUnknownIdTest() throws Exception {
+    testEnv();
+    AuthProfile.AuthProfileOptions options = getTestOptions();
+    options.setIgnoreUnknownIdentities(true);
+    PCollection<String> input = TestUtil.getTestInput("/testdata/authprof_buffer2.txt", p);
+
+    PCollection<Alert> res =
+        input
+            .apply(new AuthProfile.ParseAndWindow(options))
+            .apply(ParDo.of(new AuthProfile.Analyze(options)));
+
+    PAssert.that(res)
+        .satisfies(
+            results -> {
+              long newCnt = 0;
+              long infoCnt = 0;
+              for (Alert a : results) {
+                assertEquals("authprofile", a.getCategory());
+                String actualSummary = a.getSummary();
+                if (actualSummary.contains("new source")) {
+                  newCnt++;
+                } else {
+                  infoCnt++;
+                }
+              }
+              assertEquals(2L, newCnt);
+              // Should have one informational since the rest of the duplicates will be
+              // filtered in window since they were already seen
+              assertEquals(1L, infoCnt);
+              return null;
+            });
+    p.run().waitUntilFinish();
+  }
 }


### PR DESCRIPTION
* Break up the authprofile logic so it's a bit nicer to work with
* Add an option to ignore identities that are not mapped in the identity manager
* Don't store state for identities that are not mapped