### PR TITLE
transactions for persistent state

### DIFF
--- a/src/main/java/com/mozilla/secops/alert/AlertSlack.java
+++ b/src/main/java/com/mozilla/secops/alert/AlertSlack.java
@@ -6,6 +6,7 @@ import com.mozilla.secops.slack.SlackManager;
 import com.mozilla.secops.state.DatastoreStateInterface;
 import com.mozilla.secops.state.MemcachedStateInterface;
 import com.mozilla.secops.state.State;
+import com.mozilla.secops.state.StateCursor;
 import com.mozilla.secops.state.StateException;
 import java.io.IOException;
 import org.slf4j.Logger;
@@ -129,13 +130,23 @@ public class AlertSlack {
 
     log.info("storing state of alert for {}", userId);
 
+    StateCursor c = null;
     try {
-      a.addMetadata("status", "NEW");
       state.initialize();
-      state.set(a.getAlertId().toString(), a);
+      c = state.newCursor();
+      a.addMetadata("status", "NEW");
+      c.set(a.getAlertId().toString(), a);
     } catch (StateException exc) {
       log.error("error saving alert state (StateException): {}", exc.getMessage());
       return false;
+    } finally {
+      if (c != null) {
+        try {
+          c.commit();
+        } catch (StateException exc) {
+          log.error("error during alert state commit (StateException): {}", exc.getMessage());
+        }
+      }
     }
 
     log.info("generating slack message for {}", userId);

--- a/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
+++ b/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
@@ -17,6 +17,7 @@ import com.mozilla.secops.parser.ParserDoFn;
 import com.mozilla.secops.state.DatastoreStateInterface;
 import com.mozilla.secops.state.MemcachedStateInterface;
 import com.mozilla.secops.state.State;
+import com.mozilla.secops.state.StateCursor;
 import com.mozilla.secops.state.StateException;
 import com.mozilla.secops.window.GlobalTriggers;
 import java.io.IOException;
@@ -366,9 +367,11 @@ public class AuthProfile implements Serializable {
             continue;
           }
         } else {
+          StateCursor cur = state.newCursor();
+
           a.addMetadata("identity_key", userIdentity);
           // The event was for a tracked identity, initialize the state model
-          StateModel sm = StateModel.get(userIdentity, state);
+          StateModel sm = StateModel.get(userIdentity, cur);
           if (sm == null) {
             sm = new StateModel(userIdentity);
           }
@@ -381,6 +384,7 @@ public class AuthProfile implements Serializable {
           if (sm.updateEntry(entryKey)) {
             // Check new address ignore list
             if (ignoreDuplicateSourceAddress(e, seenNewAddresses)) {
+              cur.commit();
               continue;
             }
             // Address was new
@@ -396,6 +400,7 @@ public class AuthProfile implements Serializable {
           } else {
             // Check known address ignore list
             if (ignoreDuplicateSourceAddress(e, seenKnownAddresses)) {
+              cur.commit();
               continue;
             }
 
@@ -409,7 +414,7 @@ public class AuthProfile implements Serializable {
 
           // Update persistent state with new information
           try {
-            sm.set(state);
+            sm.set(cur);
           } catch (StateException exc) {
             log.error("{}: error updating state: {}", userIdentity, exc.getMessage());
           }

--- a/src/main/java/com/mozilla/secops/authprofile/StateModel.java
+++ b/src/main/java/com/mozilla/secops/authprofile/StateModel.java
@@ -2,7 +2,7 @@ package com.mozilla.secops.authprofile;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.mozilla.secops.state.State;
+import com.mozilla.secops.state.StateCursor;
 import com.mozilla.secops.state.StateException;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -140,10 +140,10 @@ public class StateModel {
    * Retrieve state object for user
    *
    * @param user Subject name to retrieve state for
-   * @param s Initialized state interface for request
+   * @param s Initialized state cursor for request
    * @return User {@link StateModel} or null if it does not exist
    */
-  public static StateModel get(String user, State s) throws StateException {
+  public static StateModel get(String user, StateCursor s) throws StateException {
     StateModel ret = s.get(user, StateModel.class);
     if (ret == null) {
       return null;
@@ -155,10 +155,13 @@ public class StateModel {
   /**
    * Persist state using state interface
    *
-   * @param s Initialized state interface for request
+   * <p>Calling set will also commit and close the cursor.
+   *
+   * @param s Initialized state cursor for request
    */
-  public void set(State s) throws StateException {
+  public void set(StateCursor s) throws StateException {
     s.set(subject, this);
+    s.commit();
   }
 
   /**

--- a/src/main/java/com/mozilla/secops/state/DatastoreStateCursor.java
+++ b/src/main/java/com/mozilla/secops/state/DatastoreStateCursor.java
@@ -1,0 +1,62 @@
+package com.mozilla.secops.state;
+
+import com.google.cloud.datastore.Datastore;
+import com.google.cloud.datastore.DatastoreException;
+import com.google.cloud.datastore.Entity;
+import com.google.cloud.datastore.Key;
+import com.google.cloud.datastore.KeyFactory;
+import com.google.cloud.datastore.Transaction;
+
+/** Datastore state cursor implementation */
+public class DatastoreStateCursor extends StateCursor {
+  private String namespace;
+  private String kind;
+  private KeyFactory keyFactory;
+  private Transaction tx;
+
+  public void commit() throws StateException {
+    try {
+      tx.commit();
+    } catch (DatastoreException exc) {
+      throw new StateException(exc.getMessage());
+    }
+  }
+
+  public String getObject(String s) {
+    Key nk = keyFactory.newKey(s);
+    Entity e = tx.get(nk);
+    if (e == null) {
+      return null;
+    }
+    return e.getString("state");
+  }
+
+  public void saveObject(String s, String v) throws StateException {
+    Key nk;
+    try {
+      nk = keyFactory.newKey(s);
+    } catch (IllegalArgumentException exc) {
+      throw new StateException(exc.getMessage());
+    }
+    Entity.Builder eb = Entity.newBuilder(nk);
+    eb.set("state", v);
+    Entity e = eb.build();
+    try {
+      tx.put(e);
+    } catch (DatastoreException exc) {
+      throw new StateException(exc.getMessage());
+    }
+  }
+
+  /**
+   * Initialize a new Datastore cursor
+   *
+   * @param d Initialized {@link Datastore} object
+   */
+  public DatastoreStateCursor(Datastore d, String namespace, String kind) {
+    this.namespace = namespace;
+    this.kind = kind;
+    keyFactory = d.newKeyFactory().setNamespace(namespace).setKind(kind);
+    tx = d.newTransaction();
+  }
+}

--- a/src/main/java/com/mozilla/secops/state/DatastoreStateInterface.java
+++ b/src/main/java/com/mozilla/secops/state/DatastoreStateInterface.java
@@ -2,10 +2,8 @@ package com.mozilla.secops.state;
 
 import com.google.cloud.NoCredentials;
 import com.google.cloud.datastore.Datastore;
-import com.google.cloud.datastore.DatastoreException;
 import com.google.cloud.datastore.DatastoreOptions;
 import com.google.cloud.datastore.Entity;
-import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.KeyFactory;
 import com.google.cloud.datastore.Query;
 import com.google.cloud.datastore.QueryResults;
@@ -14,59 +12,13 @@ import com.google.cloud.datastore.StructuredQuery;
 /** Utilize GCP Datastore for centralized state storage */
 public class DatastoreStateInterface implements StateInterface {
   private Datastore datastore;
-  private KeyFactory keyFactory;
   private final String kind;
   private final String namespace;
+  private KeyFactory keyFactory;
   private String project;
 
-  public void deleteAll() throws StateException {
-    StructuredQuery<Entity> query =
-        Query.newEntityQueryBuilder().setNamespace(namespace).setKind(kind).build();
-    QueryResults<Entity> results = datastore.run(query);
-
-    while (results.hasNext()) {
-      datastore.delete(results.next().getKey());
-    }
-  }
-
-  public String getObject(String s) {
-    Key nk = keyFactory.newKey(s);
-    Entity e = datastore.get(nk);
-    if (e == null) {
-      return null;
-    }
-    return e.getString("state");
-  }
-
-  public void saveObject(String s, String v) throws StateException {
-    Key nk;
-    try {
-      nk = keyFactory.newKey(s);
-    } catch (IllegalArgumentException exc) {
-      throw new StateException(exc.getMessage());
-    }
-    Entity.Builder eb = Entity.newBuilder(nk);
-    eb.set("state", v);
-    Entity e = eb.build();
-    Boolean tryAdd = false;
-    try {
-      datastore.update(e);
-    } catch (DatastoreException exc) {
-      // https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto
-      // GRPC NOT_FOUND
-      if (exc.getCode() != 5) {
-        throw exc;
-      } else {
-        tryAdd = true;
-      }
-    }
-    if (tryAdd) {
-      try {
-        datastore.add(e);
-      } catch (DatastoreException exc) {
-        throw new StateException(exc.getMessage());
-      }
-    }
+  public StateCursor newCursor() {
+    return new DatastoreStateCursor(datastore, namespace, kind);
   }
 
   public void done() {}
@@ -89,6 +41,16 @@ public class DatastoreStateInterface implements StateInterface {
       datastore = b.build().getService();
     }
     keyFactory = datastore.newKeyFactory().setNamespace(namespace).setKind(kind);
+  }
+
+  public void deleteAll() throws StateException {
+    StructuredQuery<Entity> query =
+        Query.newEntityQueryBuilder().setNamespace(namespace).setKind(kind).build();
+    QueryResults<Entity> results = datastore.run(query);
+
+    while (results.hasNext()) {
+      datastore.delete(results.next().getKey());
+    }
   }
 
   /**

--- a/src/main/java/com/mozilla/secops/state/MemcachedStateCursor.java
+++ b/src/main/java/com/mozilla/secops/state/MemcachedStateCursor.java
@@ -1,0 +1,40 @@
+package com.mozilla.secops.state;
+
+import net.spy.memcached.MemcachedClient;
+import net.spy.memcached.OperationTimeoutException;
+
+/**
+ * Memcached state cursor implementation
+ *
+ * <p>This implementation does not support transactions.
+ */
+public class MemcachedStateCursor extends StateCursor {
+  private MemcachedClient memclient;
+
+  public void commit() throws StateException {}
+
+  public String getObject(String s) throws StateException {
+    try {
+      return (String) memclient.get(s);
+    } catch (OperationTimeoutException exc) {
+      throw new StateException(exc.getMessage());
+    }
+  }
+
+  public void saveObject(String s, String v) throws StateException {
+    try {
+      memclient.set(s, 0, v);
+    } catch (IllegalArgumentException exc) {
+      throw new StateException(exc.getMessage());
+    }
+  }
+
+  /**
+   * Initialize a new Memcached state cursor
+   *
+   * @param memclient {@link MemcachedClient}
+   */
+  public MemcachedStateCursor(MemcachedClient memclient) {
+    this.memclient = memclient;
+  }
+}

--- a/src/main/java/com/mozilla/secops/state/MemcachedStateInterface.java
+++ b/src/main/java/com/mozilla/secops/state/MemcachedStateInterface.java
@@ -11,34 +11,30 @@ public class MemcachedStateInterface implements StateInterface {
   private final int memcachedPort;
   private MemcachedClient memclient;
 
-  public void deleteAll() throws StateException {
-    memclient.flush();
-  }
-
-  public String getObject(String s) throws StateException {
-    try {
-      return (String) memclient.get(s);
-    } catch (OperationTimeoutException exc) {
-      throw new StateException(exc.getMessage());
-    }
-  }
-
-  public void saveObject(String s, String v) throws StateException {
-    try {
-      memclient.set(s, 0, v);
-    } catch (IllegalArgumentException exc) {
-      throw new StateException(exc.getMessage());
-    }
+  public StateCursor newCursor() {
+    return new MemcachedStateCursor(memclient);
   }
 
   public void done() {
     memclient.shutdown();
   }
 
+  public void deleteAll() throws StateException {
+    memclient.flush();
+  }
+
   public void initialize() throws StateException {
     try {
       memclient = new MemcachedClient(new InetSocketAddress(memcachedHost, memcachedPort));
     } catch (IOException exc) {
+      throw new StateException(exc.getMessage());
+    }
+  }
+
+  public String getObject(String s) throws StateException {
+    try {
+      return (String) memclient.get(s);
+    } catch (OperationTimeoutException exc) {
       throw new StateException(exc.getMessage());
     }
   }

--- a/src/main/java/com/mozilla/secops/state/State.java
+++ b/src/main/java/com/mozilla/secops/state/State.java
@@ -1,9 +1,5 @@
 package com.mozilla.secops.state;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.joda.JodaModule;
-import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -12,7 +8,6 @@ import org.slf4j.LoggerFactory;
  * persistent storage source
  */
 public class State {
-  private final ObjectMapper mapper;
   private final StateInterface si;
   private final Logger log;
 
@@ -23,20 +18,46 @@ public class State {
    */
   public State(StateInterface in) {
     si = in;
-
     log = LoggerFactory.getLogger(State.class);
-
-    mapper = new ObjectMapper();
-    mapper.registerModule(new JodaModule());
-    mapper.configure(
-        com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
   }
 
-  private static Boolean validKey(String k) {
-    if (k.isEmpty()) {
-      return false;
+  /** Flush all keys in the underlying state storage */
+  public void deleteAll() throws StateException {
+    si.deleteAll();
+  }
+
+  /**
+   * Perform simple key fetch operation with no intended follow up modification and update of the
+   * value. For operations involving a fetch, update, and store a new cursor should be allocated by
+   * the caller instead.
+   *
+   * @param s State key to fetch state for
+   * @param cls Class to deserialize state data into
+   * @return Returns an object containing state data for key, null if not found
+   */
+  public <T> T get(String s, Class<T> cls) throws StateException {
+    StateCursor c = newCursor();
+    try {
+      return c.get(s, cls);
+    } finally {
+      c.commit();
     }
-    return true;
+  }
+
+  /**
+   * Allocate new state cursor for a set of operations
+   *
+   * <p>In cases where the underlying {@link StateInterface} supports transactions, allocating a new
+   * cursor will begin a new transaction, from which writes will not take effect until the
+   * transaction has been commited.
+   *
+   * <p>If the underlying interface does not support transactions, the new cursor will still provide
+   * read and write functionality but it will not provide any form of transaction consistency.
+   *
+   * @return {@link StateCursor}
+   */
+  public StateCursor newCursor() {
+    return si.newCursor();
   }
 
   /**
@@ -50,56 +71,12 @@ public class State {
     si.initialize();
   }
 
-  /** Delete all keys */
-  public void deleteAll() throws StateException {
-    log.info("deleting all existing keys in state");
-    si.deleteAll();
-  }
-
   /**
-   * Get a state value
+   * Inidicate state object will no longer be used
    *
-   * @param s State key to fetch state for
-   * @param cls Class to deserialize state data into
-   * @return Returns an object containing state data for key, null if not found
+   * <p>The done function must be called to ensure any background threads and resources are
+   * released.
    */
-  public <T> T get(String s, Class<T> cls) throws StateException {
-    if (!validKey(s)) {
-      throw new StateException("invalid key name");
-    }
-    log.info("Requesting state for {}", s);
-    String lv = si.getObject(s);
-    if (lv == null) {
-      return null;
-    }
-
-    try {
-      return mapper.readValue(lv, cls);
-    } catch (IOException exc) {
-      throw new StateException(exc.getMessage());
-    }
-  }
-
-  /**
-   * Set a state value
-   *
-   * @param s State key to store state for
-   * @param o Object containing state data to serialize into state storage
-   */
-  public void set(String s, Object o) throws StateException {
-    if (!validKey(s)) {
-      throw new StateException("invalid key name");
-    }
-    log.info("Writing state for {}", s);
-
-    try {
-      si.saveObject(s, mapper.writeValueAsString(o));
-    } catch (JsonProcessingException exc) {
-      throw new StateException(exc.getMessage());
-    }
-  }
-
-  /** Inidicate state object will no longer be used */
   public void done() {
     log.info("Closing state interface {}", si.getClass().getName());
     si.done();

--- a/src/main/java/com/mozilla/secops/state/StateCursor.java
+++ b/src/main/java/com/mozilla/secops/state/StateCursor.java
@@ -1,0 +1,102 @@
+package com.mozilla.secops.state;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Generic state cursor implementation */
+public abstract class StateCursor {
+  private final Logger log;
+  private final ObjectMapper mapper;
+
+  /**
+   * Low level state object fetch operation
+   *
+   * <p>Most uses should prefer {@link #get}.
+   *
+   * @param s Key
+   * @return Value
+   */
+  public abstract String getObject(String s) throws StateException;
+
+  /**
+   * Low level state object save operation
+   *
+   * <p>Most uses should prefer {@link #set}.
+   *
+   * @param s Key
+   * @param v Value
+   */
+  public abstract void saveObject(String s, String v) throws StateException;
+
+  /**
+   * Commit transaction
+   *
+   * <p>For cursors that have an underlying interface implementation that does not support
+   * transactions, commit is a noop.
+   */
+  public abstract void commit() throws StateException;
+
+  private static Boolean validKey(String k) {
+    if (k.isEmpty()) {
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Get a state value
+   *
+   * @param s State key to fetch state for
+   * @param cls Class to deserialize state data into
+   * @return Returns an object containing state data for key, null if not found
+   */
+  public <T> T get(String s, Class<T> cls) throws StateException {
+    if (!validKey(s)) {
+      throw new StateException("invalid key name");
+    }
+    log.info("Requesting state for {}", s);
+    String lv = getObject(s);
+    if (lv == null) {
+      return null;
+    }
+
+    try {
+      return mapper.readValue(lv, cls);
+    } catch (IOException exc) {
+      throw new StateException(exc.getMessage());
+    }
+  }
+
+  /**
+   * Set a state value
+   *
+   * @param s State key to store state for
+   * @param o Object containing state data to serialize into state storage
+   */
+  public void set(String s, Object o) throws StateException {
+    if (!validKey(s)) {
+      throw new StateException("invalid key name");
+    }
+    log.info("Writing state for {}", s);
+
+    try {
+      saveObject(s, mapper.writeValueAsString(o));
+    } catch (JsonProcessingException exc) {
+      throw new StateException(exc.getMessage());
+    }
+  }
+
+  /** Allocate new {@link StateCursor} */
+  public StateCursor() {
+    log = LoggerFactory.getLogger(StateCursor.class);
+
+    mapper = new ObjectMapper();
+    mapper.registerModule(new JodaModule());
+    mapper.configure(
+        com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+  }
+}

--- a/src/main/java/com/mozilla/secops/state/StateInterface.java
+++ b/src/main/java/com/mozilla/secops/state/StateInterface.java
@@ -2,28 +2,15 @@ package com.mozilla.secops.state;
 
 /** Interface for state implementations */
 public interface StateInterface {
-  /**
-   * Retrieve object from state
-   *
-   * @param s State key
-   * @return Stored state JSON
-   */
-  public String getObject(String s) throws StateException;
-
-  /** Delete all keys from state */
-  public void deleteAll() throws StateException;
-
-  /**
-   * Save object to state
-   *
-   * @param s State key
-   * @param v State JSON
-   */
-  public void saveObject(String s, String v) throws StateException;
-
   /** Notify state implementation no further processing will occur */
   public void done();
 
-  /** Perform and setup required to read and write state */
+  /** Flush all keys in the state implementation */
+  public void deleteAll() throws StateException;
+
+  /** Perform any setup required to read and write state */
   public void initialize() throws StateException;
+
+  /** Allocate new state cursor */
+  public StateCursor newCursor();
 }

--- a/src/test/java/com/mozilla/secops/authprofile/TestStateModel.java
+++ b/src/test/java/com/mozilla/secops/authprofile/TestStateModel.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.mozilla.secops.state.DatastoreStateInterface;
 import com.mozilla.secops.state.State;
+import com.mozilla.secops.state.StateCursor;
 import org.joda.time.DateTime;
 import org.junit.Rule;
 import org.junit.Test;
@@ -29,48 +30,64 @@ public class TestStateModel {
   public void StateModelTest() throws Exception {
     testEnv();
     State s = new State(new DatastoreStateInterface("authprofile", "teststatemodel"));
+    StateCursor c;
     s.initialize();
 
-    assertNull(StateModel.get("nonexist", s));
+    c = s.newCursor();
+    assertNull(StateModel.get("nonexist", c));
+    c.commit();
 
     StateModel sm = new StateModel("riker");
     assertNotNull(sm);
-    sm.set(s);
+    c = s.newCursor();
+    sm.set(c);
 
-    sm = StateModel.get("riker", s);
+    c = s.newCursor();
+    sm = StateModel.get("riker", c);
     assertNotNull(sm);
     assertEquals(sm.getEntries().size(), 0);
 
+    // Reuse existing cursor from previous step
     assertTrue(sm.updateEntry("127.0.0.1")); // Assert true for new address
     assertEquals(sm.getEntries().size(), 1);
-    sm.set(s);
-    sm = StateModel.get("riker", s);
+    sm.set(c);
+
+    c = s.newCursor();
+    sm = StateModel.get("riker", c);
     assertEquals(sm.getEntries().size(), 1);
     assertFalse(sm.updateEntry("127.0.0.1")); // Assert false for update existing
-    sm.set(s);
+    sm.set(c);
 
+    c = s.newCursor();
     assertTrue(sm.updateEntry("10.0.0.1"));
     assertEquals(sm.getEntries().size(), 2);
-    sm.set(s);
-    sm = StateModel.get("riker", s);
+    sm.set(c);
+    c = s.newCursor();
+    sm = StateModel.get("riker", c);
     assertEquals(sm.getEntries().size(), 2);
+    c.commit();
 
     sm = new StateModel("picard");
     assertNotNull(sm);
     assertTrue(sm.updateEntry("127.0.0.1"));
     assertEquals(sm.getEntries().size(), 1);
-    sm.set(s);
+    c = s.newCursor();
+    sm.set(c);
 
-    sm = StateModel.get("picard", s);
+    c = s.newCursor();
+    sm = StateModel.get("picard", c);
     assertTrue(sm.updateEntry("10.0.0.1", new DateTime().minusDays(1)));
-    sm.set(s);
+    sm.set(c);
 
-    sm = StateModel.get("picard", s);
+    c = s.newCursor();
+    sm = StateModel.get("picard", c);
     assertEquals(sm.getEntries().size(), 2);
     sm.pruneState(43200L);
-    sm.set(s);
-    sm = StateModel.get("picard", s);
+    sm.set(c);
+    c = s.newCursor();
+    sm = StateModel.get("picard", c);
     assertEquals(sm.getEntries().size(), 1);
+    c.commit();
 
     s.done();
   }

--- a/src/test/java/com/mozilla/secops/state/StateDatastoreTest.java
+++ b/src/test/java/com/mozilla/secops/state/StateDatastoreTest.java
@@ -1,0 +1,62 @@
+package com.mozilla.secops.state;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.rules.ExpectedException;
+
+public class StateDatastoreTest {
+  @Rule public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+
+  @Rule public ExpectedException expectEx = ExpectedException.none();
+
+  private void testEnv() {
+    environmentVariables.set("DATASTORE_EMULATOR_HOST", "localhost:8081");
+    environmentVariables.set("DATASTORE_EMULATOR_HOST_PATH", "localhost:8081/datastore");
+    environmentVariables.set("DATASTORE_HOST", "http://localhost:8081");
+    environmentVariables.set("DATASTORE_PROJECT_ID", "foxsec-pipeline");
+  }
+
+  @Test
+  public void testStateGetSetConcurrent() throws Exception {
+    expectEx.expect(StateException.class);
+    expectEx.expectMessage("too much contention on these datastore entities. please try again.");
+
+    testEnv();
+    State s = new State(new DatastoreStateInterface("test", "statetest"));
+    assertNotNull(s);
+    s.initialize();
+
+    StateCursor c1 = s.newCursor();
+    StateCursor c2 = s.newCursor();
+    assertNotNull(c1);
+    assertNotNull(c2);
+
+    StateTestClass t = new StateTestClass();
+    assertNotNull(t);
+
+    t.str = "test";
+    c1.set("testing", t);
+    c1.commit();
+
+    c1 = s.newCursor();
+    t = c1.get("testing", StateTestClass.class);
+    assertNotNull(t);
+    assertEquals("test", t.str);
+
+    StateTestClass t2 = c2.get("testing", StateTestClass.class);
+    assertNotNull(t2);
+    assertEquals("test", t2.str);
+
+    t2.str = "test2";
+    c2.set("testing", t2);
+    c2.commit();
+
+    t.str = "changed";
+    c1.set("testing", t);
+    c1.commit();
+  }
+}

--- a/src/test/java/com/mozilla/secops/state/StateTest.java
+++ b/src/test/java/com/mozilla/secops/state/StateTest.java
@@ -53,13 +53,21 @@ public class StateTest {
     State s = new State(si);
     assertNotNull(s);
     s.initialize();
+    StateCursor c = s.newCursor();
+    assertNotNull(c);
+
     StateTestClass t = new StateTestClass();
     assertNotNull(t);
+
     t.str = "test";
-    s.set("testing", t);
-    t = s.get("testing", StateTestClass.class);
+    c.set("testing", t);
+    c.commit();
+
+    c = s.newCursor();
+    t = c.get("testing", StateTestClass.class);
     assertNotNull(t);
     assertEquals("test", t.str);
+    c.commit();
   }
 
   @Test
@@ -71,12 +79,19 @@ public class StateTest {
     StateTestClass t = new StateTestClass();
     assertNotNull(t);
     t.str = "test";
-    s.set("testing", t);
-    t = s.get("testing", StateTestClass.class);
+
+    StateCursor c = s.newCursor();
+    c.set("testing", t);
+    c.commit();
+    c = s.newCursor();
+    t = c.get("testing", StateTestClass.class);
     assertNotNull(t);
     assertEquals("test", t.str);
+    c.commit();
 
-    assertNull(s.get("nonexist", StateTestClass.class));
+    c = s.newCursor();
+    assertNull(c.get("nonexist", StateTestClass.class));
+    c.commit();
   }
 
   @Test(expected = StateException.class)
@@ -88,7 +103,14 @@ public class StateTest {
     StateTestClass t = new StateTestClass();
     assertNotNull(t);
     t.str = "test";
-    s.set("", t);
+    StateCursor c = s.newCursor();
+    try {
+      c.set("", t);
+    } catch (StateException exc) {
+      throw exc;
+    } finally {
+      c.commit();
+    }
   }
 
   @Test(expected = StateException.class)
@@ -97,6 +119,13 @@ public class StateTest {
     State s = new State(si);
     assertNotNull(s);
     s.initialize();
-    s.get("", StateTestClass.class);
+    StateCursor c = s.newCursor();
+    try {
+      c.get("", StateTestClass.class);
+    } catch (StateException exc) {
+      throw exc;
+    } finally {
+      c.commit();
+    }
   }
 }


### PR DESCRIPTION
Improves persistent state handling by utilizing transactions where
possible.

For Datastore based state implementations, transaction support has been
added that can provide error reporting on key contention.

The existing memcached state implementation has been modified to work
with the newer cursor API, however it has been noted that no transaction
support exists in the implementation.