### PR TITLE
Improve performance of httprequest

### DIFF
--- a/src/main/java/com/mozilla/secops/DetectNat.java
+++ b/src/main/java/com/mozilla/secops/DetectNat.java
@@ -42,6 +42,7 @@ public class DetectNat extends PTransform<PCollection<Event>, PCollection<KV<Str
    */
   public static PCollectionView<Map<String, Boolean>> getEmptyView(Pipeline p) {
     return p.apply(
+            "empty nat view",
             Create.empty(
                 TypeDescriptors.kvs(TypeDescriptors.strings(), TypeDescriptors.booleans())))
         .apply(View.<String, Boolean>asMap());
@@ -54,7 +55,7 @@ public class DetectNat extends PTransform<PCollection<Event>, PCollection<KV<Str
    * @return {@link PCollectionView} representing output of analysis
    */
   public static PCollectionView<Map<String, Boolean>> getView(PCollection<Event> events) {
-    return events.apply(new DetectNat()).apply(View.<String, Boolean>asMap());
+    return events.apply("nat view", new DetectNat()).apply(View.<String, Boolean>asMap());
   }
 
   @Override
@@ -62,7 +63,7 @@ public class DetectNat extends PTransform<PCollection<Event>, PCollection<KV<Str
     PCollection<KV<String, Long>> perSourceUACounts =
         events
             .apply(
-                "extract user agents",
+                "detectnat extract user agents",
                 ParDo.of(
                     new DoFn<Event, KV<String, String>>() {
                       private static final long serialVersionUID = 1L;
@@ -86,8 +87,8 @@ public class DetectNat extends PTransform<PCollection<Event>, PCollection<KV<Str
                         }
                       }
                     }))
-            .apply(Distinct.<KV<String, String>>create())
-            .apply(Count.<String, String>perKey());
+            .apply("detectnat distinct ua map", Distinct.<KV<String, String>>create())
+            .apply("detectnat ua count per key", Count.<String, String>perKey());
 
     // Operate solely on the UA output right now here, but this should be expanded with more
     // detailed analysis

--- a/src/main/java/com/mozilla/secops/Stats.java
+++ b/src/main/java/com/mozilla/secops/Stats.java
@@ -188,14 +188,16 @@ public class Stats extends PTransform<PCollection<Long>, PCollection<Stats.Stats
    */
   public static PCollectionView<StatsOutput> getView(PCollection<Long> input) {
     return input
-        .apply(new Stats())
-        .apply(View.<StatsOutput>asSingleton().withDefaultValue(new StatsOutput()));
+        .apply("stats transform", new Stats())
+        .apply("stats view", View.<StatsOutput>asSingleton().withDefaultValue(new StatsOutput()));
   }
 
   @Override
   public PCollection<StatsOutput> expand(PCollection<Long> input) {
-    PCollectionView<Double> meanValue = input.apply(Mean.<Long>globally().asSingletonView());
+    PCollectionView<Double> meanValue =
+        input.apply("stats mean calculation", Mean.<Long>globally().asSingletonView());
     return input.apply(
+        "stats",
         Combine.globally(new StatsCombiner(meanValue)).withoutDefaults().withSideInputs(meanValue));
   }
 }

--- a/src/main/java/com/mozilla/secops/Stats.java
+++ b/src/main/java/com/mozilla/secops/Stats.java
@@ -187,7 +187,9 @@ public class Stats extends PTransform<PCollection<Long>, PCollection<Stats.Stats
    * @return {@link PCollectionView} representing results of analysis
    */
   public static PCollectionView<StatsOutput> getView(PCollection<Long> input) {
-    return input.apply(new Stats()).apply(View.<StatsOutput>asSingleton());
+    return input
+        .apply(new Stats())
+        .apply(View.<StatsOutput>asSingleton().withDefaultValue(new StatsOutput()));
   }
 
   @Override

--- a/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
+++ b/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
@@ -18,6 +18,7 @@ import com.mozilla.secops.state.DatastoreStateInterface;
 import com.mozilla.secops.state.MemcachedStateInterface;
 import com.mozilla.secops.state.State;
 import com.mozilla.secops.state.StateException;
