### PR TITLE
Set IdentityManager for Parser within ParserDoFn

### DIFF
--- a/src/main/java/com/mozilla/secops/InputOptions.java
+++ b/src/main/java/com/mozilla/secops/InputOptions.java
@@ -32,4 +32,9 @@ public interface InputOptions extends PipelineOptions, PubsubOptions, GcpOptions
   String getXffAddressSelector();
 
   void setXffAddressSelector(String value);
+
+  @Description("Override default identity manager configuration; resource path")
+  String getIdentityManagerPath();
+
+  void setIdentityManagerPath(String value);
 }

--- a/src/main/java/com/mozilla/secops/InputOptions.java
+++ b/src/main/java/com/mozilla/secops/InputOptions.java
@@ -33,7 +33,7 @@ public interface InputOptions extends PipelineOptions, PubsubOptions, GcpOptions
 
   void setXffAddressSelector(String value);
 
-  @Description("Override default identity manager configuration; resource path")
+  @Description("Specify identity manager configuration location; resource path, gcs path")
   String getIdentityManagerPath();
 
   void setIdentityManagerPath(String value);

--- a/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
+++ b/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
@@ -100,11 +100,7 @@ public class AuthProfile implements Serializable {
 
                     @Setup
                     public void setup() throws IOException {
-                      if (idmanagerPath == null) {
-                        idmanager = IdentityManager.load();
-                      } else {
-                        idmanager = IdentityManager.load(idmanagerPath);
-                      }
+                      idmanager = IdentityManager.load(idmanagerPath);
 
                       if (ignoreUserRegex != null) {
                         ignoreUsers = new Pattern[ignoreUserRegex.length];
@@ -198,11 +194,7 @@ public class AuthProfile implements Serializable {
     public void setup() throws StateException, IOException {
       log = LoggerFactory.getLogger(Analyze.class);
 
-      if (idmanagerPath == null) {
-        idmanager = IdentityManager.load();
-      } else {
-        idmanager = IdentityManager.load(idmanagerPath);
-      }
+      idmanager = IdentityManager.load(idmanagerPath);
 
       if (memcachedHost != null && memcachedPort != null) {
         log.info("using memcached for state management");

--- a/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
+++ b/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
@@ -89,7 +89,11 @@ public class AuthProfile implements Serializable {
       filter.addRule(new EventFilterRule().wantNormalizedType(Normalized.Type.AUTH_SESSION));
 
       return col.apply(
-              ParDo.of(new ParserDoFn().withConfiguration(cfg).withInlineEventFilter(filter)))
+              ParDo.of(
+                  new ParserDoFn()
+                      .withConfiguration(cfg)
+                      .withInlineEventFilter(filter)
+                      .withIdentityManagerFromPath(idmanagerPath)))
           .apply(
               ParDo.of(
                   new DoFn<Event, KV<String, Event>>() {

--- a/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
+++ b/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
@@ -89,11 +89,7 @@ public class AuthProfile implements Serializable {
       filter.addRule(new EventFilterRule().wantNormalizedType(Normalized.Type.AUTH_SESSION));
 
       return col.apply(
-              ParDo.of(
-                  new ParserDoFn()
-                      .withConfiguration(cfg)
-                      .withInlineEventFilter(filter)
-                      .withIdentityManagerFromPath(idmanagerPath)))
+              ParDo.of(new ParserDoFn().withConfiguration(cfg).withInlineEventFilter(filter)))
           .apply(
               ParDo.of(
                   new DoFn<Event, KV<String, Event>>() {
@@ -419,11 +415,6 @@ public class AuthProfile implements Serializable {
     String getDatastoreKind();
 
     void setDatastoreKind(String value);
-
-    @Description("Override default identity manager configuration; resource path")
-    String getIdentityManagerPath();
-
-    void setIdentityManagerPath(String value);
 
     @Description("Ignore events for any usernames match regex (multiple allowed)")
     String[] getIgnoreUserRegex();

--- a/src/main/java/com/mozilla/secops/identity/IdentityManager.java
+++ b/src/main/java/com/mozilla/secops/identity/IdentityManager.java
@@ -20,9 +20,6 @@ public class IdentityManager {
   private Map<String, String> awsAccountMap;
   private Notify defaultNotification;
 
-  /** Default identity manager resource path */
-  public static final String DEFAULT_RESOURCE_PATH = "/identitymanager.json";
-
   /**
    * Load identity manager configuration from a resource file
    *
@@ -31,6 +28,9 @@ public class IdentityManager {
    */
   public static IdentityManager load(String path) throws IOException {
     InputStream in;
+    if (path == null) {
+      throw new IOException("attempt to load identity manager with null path");
+    }
     if (GcsUtil.isGcsUrl(path)) {
       in = GcsUtil.fetchInputStreamContent(path);
     } else {
@@ -41,15 +41,6 @@ public class IdentityManager {
     }
     ObjectMapper mapper = new ObjectMapper();
     return mapper.readValue(in, IdentityManager.class);
-  }
-
-  /**
-   * Load identity manager configuration from default resource location
-   *
-   * @return {@link IdentityManager}
-   */
-  public static IdentityManager load() throws IOException {
-    return load(DEFAULT_RESOURCE_PATH);
   }
 
   /**

--- a/src/main/java/com/mozilla/secops/parser/Parser.java
+++ b/src/main/java/com/mozilla/secops/parser/Parser.java
@@ -312,7 +312,7 @@ public class Parser {
         IdentityManager mgr = IdentityManager.load(cfg.getIdentityManagerPath());
         setIdentityManager(mgr);
       } catch (IOException exc) {
-        log.warn("could not load identity manager within ParserDoFn: {}", exc.getMessage());
+        log.error("could not load identity manager within Parser: {}", exc.getMessage());
       }
     }
   }

--- a/src/main/java/com/mozilla/secops/parser/Parser.java
+++ b/src/main/java/com/mozilla/secops/parser/Parser.java
@@ -306,6 +306,15 @@ public class Parser {
     payloads.add(new OpenSSH());
     payloads.add(new Duopull());
     payloads.add(new Raw());
+
+    if (cfg.getIdentityManagerPath() != null) {
+      try {
+        IdentityManager mgr = IdentityManager.load(cfg.getIdentityManagerPath());
+        setIdentityManager(mgr);
+      } catch (IOException exc) {
+        log.warn("could not load identity manager within ParserDoFn: {}", exc.getMessage());
+      }
+    }
   }
 
   /** Create new parser instance with default configuration */

--- a/src/main/java/com/mozilla/secops/parser/ParserCfg.java
+++ b/src/main/java/com/mozilla/secops/parser/ParserCfg.java
@@ -12,6 +12,7 @@ public class ParserCfg implements Serializable {
 
   private String maxmindDbPath;
   private ArrayList<String> xffAddressSelectorSubnets;
+  private String idmanagerPath;
 
   /**
    * Create a parser configuration from pipeline {@link InputOptions}
@@ -22,6 +23,7 @@ public class ParserCfg implements Serializable {
   public static ParserCfg fromInputOptions(InputOptions options) {
     ParserCfg cfg = new ParserCfg();
     cfg.setMaxmindDbPath(options.getMaxmindDbPath());
+    cfg.setIdentityManagerPath(options.getIdentityManagerPath());
     if (options.getXffAddressSelector() != null) {
       String parts[] = options.getXffAddressSelector().split(",");
       if (parts.length > 0) {
@@ -92,6 +94,24 @@ public class ParserCfg implements Serializable {
    */
   public void setMaxmindDbPath(String path) {
     maxmindDbPath = path;
+  }
+
+  /**
+   * Get IdentityManager json file path
+   *
+   * @return String of null if not specified
+   */
+  public String getIdentityManagerPath() {
+    return idmanagerPath;
+  }
+
+  /**
+   * Set IdentityManager json file path
+   *
+   * @param path Path
+   */
+  public void setIdentityManagerPath(String path) {
+    idmanagerPath = path;
   }
 
   /** Construct default parser configuration */

--- a/src/main/java/com/mozilla/secops/parser/ParserDoFn.java
+++ b/src/main/java/com/mozilla/secops/parser/ParserDoFn.java
@@ -57,8 +57,8 @@ public class ParserDoFn extends DoFn<String, Event> {
     }
     log = LoggerFactory.getLogger(ParserDoFn.class);
 
-    IdentityManager mgr = null;
     try {
+      IdentityManager mgr;
       if (idmanagerPath == null) {
         mgr = IdentityManager.load();
       } else {

--- a/src/main/java/com/mozilla/secops/parser/ParserDoFn.java
+++ b/src/main/java/com/mozilla/secops/parser/ParserDoFn.java
@@ -1,7 +1,5 @@
 package com.mozilla.secops.parser;
 
-import com.mozilla.secops.identity.IdentityManager;
-import java.io.IOException;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,7 +14,6 @@ public class ParserDoFn extends DoFn<String, Event> {
 
   private EventFilter inlineFilter;
   private ParserCfg cfg;
-  private String idmanagerPath;
 
   /**
    * Install an inline {@link EventFilter} in this transform
@@ -43,11 +40,6 @@ public class ParserDoFn extends DoFn<String, Event> {
     return this;
   }
 
-  public ParserDoFn withIdentityManagerFromPath(String idmanagerPath) {
-    this.idmanagerPath = idmanagerPath;
-    return this;
-  }
-
   @Setup
   public void setup() {
     if (cfg == null) {
@@ -56,18 +48,6 @@ public class ParserDoFn extends DoFn<String, Event> {
       ep = new Parser(cfg);
     }
     log = LoggerFactory.getLogger(ParserDoFn.class);
-
-    try {
-      IdentityManager mgr;
-      if (idmanagerPath == null) {
-        mgr = IdentityManager.load();
-      } else {
-        mgr = IdentityManager.load(idmanagerPath);
-      }
-      ep.setIdentityManager(mgr);
-    } catch (IOException exc) {
-      log.warn("could not load identity manager within ParserDoFn: {}", exc.getMessage());
-    }
   }
 
   @StartBundle


### PR DESCRIPTION
Currently, the mapping from account id -> account name for `Normalized.object` (https://github.com/mozilla-services/foxsec-pipeline/blob/master/src/main/java/com/mozilla/secops/parser/Cloudtrail.java#L75-L86) is not getting set within AuthProfile.

This adds setting the IdentityManager within ParserDoFn with support for passing in the path.