### PR TITLE
explicitly specify geoip db load path in parser

### DIFF
--- a/src/main/java/com/mozilla/secops/customs/Customs.java
+++ b/src/main/java/com/mozilla/secops/customs/Customs.java
@@ -124,9 +124,12 @@ public class Customs implements Serializable {
 
     CustomsCfg cfg = CustomsCfg.loadFromResource(options.getConfigurationResourcePath());
 
+    ParserDoFn fn = new ParserDoFn();
+    if (options.getMaxmindDbPath() != null) {
+      fn = fn.withGeoIP(options.getMaxmindDbPath());
+    }
     PCollection<Event> input =
-        p.apply("input", options.getInputType().read(p, options))
-            .apply("parse", ParDo.of(new ParserDoFn()));
+        p.apply("input", options.getInputType().read(p, options)).apply("parse", ParDo.of(fn));
 
     PCollection<Alert> alerts = input.apply(new Detectors(cfg, options));
 

--- a/src/main/java/com/mozilla/secops/parser/GeoIP.java
+++ b/src/main/java/com/mozilla/secops/parser/GeoIP.java
@@ -8,28 +8,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetAddress;
 
-/**
- * GeoIP resolution
- *
- * <p>Upon initialization, if the constructor is called with no arguments the object will attempt to
- * load database files from specific resource paths in the following order.
- *
- * <p>
- *
- * <ul>
- *   <li>/GeoLite2-City.mmdb
- *   <li>/testdata/GeoIP2-City-Test.mmdb
- * </ul>
- *
- * <p>If the test database is used, the usingTest function will return true.
- */
+/** GeoIP resolution */
 public class GeoIP {
-  private final String GEOIP_TESTDBPATH = "/testdata/GeoIP2-City-Test.mmdb";
-  private final String GEOIP_DBPATH = "/GeoLite2-City.mmdb";
-
   private DatabaseReader geoipDb;
   private Boolean initialized = false;
-  private Boolean initializingWithTest = false;
 
   /**
    * Lookup city/country from IP address string
@@ -53,15 +35,6 @@ public class GeoIP {
   }
 
   /**
-   * Indicate if {@link GeoIP} initialized with testing database
-   *
-   * @return True if testing database is configured
-   */
-  public Boolean usingTest() {
-    return initializingWithTest;
-  }
-
-  /**
    * Initialize new {@link GeoIP}, load database from specified path
    *
    * @param path Resource or GCS path to load database from
@@ -69,19 +42,10 @@ public class GeoIP {
   public GeoIP(String path) {
     InputStream in;
 
-    // If the specified path was null, try to load the database from the default path locations
-    if (path == null) {
-      in = GeoIP.class.getResourceAsStream(GEOIP_DBPATH);
-      if (in == null) {
-        initializingWithTest = true;
-        in = GeoIP.class.getResourceAsStream(GEOIP_TESTDBPATH);
-      }
+    if (GcsUtil.isGcsUrl(path)) {
+      in = GcsUtil.fetchInputStreamContent(path);
     } else {
-      if (GcsUtil.isGcsUrl(path)) {
-        in = GcsUtil.fetchInputStreamContent(path);
-      } else {
-        in = GeoIP.class.getResourceAsStream(path);
-      }
+      in = GeoIP.class.getResourceAsStream(path);
     }
     if (in == null) {
       return;
@@ -93,10 +57,5 @@ public class GeoIP {
     } catch (IOException exc) {
       // pass
     }
-  }
-
-  /** Initialize new {@link GeoIP}, load database from default paths */
-  public GeoIP() {
-    this(null);
   }
 }

--- a/src/main/java/com/mozilla/secops/parser/Parser.java
+++ b/src/main/java/com/mozilla/secops/parser/Parser.java
@@ -7,13 +7,11 @@ import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.logging.v2.model.LogEntry;
 import com.google.api.services.logging.v2.model.MonitoredResource;
 import com.maxmind.geoip2.model.CityResponse;
-import com.mozilla.secops.InputOptions;
 import com.mozilla.secops.identity.IdentityManager;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.commons.validator.routines.InetAddressValidator;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormatter;
@@ -25,10 +23,6 @@ import org.slf4j.LoggerFactory;
  * Event parser
  *
  * <p>{@link Parser} can be used to parse incoming events and generate {@link Event} objects.
- *
- * <p>On initialization the parser will also attempt to initialize the GeoIP parser that some
- * individual event parsers can utilize. See documentation for {@link GeoIP} on dependencies for
- * GeoIP lookup support.
  */
 public class Parser {
   private static final long serialVersionUID = 1L;
@@ -36,7 +30,7 @@ public class Parser {
   private final List<PayloadBase> payloads;
   private final JacksonFactory jf;
   private final Logger log;
-  private final GeoIP geoip;
+  private GeoIP geoip;
 
   private IdentityManager idmanager;
 
@@ -174,20 +168,25 @@ public class Parser {
   /**
    * Resolve GeoIP information from IP address string
    *
+   * <p>GeoIP resolution must be enabled in the parser, or this function will always return null.
+   *
    * @param ip IP address string
    * @return MaxmindDB {@link CityResponse}, or null if lookup fails
    */
   public CityResponse geoIp(String ip) {
+    if (geoip == null) {
+      return null;
+    }
     return geoip.lookup(ip);
   }
 
   /**
-   * Determine if GeoIP test database is being used
+   * Enable GeoIP resolution in the parser
    *
-   * @return True if test database is loaded by GeoIP submodule
+   * @param dbpath Path to Maxmind database, resource path or GCS URL
    */
-  public Boolean geoIpUsingTest() {
-    return geoip.usingTest();
+  public void enableGeoIp(String dbpath) {
+    geoip = new GeoIP(dbpath);
   }
 
   /**
@@ -247,19 +246,9 @@ public class Parser {
     return e;
   }
 
-  /** Create new parser instance using default values from {@link InputOptions} */
+  /** Create new parser instance */
   public Parser() {
-    this(PipelineOptionsFactory.as(InputOptions.class));
-  }
-
-  /**
-   * Create new parser based on any applicable configuration in {@link InputOptions}
-   *
-   * @param options InputOptions
-   */
-  public Parser(InputOptions options) {
     log = LoggerFactory.getLogger(Parser.class);
-    geoip = new GeoIP(options.getMaxmindDbPath());
     jf = new JacksonFactory();
     payloads = new ArrayList<PayloadBase>();
     payloads.add(new GLB());

--- a/src/main/java/com/mozilla/secops/parser/ParserDoFn.java
+++ b/src/main/java/com/mozilla/secops/parser/ParserDoFn.java
@@ -13,21 +13,39 @@ public class ParserDoFn extends DoFn<String, Event> {
   private Long parseCount;
 
   private EventFilter inlineFilter;
+  private String geoIpDbPath;
 
   /**
    * Install an inline {@link EventFilter} in this transform
    *
    * <p>If an inline filter is present in the transform, the transform will only emit events that
    * match the filter.
+   *
+   * @param inlineFilter Event filter to install
+   * @return ParserDoFn
    */
   public ParserDoFn withInlineEventFilter(EventFilter inlineFilter) {
     this.inlineFilter = inlineFilter;
     return this;
   }
 
+  /**
+   * Enable GeoIP resolution in this parser function
+   *
+   * @param geoIpDbPath Path to Maxmind DB
+   * @return ParserDoFn
+   */
+  public ParserDoFn withGeoIP(String geoIpDbPath) {
+    this.geoIpDbPath = geoIpDbPath;
+    return this;
+  }
+
   @Setup
   public void setup() {
     ep = new Parser();
+    if (geoIpDbPath != null) {
+      ep.enableGeoIp(geoIpDbPath);
+    }
     log = LoggerFactory.getLogger(ParserDoFn.class);
     log.info("initialized new parser");
   }

--- a/src/test/java/com/mozilla/secops/authprofile/TestAuthProfile.java
+++ b/src/test/java/com/mozilla/secops/authprofile/TestAuthProfile.java
@@ -11,6 +11,7 @@ import com.mozilla.secops.TestUtil;
 import com.mozilla.secops.alert.Alert;
 import com.mozilla.secops.parser.Event;
 import com.mozilla.secops.parser.Normalized;
+import com.mozilla.secops.parser.ParserTest;
 import com.mozilla.secops.state.DatastoreStateInterface;
 import com.mozilla.secops.state.State;
 import java.util.Collection;
@@ -50,6 +51,7 @@ public class TestAuthProfile {
     ret.setDatastoreNamespace("testauthprofileanalyze");
     ret.setDatastoreKind("authprofile");
     ret.setIdentityManagerPath("/testdata/identitymanager.json");
+    ret.setMaxmindDbPath(ParserTest.TEST_GEOIP_DBPATH);
     return ret;
   }
 

--- a/src/test/java/com/mozilla/secops/customs/TestCustoms.java
+++ b/src/test/java/com/mozilla/secops/customs/TestCustoms.java
@@ -8,6 +8,7 @@ import com.mozilla.secops.TestUtil;
 import com.mozilla.secops.alert.Alert;
 import com.mozilla.secops.parser.Event;
 import com.mozilla.secops.parser.ParserDoFn;
+import com.mozilla.secops.parser.ParserTest;
 import java.util.ArrayList;
 import java.util.Collection;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
@@ -28,6 +29,7 @@ public class TestCustoms {
   private Customs.CustomsOptions getTestOptions() {
     Customs.CustomsOptions ret = PipelineOptionsFactory.as(Customs.CustomsOptions.class);
     ret.setMonitoredResourceIndicator("test");
+    ret.setMaxmindDbPath(ParserTest.TEST_GEOIP_DBPATH);
     return ret;
   }
 
@@ -62,7 +64,9 @@ public class TestCustoms {
     cfg.setTimestampOverride(true);
 
     PCollection<Alert> alerts =
-        input.apply(ParDo.of(new ParserDoFn())).apply(new Customs.Detectors(cfg, getTestOptions()));
+        input
+            .apply(ParDo.of(new ParserDoFn().withGeoIP(ParserTest.TEST_GEOIP_DBPATH)))
+            .apply(new Customs.Detectors(cfg, getTestOptions()));
 
     ArrayList<IntervalWindow> windows = new ArrayList<IntervalWindow>();
     windows.add(new IntervalWindow(new Instant(3600000L), new Instant(4500000L)));
@@ -155,7 +159,9 @@ public class TestCustoms {
     cfg.setTimestampOverride(true);
 
     PCollection<Alert> alerts =
-        input.apply(ParDo.of(new ParserDoFn())).apply(new Customs.Detectors(cfg, getTestOptions()));
+        input
+            .apply(ParDo.of(new ParserDoFn().withGeoIP(ParserTest.TEST_GEOIP_DBPATH)))
+            .apply(new Customs.Detectors(cfg, getTestOptions()));
 
     ArrayList<IntervalWindow> windows = new ArrayList<IntervalWindow>();
     windows.add(new IntervalWindow(new Instant(1800000L), new Instant(2700000L)));
@@ -208,7 +214,9 @@ public class TestCustoms {
     cfg.setTimestampOverride(true);
 
     PCollection<Alert> alerts =
-        input.apply(ParDo.of(new ParserDoFn())).apply(new Customs.Detectors(cfg, getTestOptions()));
+        input
+            .apply(ParDo.of(new ParserDoFn().withGeoIP(ParserTest.TEST_GEOIP_DBPATH)))
+            .apply(new Customs.Detectors(cfg, getTestOptions()));
 
     PCollection<Long> count =
         alerts.apply(Combine.globally(Count.<Alert>combineFn()).withoutDefaults());

--- a/src/test/java/com/mozilla/secops/parser/ParserTest.java
+++ b/src/test/java/com/mozilla/secops/parser/ParserTest.java
@@ -10,6 +10,8 @@ import org.joda.time.DateTime;
 import org.junit.Test;
 
 public class ParserTest {
+  public static final String TEST_GEOIP_DBPATH = "/testdata/GeoIP2-City-Test.mmdb";
+
   public ParserTest() {}
 
   @Test
@@ -183,8 +185,8 @@ public class ParserTest {
             + "216.160.83.56 port 58530 ssh2: RSA SHA256:dd/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\",\"timestamp"
             + "\":\"2018-09-18T22:15:38Z\"}";
     Parser p = new Parser();
+    p.enableGeoIp(TEST_GEOIP_DBPATH);
     assertNotNull(p);
-    assertTrue(p.geoIpUsingTest());
     Event e = p.parse(buf);
     assertNotNull(e);
     assertEquals(Payload.PayloadType.OPENSSH, e.getPayloadType());
@@ -326,6 +328,7 @@ public class ParserTest {
             + "\"project_id\":\"prod\",\"region\":\"aws:us-west-2a\"},\"type\":\"aws_ec2_instance\"},\""
             + "timestamp\":\"2019-01-31T17:45:27.478007784Z\"}";
     Parser p = new Parser();
+    p.enableGeoIp(TEST_GEOIP_DBPATH);
     assertNotNull(p);
     Event e = p.parse(buf);
     assertNotNull(e);
@@ -361,6 +364,7 @@ public class ParserTest {
             + "i-0\",\"project_id\":\"prod\",\"region\":\"aws:us-west-2a\"},\"type\":\"aws"
             + "_ec2_instance\"},\"timestamp\":\"2019-01-31T17:48:26.593764735Z\"}";
     Parser p = new Parser();
+    p.enableGeoIp(TEST_GEOIP_DBPATH);
     assertNotNull(p);
     Event e = p.parse(buf);
     assertNotNull(e);
@@ -662,6 +666,7 @@ public class ParserTest {
             + "CE\",\"logName\":\"projects/test/logs/cloudaudit.googleapis.com%2Factivity\",\"rece"
             + "iveTimestamp\":\"2019-01-03T20:52:05.807173206Z\"}";
     Parser p = new Parser();
+    p.enableGeoIp(TEST_GEOIP_DBPATH);
     assertNotNull(p);
     Event e = p.parse(buf);
     assertNotNull(e);
@@ -787,8 +792,8 @@ public class ParserTest {
   @Test
   public void testGeoIp() throws Exception {
     Parser p = new Parser();
+    p.enableGeoIp(TEST_GEOIP_DBPATH);
     assertNotNull(p);
-    assertTrue(p.geoIpUsingTest());
     CityResponse resp = p.geoIp("216.160.83.56");
     assertNotNull(resp);
     assertEquals("US", resp.getCountry().getIsoCode());


### PR DESCRIPTION
Reverts a bunch of the changes made in 231146e, and modifies
initialization so a GeoIP database path must be explicitly specified.
This prevents undesirable behavior where the test resource will be
loaded if the default resource is not found.

Pipelines must now explicitly enable GeoIP resolution in the parser or
in ParserDoFn by setting the correct input option.