+import com.mozilla.secops.window.GlobalTriggers;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -31,13 +32,8 @@ import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.GroupByKey;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
-import org.apache.beam.sdk.transforms.windowing.AfterProcessingTime;
-import org.apache.beam.sdk.transforms.windowing.GlobalWindows;
-import org.apache.beam.sdk.transforms.windowing.Repeatedly;
-import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
-import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -156,13 +152,7 @@ public class AuthProfile implements Serializable {
                       }
                     }
                   }))
-          .apply(
-              Window.<KV<String, Event>>into(new GlobalWindows())
-                  .triggering(
-                      Repeatedly.forever(
-                          AfterProcessingTime.pastFirstElementInPane()
-                              .plusDelayOf(Duration.standardSeconds(60))))
-                  .discardingFiredPanes())
+          .apply(new GlobalTriggers<KV<String, Event>>(60))
           .apply(GroupByKey.<String, Event>create());
     }
   }

--- a/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
+++ b/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
@@ -792,17 +792,6 @@ public class HTTPRequest implements Serializable {
                   new DoFn<KV<String, Long>, Alert>() {
                     private static final long serialVersionUID = 1L;
 
-                    private Boolean warningLogged;
-                    private Boolean clampMaximumLogged;
-                    private Boolean statsLogged;
-
-                    @StartBundle
-                    public void startBundle() {
-                      warningLogged = false;
-                      clampMaximumLogged = false;
-                      statsLogged = false;
-                    }
-
                     @ProcessElement
                     public void processElement(ProcessContext c, BoundedWindow w) {
                       Stats.StatsOutput sOutput = c.sideInput(wStats);
@@ -810,45 +799,16 @@ public class HTTPRequest implements Serializable {
                       Map<String, Boolean> nv = c.sideInput(natView);
 
                       Double cMean = sOutput.getMean();
-                      if (!statsLogged) {
-                        log.info(
-                            "{}: statistics: mean/{} unique_clients/{} threshold/{}",
-                            w.toString(),
-                            cMean,
-                            uc,
-                            cMean * thresholdModifier);
-                        statsLogged = true;
-                      }
 
                       if (uc < requiredMinimumClients) {
-                        if (!warningLogged) {
-                          log.warn(
-                              "{}: ignoring events as window does not meet minimum clients",
-                              w.toString());
-                          warningLogged = true;
-                        }
                         return;
                       }
 
                       if (cMean < requiredMinimumAverage) {
-                        if (!warningLogged) {
-                          log.warn(
-                              "{}: ignoring events as window does not meet minimum average",
-                              w.toString());
-                          warningLogged = true;
-                        }
                         return;
                       }
 
                       if ((clampThresholdMaximum != null) && (cMean > clampThresholdMaximum)) {
-                        if (!clampMaximumLogged) {
-                          log.info(
-                              "{}: clamping calculated mean {} to maximum {}",
-                              w.toString(),
-                              cMean,
-                              clampThresholdMaximum);
-                          clampMaximumLogged = true;
-                        }
                         cMean = clampThresholdMaximum;
                       }
 

--- a/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
+++ b/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
@@ -1063,7 +1063,7 @@ public class HTTPRequest implements Serializable {
       }
 
       resultsList
-          .apply(Flatten.<Alert>pCollections())
+          .apply("flatten window for fixed output", Flatten.<Alert>pCollections())
           .apply("output format", ParDo.of(new AlertFormatter(options)))
           .apply("output", OutputOptions.compositeOutput(options));
     }

--- a/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
+++ b/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
@@ -788,7 +788,7 @@ public class HTTPRequest implements Serializable {
               .apply(Keys.<String>create())
               .apply(
                   "unique client count",
-                  Combine.globally(Count.<String>combineFn()).withoutDefaults().asSingletonView());
+                  Combine.globally(Count.<String>combineFn()).asSingletonView());
 
       // For each client, extract the request count
       PCollection<Long> counts = clientCounts.apply("extract counts", Values.<Long>create());

--- a/src/main/java/com/mozilla/secops/parser/GLB.java
+++ b/src/main/java/com/mozilla/secops/parser/GLB.java
@@ -73,9 +73,8 @@ public class GLB extends PayloadBase implements Serializable {
     jfmatcher = null;
     LogEntry entry = state.getLogEntryHint();
     if (entry == null) {
-      // Use method local JacksonFactory as the object is not serializable, and this event
-      // may be passed around
-      JacksonFactory jf = new JacksonFactory();
+      // Reuse JacksonFactory from parser state
+      JacksonFactory jf = state.getGoogleJacksonFactory();
       try {
         JsonParser jp = jf.createJsonParser(input);
         entry = jp.parse(LogEntry.class);

--- a/src/main/java/com/mozilla/secops/parser/GLB.java
+++ b/src/main/java/com/mozilla/secops/parser/GLB.java
@@ -31,6 +31,7 @@ public class GLB extends PayloadBase implements Serializable {
       if (entry == null) {
         JsonParser jp = jfmatcher.createJsonParser(input);
         entry = jp.parse(LogEntry.class);
+        jp.close();
       }
 
       Map<String, Object> m = entry.getJsonPayload();
@@ -75,11 +76,22 @@ public class GLB extends PayloadBase implements Serializable {
     if (entry == null) {
       // Reuse JacksonFactory from parser state
       JacksonFactory jf = state.getGoogleJacksonFactory();
+      JsonParser jp;
       try {
-        JsonParser jp = jf.createJsonParser(input);
+        jp = jf.createJsonParser(input);
+      } catch (IOException exc) {
+        return;
+      }
+      try {
         entry = jp.parse(LogEntry.class);
       } catch (IOException exc) {
         return;
+      } finally {
+        try {
+          jp.close();
+        } catch (IOException jexc) {
+          throw new RuntimeException(jexc.getMessage());
+        }
       }
     }
     HttpRequest h = entry.getHttpRequest();

--- a/src/main/java/com/mozilla/secops/parser/Mozlog.java
+++ b/src/main/java/com/mozilla/secops/parser/Mozlog.java
@@ -4,9 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.joda.JodaModule;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Map;
@@ -133,17 +131,11 @@ public class Mozlog implements Serializable {
    * Create a new {@link Mozlog} object using a JSON string as input
    *
    * @param input Mozlog JSON event
+   * @param mapper ObjectMapper to use
    * @return Mozlog event or null if deserialization failed
    */
-  public static Mozlog fromJSON(String input) {
+  public static Mozlog fromJSON(String input, ObjectMapper mapper) {
     Mozlog ret;
-
-    ObjectMapper mapper = new ObjectMapper();
-    mapper.registerModule(new JodaModule());
-    mapper.configure(
-        com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
-    // Not all Mozlog implementations use lower case field names
-    mapper.configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true);
 
     try {
       ret = mapper.readValue(input, Mozlog.class);

--- a/src/main/java/com/mozilla/secops/parser/Parser.java
+++ b/src/main/java/com/mozilla/secops/parser/Parser.java
@@ -33,6 +33,7 @@ public class Parser {
   private final List<PayloadBase> payloads;
   private final JacksonFactory jf;
   private final ObjectMapper mapper;
+  private final JacksonFactory googleJacksonFactory;
   private final Logger log;
   private final ParserCfg cfg;
   private GeoIP geoip;
@@ -261,6 +262,7 @@ public class Parser {
     }
 
     ParserState state = new ParserState(this);
+    state.setGoogleJacksonFactory(googleJacksonFactory);
 
     if (input == null) {
       input = "";
@@ -308,6 +310,8 @@ public class Parser {
     // Not all Mozlog implementations use lower case field names, and we will reuse this mapper
     // for Mozlog conversion
     mapper.configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true);
+
+    googleJacksonFactory = new JacksonFactory();
 
     this.cfg = cfg;
     if (cfg.getMaxmindDbPath() != null) {

--- a/src/main/java/com/mozilla/secops/parser/ParserState.java
+++ b/src/main/java/com/mozilla/secops/parser/ParserState.java
@@ -7,6 +7,7 @@ class ParserState {
   private final Parser parser;
   private LogEntry logEntryHint;
   private Mozlog mozLogHint;
+  private com.google.api.client.json.jackson2.JacksonFactory googleJacksonFactory;
 
   /**
    * Get LogEntry hint
@@ -42,6 +43,25 @@ class ParserState {
    */
   public void setMozlogHint(Mozlog entry) {
     mozLogHint = entry;
+  }
+
+  /**
+   * Set Google JacksonFactory
+   *
+   * @param googleJacksonFactory JacksonFactory
+   */
+  public void setGoogleJacksonFactory(
+      com.google.api.client.json.jackson2.JacksonFactory googleJacksonFactory) {
+    this.googleJacksonFactory = googleJacksonFactory;
+  }
+
+  /**
+   * Get Google JacksonFactory
+   *
+   * @return JacksonFactory, or null if unset
+   */
+  public com.google.api.client.json.jackson2.JacksonFactory getGoogleJacksonFactory() {
+    return googleJacksonFactory;
   }
 
   /**

--- a/src/main/java/com/mozilla/secops/window/GlobalTriggers.java
+++ b/src/main/java/com/mozilla/secops/window/GlobalTriggers.java
@@ -1,0 +1,40 @@
+package com.mozilla.secops.window;
+
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.windowing.AfterProcessingTime;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindows;
+import org.apache.beam.sdk.transforms.windowing.Repeatedly;
+import org.apache.beam.sdk.transforms.windowing.Window;
+import org.apache.beam.sdk.values.PCollection;
+import org.joda.time.Duration;
+
+/**
+ * Window input type into global windows, triggering at a specific interval and discarding fired
+ * panes.
+ */
+public class GlobalTriggers<T> extends PTransform<PCollection<T>, PCollection<T>> {
+  private static final long serialVersionUID = 1L;
+
+  private final int tseconds;
+
+  /**
+   * Initialize new {@link GlobalTriggers}
+   *
+   * @param tseconds Trigger every specified seconds
+   */
+  public GlobalTriggers(int tseconds) {
+    this.tseconds = tseconds;
+  }
+
+  @Override
+  public PCollection<T> expand(PCollection<T> input) {
+    return input.apply(
+        "global triggers",
+        Window.<T>into(new GlobalWindows())
+            .triggering(
+                Repeatedly.forever(
+                    AfterProcessingTime.pastFirstElementInPane()
+                        .plusDelayOf(Duration.standardSeconds(tseconds))))
+            .discardingFiredPanes());
+  }
+}

--- a/src/main/java/com/mozilla/secops/window/package-info.java
+++ b/src/main/java/com/mozilla/secops/window/package-info.java
@@ -1,0 +1,2 @@
+/** Utility window transforms */
+package com.mozilla.secops.window;

--- a/src/test/java/com/mozilla/secops/TestStats.java
+++ b/src/test/java/com/mozilla/secops/TestStats.java
@@ -28,6 +28,7 @@ public class TestStats {
               assertEquals(5.5, (double) s.getMean(), 0.1);
               assertEquals(2.25, (double) s.getPopulationVariance(), 0.1);
               assertEquals(55L, (long) s.getTotalSum());
+              assertEquals(10L, (long) s.getTotalElements());
               return null;
             });
 

--- a/src/test/java/com/mozilla/secops/TestStats.java
+++ b/src/test/java/com/mozilla/secops/TestStats.java
@@ -26,7 +26,6 @@ public class TestStats {
               Stats.StatsOutput s =
                   ((Collection<Stats.StatsOutput>) x).toArray(new Stats.StatsOutput[0])[0];
               assertEquals(5.5, (double) s.getMean(), 0.1);
-              assertEquals(2.25, (double) s.getPopulationVariance(), 0.1);
               assertEquals(55L, (long) s.getTotalSum());
               assertEquals(10L, (long) s.getTotalElements());
               return null;


### PR DESCRIPTION
* Calculate mean in `Stats` `CombineFn`
* Prefer `CombineFn` over `CombineFnWithContext`
* Window output into unified global windows for alerting output
* Remove excessive bundle logging from threshold analysis `DoFn`
* Improve performance of various JSON deserialization functions
* Share parser `ObjectMapper` and `JsonFactory` with payload parsers
