### PR TITLE
improve error handling on whitelist lookup

### DIFF
--- a/src/main/java/com/mozilla/secops/IprepdIO.java
+++ b/src/main/java/com/mozilla/secops/IprepdIO.java
@@ -219,7 +219,7 @@ public class IprepdIO {
    * @param ip IP address to check
    * @param a Alert to add metadata to
    */
-  public static void addMetadataIfWhitelisted(String ip, Alert a) {
+  public static void addMetadataIfWhitelisted(String ip, Alert a) throws IOException {
     addMetadataIfWhitelisted(ip, a, null);
   }
 
@@ -233,7 +233,8 @@ public class IprepdIO {
    * @param a Alert to add metadata to
    * @param datastoreProject If Datastore is in another project, non-null project ID
    */
-  public static void addMetadataIfWhitelisted(String ip, Alert a, String datastoreProject) {
+  public static void addMetadataIfWhitelisted(String ip, Alert a, String datastoreProject)
+      throws IOException {
     if (ip == null || a == null) {
       return;
     }
@@ -247,12 +248,16 @@ public class IprepdIO {
     } else {
       state = new State(new DatastoreStateInterface(whitelistedIpKind, whitelistedIpNamespace));
     }
+
     Logger log = LoggerFactory.getLogger(IprepdIO.class);
+
     try {
       state.initialize();
     } catch (StateException exc) {
       log.error("error initializing state: {}", exc.getMessage());
+      throw new IOException(exc.getMessage());
     }
+
     try {
       WhitelistedIp wip = state.get(ip, WhitelistedIp.class);
       if (wip != null) {
@@ -261,6 +266,9 @@ public class IprepdIO {
       }
     } catch (StateException exc) {
       log.error("error getting whitelisted ip: {}", exc.getMessage());
+      throw new IOException(exc.getMessage());
+    } finally {
+      state.done();
     }
   }
 }

--- a/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
+++ b/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
@@ -256,10 +256,16 @@ public class HTTPRequest implements Serializable {
                       a.setCategory("httprequest");
                       a.addMetadata("category", "error_rate");
                       a.addMetadata("sourceaddress", c.element().getKey());
+
                       if (enableIprepdDatastoreWhitelist) {
-                        IprepdIO.addMetadataIfWhitelisted(
-                            c.element().getKey(), a, iprepdDatastoreWhitelistProject);
+                        try {
+                          IprepdIO.addMetadataIfWhitelisted(
+                              c.element().getKey(), a, iprepdDatastoreWhitelistProject);
+                        } catch (IOException exc) {
+                          return;
+                        }
                       }
+
                       a.addMetadata("error_count", c.element().getValue().toString());
                       a.addMetadata("error_threshold", maxErrorRate.toString());
                       a.setNotifyMergeKey("error_count");
@@ -362,10 +368,16 @@ public class HTTPRequest implements Serializable {
                           a.setCategory("httprequest");
                           a.addMetadata("category", "hard_limit");
                           a.addMetadata("sourceaddress", c.element().getKey());
-                          if (enableIprepdDatastoreWhitelist) {
-                            IprepdIO.addMetadataIfWhitelisted(
-                                c.element().getKey(), a, iprepdDatastoreWhitelistProject);
+
+                          try {
+                            if (enableIprepdDatastoreWhitelist) {
+                              IprepdIO.addMetadataIfWhitelisted(
+                                  c.element().getKey(), a, iprepdDatastoreWhitelistProject);
+                            }
+                          } catch (IOException exc) {
+                            return;
                           }
+
                           a.addMetadata("count", c.element().getValue().toString());
                           a.addMetadata("request_threshold", maxCount.toString());
                           a.setNotifyMergeKey("hard_limit_count");
@@ -493,10 +505,16 @@ public class HTTPRequest implements Serializable {
                           a.setCategory("httprequest");
                           a.addMetadata("category", "useragent_blacklist");
                           a.addMetadata("sourceaddress", saddr);
-                          if (enableIprepdDatastoreWhitelist) {
-                            IprepdIO.addMetadataIfWhitelisted(
-                                saddr, a, iprepdDatastoreWhitelistProject);
+
+                          try {
+                            if (enableIprepdDatastoreWhitelist) {
+                              IprepdIO.addMetadataIfWhitelisted(
+                                  saddr, a, iprepdDatastoreWhitelistProject);
+                            }
+                          } catch (IOException exc) {
+                            return;
                           }
+
                           a.setNotifyMergeKey("useragent_blacklist");
                           a.addMetadata(
                               "window_timestamp", (new DateTime(w.maxTimestamp())).toString());
@@ -678,10 +696,16 @@ public class HTTPRequest implements Serializable {
                         a.setCategory("httprequest");
                         a.addMetadata("category", "endpoint_abuse");
                         a.addMetadata("sourceaddress", remoteAddress);
-                        if (enableIprepdDatastoreWhitelist) {
-                          IprepdIO.addMetadataIfWhitelisted(
-                              remoteAddress, a, iprepdDatastoreWhitelistProject);
+
+                        try {
+                          if (enableIprepdDatastoreWhitelist) {
+                            IprepdIO.addMetadataIfWhitelisted(
+                                remoteAddress, a, iprepdDatastoreWhitelistProject);
+                          }
+                        } catch (IOException exc) {
+                          return;
                         }
+
                         a.addMetadata("endpoint", comparePath);
                         a.addMetadata("method", compareMethod);
                         a.addMetadata("count", Integer.toString(count));
@@ -848,10 +872,16 @@ public class HTTPRequest implements Serializable {
                             a.setCategory("httprequest");
                             a.addMetadata("category", "threshold_analysis");
                             a.addMetadata("sourceaddress", c.element().getKey());
-                            if (enableIprepdDatastoreWhitelist) {
-                              IprepdIO.addMetadataIfWhitelisted(
-                                  c.element().getKey(), a, iprepdDatastoreWhitelistProject);
+
+                            try {
+                              if (enableIprepdDatastoreWhitelist) {
+                                IprepdIO.addMetadataIfWhitelisted(
+                                    c.element().getKey(), a, iprepdDatastoreWhitelistProject);
+                              }
+                            } catch (IOException exc) {
+                              return;
                             }
+
                             a.addMetadata("mean", sOutput.getMean().toString());
                             a.addMetadata("count", c.element().getValue().toString());
                             a.addMetadata("threshold_modifier", thresholdModifier.toString());


### PR DESCRIPTION
If a whitelist lookup fails in HTTPRequest, give up on processing that
particular entry.

Also adjust addMetadataIfWhitelisted so the state is properly closed
when the lookup is completed.