### PR TITLE
prefer PAssert.SingletonAssert

### DIFF
--- a/src/test/java/com/mozilla/secops/TestInputTypeFile.java
+++ b/src/test/java/com/mozilla/secops/TestInputTypeFile.java
@@ -31,7 +31,7 @@ public class TestInputTypeFile {
     PCollection<String> results = pipeline.apply(new CompositeInput(o));
     PCollection<Long> count = results.apply(Count.globally());
 
-    PAssert.that(count).containsInAnyOrder(10L);
+    PAssert.thatSingleton(count).isEqualTo(10L);
 
     pipeline.run().waitUntilFinish();
   }

--- a/src/test/java/com/mozilla/secops/TestInputTypeFileMulti.java
+++ b/src/test/java/com/mozilla/secops/TestInputTypeFileMulti.java
@@ -35,7 +35,7 @@ public class TestInputTypeFileMulti {
     PCollection<String> results = pipeline.apply(new CompositeInput(o));
     PCollection<Long> count = results.apply(Count.globally());
 
-    PAssert.that(count).containsInAnyOrder(30L);
+    PAssert.thatSingleton(count).isEqualTo(30L);
 
     pipeline.run().waitUntilFinish();
   }

--- a/src/test/java/com/mozilla/secops/customs/TestCustoms.java
+++ b/src/test/java/com/mozilla/secops/customs/TestCustoms.java
@@ -50,7 +50,7 @@ public class TestCustoms {
             .apply(ParDo.of(new ParserDoFn()))
             .apply(Combine.globally(Count.<Event>combineFn()).withoutDefaults());
 
-    PAssert.that(count).containsInAnyOrder(5L);
+    PAssert.thatSingleton(count).isEqualTo(5L);
 
     p.run().waitUntilFinish();
   }
