### PR TITLE
Use sentence style in authprofile alert summary

### DIFF
--- a/src/main/java/com/mozilla/secops/alert/AlertSlack.java
+++ b/src/main/java/com/mozilla/secops/alert/AlertSlack.java
@@ -97,8 +97,8 @@ public class AlertSlack {
 
     String text =
         String.format(
-            "Foxsec Fraud Detection Alert\n\n%s\n%s\nAlert Id: %s",
-            a.getSummary(), a.assemblePayload(), a.getAlertId());
+            "Foxsec Fraud Detection Alert\n\n%s\n\nIf this was not you, or you have any questions about this alert, email us at secops@mozilla.com with the alert id: %s\n",
+            a.getSummary(), a.getAlertId());
     try {
       return slackManager.handleSlackResponse(slackManager.sendMessageToChannel(userId, text));
     } catch (IOException exc) {
@@ -136,8 +136,7 @@ public class AlertSlack {
 
     String text =
         String.format(
-            "Foxsec Fraud Detection Alert\n\n%s\n%s\nAlert Id: %s",
-            a.getSummary(), a.assemblePayload(), a.getAlertId());
+            "Foxsec Fraud Detection Alert\n\n%s\n\nAlert Id: %s\n", a.getSummary(), a.getAlertId());
     try {
       return slackManager.handleSlackResponse(
           slackManager.sendConfirmationRequestToUser(userId, a.getAlertId().toString(), text));

--- a/src/test/java/com/mozilla/secops/authprofile/TestAuthProfile.java
+++ b/src/test/java/com/mozilla/secops/authprofile/TestAuthProfile.java
@@ -111,15 +111,15 @@ public class TestAuthProfile {
                 assertEquals("authprofile", a.getCategory());
                 String actualSummary = a.getSummary();
                 if (actualSummary.equals(
-                    "authentication event observed riker [wriker@mozilla.com] to emit-bastion, "
-                        + "216.160.83.56 [Milton/US]")) {
+                    "An authentication event for user riker was detected to access emit-bastion "
+                        + "from 216.160.83.56 [Milton/US]. This occurred from a known source address.")) {
                   infoCnt++;
                   assertEquals(Alert.AlertSeverity.INFORMATIONAL, a.getSeverity());
                   assertNull(a.getTemplateName());
                   assertNull(a.getMetadataValue("notify_email_direct"));
                 } else if (actualSummary.equals(
-                    "authentication event observed riker [wriker@mozilla.com] to emit-bastion, "
-                        + "new source 216.160.83.56 [Milton/US]")) {
+                    "An authentication event for user riker was detected to access emit-bastion "
+                        + "from 216.160.83.56 [Milton/US]. This occurred from a source address unknown to the system.")) {
                   newCnt++;
                   assertEquals(Alert.AlertSeverity.WARNING, a.getSeverity());
                   assertEquals("authprofile.ftlh", a.getTemplateName());
@@ -162,7 +162,7 @@ public class TestAuthProfile {
               for (Alert a : results) {
                 assertEquals("authprofile", a.getCategory());
                 String actualSummary = a.getSummary();
-                if (actualSummary.contains("new source")) {
+                if (actualSummary.contains("source address unknown")) {
                   newCnt++;
                 } else {
                   infoCnt++;
@@ -219,7 +219,7 @@ public class TestAuthProfile {
               for (Alert a : results) {
                 assertEquals("authprofile", a.getCategory());
                 String actualSummary = a.getSummary();
-                if (actualSummary.contains("new source")) {
+                if (actualSummary.contains("source address unknown")) {
                   newCnt++;
                 } else {
                   infoCnt++;
@@ -254,7 +254,7 @@ public class TestAuthProfile {
               for (Alert a : results) {
                 assertEquals("authprofile", a.getCategory());
                 String actualSummary = a.getSummary();
-                if (actualSummary.contains("new source")) {
+                if (actualSummary.contains("source address unknown")) {
                   newCnt++;
                 } else {
                   infoCnt++;


### PR DESCRIPTION
Remove the difference between summary and payload construction for
alerts in authprofile and just use the full sentence style.

Alerts in Slack catchall will now look like:
>An authentication event for user ajvb was detected to access emit-bastion from 127.0.0.1 [unknown/unknown]. This occurred from a source address unknown to the system.  (64979792-cb45-4b9a-b596-48ef4813d2a7)

Alerts to users in Slack will now look like:
>Foxsec Fraud Detection Alert
>
>An authentication event for user ajvb was detected to access emit-bastion from 127.0.0.1 [unknown/unknown]. This occurred from a source address unknown to the system.
>
>If this was not you, or you have any questions about this alert, email us at secops@mozilla.com with the alert id: 648086bd-4564-4fca-9e50-b56f4f9a288c