### PR TITLE
Expand payload in authprofile for alert

### DIFF
--- a/src/main/java/com/mozilla/secops/alert/AlertSlack.java
+++ b/src/main/java/com/mozilla/secops/alert/AlertSlack.java
@@ -97,8 +97,7 @@ public class AlertSlack {
 
     String text =
         String.format(
-            "Foxsec Fraud Detection Alert\n\n%s\n%s\nAlert Id: %s",
-            a.getSummary(), a.assemblePayload(), a.getAlertId());
+            "Foxsec Fraud Detection Alert\n\n%s\n\nalert id: %s", a.getPayload(), a.getAlertId());
     try {
       return slackManager.handleSlackResponse(slackManager.sendMessageToChannel(userId, text));
     } catch (IOException exc) {
@@ -136,8 +135,7 @@ public class AlertSlack {
 
     String text =
         String.format(
-            "Foxsec Fraud Detection Alert\n\n%s\n%s\nAlert Id: %s",
-            a.getSummary(), a.assemblePayload(), a.getAlertId());
+            "Foxsec Fraud Detection Alert\n\n%s\n\nalert id: %s", a.getPayload(), a.getAlertId());
     try {
       return slackManager.handleSlackResponse(
           slackManager.sendConfirmationRequestToUser(userId, a.getAlertId().toString(), text));

--- a/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
+++ b/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
@@ -302,8 +302,12 @@ public class AuthProfile implements Serializable {
     private void buildAlertPayload(Alert a) {
       String payload =
           String.format(
-              "An authentication event for user %s was detected to access %s.",
-              a.getMetadataValue("username"), a.getMetadataValue("object"));
+              "An authentication event for user %s was detected to access %s from %s [%s/%s].",
+              a.getMetadataValue("username"),
+              a.getMetadataValue("object"),
+              a.getMetadataValue("sourceaddress"),
+              a.getMetadataValue("sourceaddress_city"),
+              a.getMetadataValue("sourceaddress_country"));
       if (a.getMetadataValue("identity_key") != null) {
         if (a.getSeverity().equals(Alert.AlertSeverity.WARNING)) {
           payload = payload + " This occurred from a source address unknown to the system.";
@@ -311,8 +315,12 @@ public class AuthProfile implements Serializable {
           payload = payload + " This occurred from a known source address.";
         }
       } else {
-        payload = payload = " This event occurred for an untracked identity.";
+        payload = payload + " This event occurred for an untracked identity.";
       }
+      payload =
+          payload
+              + "\n\nIf this was not you, or you have any questions about "
+              + "this alert, email us at secops@mozilla.com with the alert id.";
       a.addToPayload(payload);
     }
 


### PR DESCRIPTION
Follow up from https://github.com/mozilla-services/foxsec-pipeline/pull/84

Looks like:
>Foxsec Fraud Detection Alert
>
>An authentication event for user ajvb was detected to access emit-bastion from 127.0.0.1 [unknown/unknown]. This occurred from a source address unknown to the system.
>
>If this was not you, or you have any questions about this alert, email us at secops@mozilla.com with the alert id.
>
>alert id: 51b62650-6be8-4f33-bc0b-26b4ad78852c