@@ -74,7 +74,7 @@ public class TestCustoms {
 
     PCollection<Long> count =
         alerts.apply(Combine.globally(Count.<Alert>combineFn()).withoutDefaults());
-    PAssert.that(count).containsInAnyOrder(1L);
+    PAssert.thatSingleton(count).isEqualTo(1L);
 
     PAssert.that(alerts)
         .satisfies(
@@ -134,7 +134,7 @@ public class TestCustoms {
 
     PCollection<Long> count =
         alerts.apply(Combine.globally(Count.<Alert>combineFn()).withoutDefaults());
-    PAssert.that(count).containsInAnyOrder(2L);
+    PAssert.thatSingleton(count).isEqualTo(2L);
 
     p.run().waitUntilFinish();
   }
@@ -157,7 +157,7 @@ public class TestCustoms {
 
     PCollection<Long> count =
         alerts.apply(Combine.globally(Count.<Alert>combineFn()).withoutDefaults());
-    PAssert.that(count).containsInAnyOrder(6L);
+    PAssert.thatSingleton(count).isEqualTo(6L);
 
     p.run().waitUntilFinish();
   }

--- a/src/test/java/com/mozilla/secops/httprequest/TestEndpointAbuse1.java
+++ b/src/test/java/com/mozilla/secops/httprequest/TestEndpointAbuse1.java
@@ -47,9 +47,9 @@ public class TestEndpointAbuse1 {
     PCollection<Long> count =
         results.apply(Combine.globally(Count.<Alert>combineFn()).withoutDefaults());
 
-    PAssert.that(count)
-        .inWindow(new IntervalWindow(new Instant(0L), new Instant(600000L)))
-        .containsInAnyOrder(1L);
+    PAssert.thatSingleton(count)
+        .inOnlyPane(new IntervalWindow(new Instant(0L), new Instant(600000L)))
+        .isEqualTo(1L);
 
     PAssert.that(results)
         .inWindow(new IntervalWindow(new Instant(0L), new Instant(600000L)))

--- a/src/test/java/com/mozilla/secops/httprequest/TestErrorRate1.java
+++ b/src/test/java/com/mozilla/secops/httprequest/TestErrorRate1.java
@@ -49,12 +49,12 @@ public class TestErrorRate1 {
     PCollection<Long> count =
         events.apply(Combine.globally(Count.<Event>combineFn()).withoutDefaults());
 
-    PAssert.that(count)
-        .inWindow(new IntervalWindow(new Instant(0L), new Instant(60000L)))
-        .containsInAnyOrder(720L);
-    PAssert.that(count)
-        .inWindow(new IntervalWindow(new Instant(300000L), new Instant(360000L)))
-        .containsInAnyOrder(720L);
+    PAssert.thatSingleton(count)
+        .inOnlyPane(new IntervalWindow(new Instant(0L), new Instant(60000L)))
+        .isEqualTo(720L);
+    PAssert.thatSingleton(count)
+        .inOnlyPane(new IntervalWindow(new Instant(300000L), new Instant(360000L)))
+        .isEqualTo(720L);
 
     p.run().waitUntilFinish();
   }
@@ -72,9 +72,9 @@ public class TestErrorRate1 {
 
     PCollection<Long> resultCount =
         results.apply(Combine.globally(Count.<Alert>combineFn()).withoutDefaults());
-    PAssert.that(resultCount)
-        .inWindow(new IntervalWindow(new Instant(300000L), new Instant(360000L)))
-        .containsInAnyOrder(2L);
+    PAssert.thatSingleton(resultCount)
+        .inOnlyPane(new IntervalWindow(new Instant(300000L), new Instant(360000L)))
+        .isEqualTo(2L);
 
     PAssert.that(results)
         .inWindow(new IntervalWindow(new Instant(300000L), new Instant(360000L)))

--- a/src/test/java/com/mozilla/secops/httprequest/TestFilter.java
+++ b/src/test/java/com/mozilla/secops/httprequest/TestFilter.java
@@ -36,9 +36,9 @@ public class TestFilter {
     PCollection<Long> count =
         events.apply(Combine.globally(Count.<Event>combineFn()).withoutDefaults());
 
-    PAssert.that(count)
-        .inWindow(new IntervalWindow(new Instant(0L), new Instant(60000)))
-        .containsInAnyOrder(3L);
+    PAssert.thatSingleton(count)
+        .inOnlyPane(new IntervalWindow(new Instant(0L), new Instant(60000)))
+        .isEqualTo(3L);
 
     p.run().waitUntilFinish();
   }
@@ -54,9 +54,9 @@ public class TestFilter {
     PCollection<Long> count =
         events.apply(Combine.globally(Count.<Event>combineFn()).withoutDefaults());
 
-    PAssert.that(count)
-        .inWindow(new IntervalWindow(new Instant(0L), new Instant(60000)))
-        .containsInAnyOrder(1L);
+    PAssert.thatSingleton(count)
+        .inOnlyPane(new IntervalWindow(new Instant(0L), new Instant(60000)))
+        .isEqualTo(1L);
 
     p.run().waitUntilFinish();
   }
@@ -72,9 +72,9 @@ public class TestFilter {
     PCollection<Long> count =
         events.apply(Combine.globally(Count.<Event>combineFn()).withoutDefaults());
 
-    PAssert.that(count)
-        .inWindow(new IntervalWindow(new Instant(0L), new Instant(60000)))
-        .containsInAnyOrder(2L);
+    PAssert.thatSingleton(count)
+        .inOnlyPane(new IntervalWindow(new Instant(0L), new Instant(60000)))
+        .isEqualTo(2L);
 
     p.run().waitUntilFinish();
   }
@@ -90,9 +90,9 @@ public class TestFilter {
     PCollection<Long> count =
         events.apply(Combine.globally(Count.<Event>combineFn()).withoutDefaults());
 
-    PAssert.that(count)
-        .inWindow(new IntervalWindow(new Instant(0L), new Instant(60000)))
-        .containsInAnyOrder(2L);
+    PAssert.thatSingleton(count)
+        .inOnlyPane(new IntervalWindow(new Instant(0L), new Instant(60000)))
+        .isEqualTo(2L);
 
     p.run().waitUntilFinish();
   }
@@ -123,9 +123,9 @@ public class TestFilter {
     PCollection<Long> count =
         events.apply(Combine.globally(Count.<Event>combineFn()).withoutDefaults());
 
-    PAssert.that(count)
-        .inWindow(new IntervalWindow(new Instant(0L), new Instant(60000)))
-        .containsInAnyOrder(4L);
+    PAssert.thatSingleton(count)
+        .inOnlyPane(new IntervalWindow(new Instant(0L), new Instant(60000)))
+        .isEqualTo(4L);
 
     p.run().waitUntilFinish();
   }
@@ -141,9 +141,9 @@ public class TestFilter {
     PCollection<Long> count =
         events.apply(Combine.globally(Count.<Event>combineFn()).withoutDefaults());
 
-    PAssert.that(count)
-        .inWindow(new IntervalWindow(new Instant(0L), new Instant(60000)))
-        .containsInAnyOrder(2L);
+    PAssert.thatSingleton(count)
+        .inOnlyPane(new IntervalWindow(new Instant(0L), new Instant(60000)))
+        .isEqualTo(2L);
 
     p.run().waitUntilFinish();
   }

--- a/src/test/java/com/mozilla/secops/httprequest/TestHardLimit1.java
+++ b/src/test/java/com/mozilla/secops/httprequest/TestHardLimit1.java
@@ -49,9 +49,9 @@ public class TestHardLimit1 {
 
     PCollection<Long> resultCount =
         results.apply(Combine.globally(Count.<Alert>combineFn()).withoutDefaults());
-    PAssert.that(resultCount)
-        .inWindow(new IntervalWindow(new Instant(0L), new Instant(60000L)))
-        .containsInAnyOrder(2L);
+    PAssert.thatSingleton(resultCount)
+        .inOnlyPane(new IntervalWindow(new Instant(0L), new Instant(60000L)))
+        .isEqualTo(2L);
 
     PAssert.that(results)
         .inWindow(new IntervalWindow(new Instant(0L), new Instant(60000L)))
@@ -90,9 +90,9 @@ public class TestHardLimit1 {
 
     PCollection<Long> resultCount =
         results.apply(Combine.globally(Count.<Alert>combineFn()).withoutDefaults());
-    PAssert.that(resultCount)
-        .inWindow(new IntervalWindow(new Instant(0L), new Instant(60000L)))
-        .containsInAnyOrder(1L);
+    PAssert.thatSingleton(resultCount)
+        .inOnlyPane(new IntervalWindow(new Instant(0L), new Instant(60000L)))
+        .isEqualTo(1L);
 
     PAssert.that(results)
         .inWindow(new IntervalWindow(new Instant(0L), new Instant(60000L)))

--- a/src/test/java/com/mozilla/secops/httprequest/TestThresholdAnalysis1.java
+++ b/src/test/java/com/mozilla/secops/httprequest/TestThresholdAnalysis1.java
@@ -53,12 +53,12 @@ public class TestThresholdAnalysis1 {
     PCollection<Long> count =
         events.apply(Combine.globally(Count.<Event>combineFn()).withoutDefaults());
 
-    PAssert.that(count)
-        .inWindow(new IntervalWindow(new Instant(0L), new Instant(60000)))
-        .containsInAnyOrder(2400L);
-    PAssert.that(count)
-        .inWindow(new IntervalWindow(new Instant(300000L), new Instant(360000)))
-        .containsInAnyOrder(2520L);
+    PAssert.thatSingleton(count)
+        .inOnlyPane(new IntervalWindow(new Instant(0L), new Instant(60000)))
+        .isEqualTo(2400L);
+    PAssert.thatSingleton(count)
+        .inOnlyPane(new IntervalWindow(new Instant(300000L), new Instant(360000)))
+        .isEqualTo(2520L);
 
     p.run().waitUntilFinish();
   }
@@ -77,9 +77,9 @@ public class TestThresholdAnalysis1 {
 
     PCollection<Long> resultCount =
         results.apply(Combine.globally(Count.<Alert>combineFn()).withoutDefaults());
-    PAssert.that(resultCount)
-        .inWindow(new IntervalWindow(new Instant(300000L), new Instant(360000L)))
-        .containsInAnyOrder(2L);
+    PAssert.thatSingleton(resultCount)
+        .inOnlyPane(new IntervalWindow(new Instant(300000L), new Instant(360000L)))
+        .isEqualTo(2L);
 
     PAssert.that(results)
         .inWindow(new IntervalWindow(new Instant(300000L), new Instant(360000L)))
@@ -124,9 +124,9 @@ public class TestThresholdAnalysis1 {
         results.apply(Combine.globally(Count.<Alert>combineFn()).withoutDefaults());
     // 10.0.0.2 would normally trigger a result being emitted, but with NAT detection enabled
     // we should only see a single result for 10.0.0.1 in the selected interval window
-    PAssert.that(resultCount)
-        .inWindow(new IntervalWindow(new Instant(300000L), new Instant(360000L)))
-        .containsInAnyOrder(1L);
+    PAssert.thatSingleton(resultCount)
+        .inOnlyPane(new IntervalWindow(new Instant(300000L), new Instant(360000L)))
+        .isEqualTo(1L);
 
     PAssert.that(results)
         .inWindow(new IntervalWindow(new Instant(300000L), new Instant(360000L)))
@@ -211,9 +211,9 @@ public class TestThresholdAnalysis1 {
 
     PCollection<Long> resultCount =
         results.apply(Combine.globally(Count.<Alert>combineFn()).withoutDefaults());
-    PAssert.that(resultCount)
-        .inWindow(new IntervalWindow(new Instant(300000L), new Instant(360000L)))
-        .containsInAnyOrder(14L);
+    PAssert.thatSingleton(resultCount)
+        .inOnlyPane(new IntervalWindow(new Instant(300000L), new Instant(360000L)))
+        .isEqualTo(14L);
 
     p.run().waitUntilFinish();
   }

--- a/src/test/java/com/mozilla/secops/httprequest/TestUserAgentBlacklist1.java
+++ b/src/test/java/com/mozilla/secops/httprequest/TestUserAgentBlacklist1.java
@@ -47,9 +47,9 @@ public class TestUserAgentBlacklist1 {
 
     PCollection<Long> resultCount =
         results.apply(Combine.globally(Count.<Alert>combineFn()).withoutDefaults());
-    PAssert.that(resultCount)
-        .inWindow(new IntervalWindow(new Instant(0L), new Instant(60000L)))
-        .containsInAnyOrder(1L);
+    PAssert.thatSingleton(resultCount)
+        .inOnlyPane(new IntervalWindow(new Instant(0L), new Instant(60000L)))
+        .isEqualTo(1L);
 
     PAssert.that(results)
         .inWindow(new IntervalWindow(new Instant(0L), new Instant(60000L)))

--- a/src/test/java/com/mozilla/secops/parser/EventFilterTransformTest.java
+++ b/src/test/java/com/mozilla/secops/parser/EventFilterTransformTest.java
@@ -40,10 +40,10 @@ public class EventFilterTransformTest {
     PCollection<Event> nfiltered = input.apply("negative", EventFilter.getTransform(nFilter));
 
     PCollection<Long> pcount = pfiltered.apply("pcount", Count.globally());
-    PAssert.that(pcount).containsInAnyOrder(1L);
+    PAssert.thatSingleton(pcount).isEqualTo(1L);
 
     PCollection<Long> ncount = nfiltered.apply("ncount", Count.globally());
-    PAssert.that(ncount).containsInAnyOrder(0L);
+    PAssert.thatSingleton(ncount).isEqualTo(0L);
 
     pipeline.run().waitUntilFinish();
   }
@@ -77,10 +77,10 @@ public class EventFilterTransformTest {
     PCollection<Event> nfiltered = input.apply("negative", EventFilter.getTransform(nFilter));
 
     PCollection<Long> pcount = pfiltered.apply("pcount", Count.globally());
-    PAssert.that(pcount).containsInAnyOrder(1L);
+    PAssert.thatSingleton(pcount).isEqualTo(1L);
 
     PCollection<Long> ncount = nfiltered.apply("ncount", Count.globally());
-    PAssert.that(ncount).containsInAnyOrder(0L);
+    PAssert.thatSingleton(ncount).isEqualTo(0L);
 
     pipeline.run().waitUntilFinish();
   }
@@ -226,7 +226,7 @@ public class EventFilterTransformTest {
     filter.addRule(new EventFilterRule().wantSubtype(Payload.PayloadType.GLB));
     PCollection<Event> filtered = input.apply("match all", EventFilter.getTransform(filter));
     PCollection<Long> count = filtered.apply("count all", Count.globally());
-    PAssert.that(count).containsInAnyOrder(2L);
+    PAssert.thatSingleton(count).isEqualTo(2L);
 
     filter = new EventFilter();
     assertNotNull(filter);
@@ -234,7 +234,7 @@ public class EventFilterTransformTest {
         new EventFilterRule().wantSubtype(Payload.PayloadType.GLB).wantStackdriverProject("moz"));
     filtered = input.apply("match one", EventFilter.getTransform(filter));
     count = filtered.apply("count one", Count.globally());
-    PAssert.that(count).containsInAnyOrder(1L);
+    PAssert.thatSingleton(count).isEqualTo(1L);
     PAssert.that(filtered)
         .satisfies(
             x -> {


### PR DESCRIPTION
In tests, where asserting the value of a singleton prefer using
PAssert.SingletonAssert over asserting collection contents equal a
single value.