### PR TITLE
fix npe for pipelines with no templates

### DIFF
--- a/src/main/java/com/mozilla/secops/CompositeOutput.java
+++ b/src/main/java/com/mozilla/secops/CompositeOutput.java
@@ -43,8 +43,10 @@ public abstract class CompositeOutput {
     Logger log = LoggerFactory.getLogger(CompositeOutput.class);
 
     AlertConfiguration alertcfg = new AlertConfiguration();
-    for (String tmpl : options.getOutputAlertTemplates()) {
-      alertcfg.registerTemplate(tmpl);
+    if (options.getOutputAlertTemplates() != null) {
+      for (String tmpl : options.getOutputAlertTemplates()) {
+        alertcfg.registerTemplate(tmpl);
+      }
     }
     alertcfg.setSmtpCredentials(options.getOutputAlertSmtpCredentials());
     alertcfg.setSmtpRelay(options.getOutputAlertSmtpRelay());


### PR DESCRIPTION
Fixes a null pointer exception that occurs if a pipeline doesn't have
any configured templates.