### PR TITLE
Changes to hook duopull into Authprofile

### DIFF
--- a/src/main/java/com/mozilla/secops/parser/models/duopull/Duopull.java
+++ b/src/main/java/com/mozilla/secops/parser/models/duopull/Duopull.java
@@ -8,13 +8,14 @@ import java.io.Serializable;
 /**
  * Describes the format of a duopull event
  *
- * <p>See also https://github.com/mozilla-services/duopull-lambda
+ * <p>See also https://github.com/mozilla-services/foxsec-pipeline-contrib/tree/master/duopull
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Duopull implements Serializable {
   private static final long serialVersionUID = 1L;
 
   private String eventDescriptionUserId;
+  private String eventDescriptionIpAddress;
   private String eventObject;
   private Long eventTimestamp;
   private String eventUsername;
@@ -34,6 +35,16 @@ public class Duopull implements Serializable {
   @JsonProperty("event_description_user_id")
   public String getEventDescriptionUserId() {
     return eventDescriptionUserId;
+  }
+
+  /**
+   * Get event description ip address
+   *
+   * @return String source ip
+   */
+  @JsonProperty("event_description_ip_address")
+  public String getEventDescriptionIpAddress() {
+    return eventDescriptionIpAddress;
   }
 
   /**

--- a/src/test/java/com/mozilla/secops/identity/TestIdentityManager.java
+++ b/src/test/java/com/mozilla/secops/identity/TestIdentityManager.java
@@ -18,6 +18,7 @@ public class TestIdentityManager {
     assertNotNull(mgr);
 
     assertEquals("testuser@mozilla.com", mgr.lookupAlias("testuser"));
+    assertEquals("testuser@mozilla.com", mgr.lookupAlias("test user"));
     assertNull(mgr.lookupAlias("unknown"));
     assertEquals("testuser@mozilla.com", mgr.lookupAlias("testuser@mozilla.com"));
 

--- a/src/test/java/com/mozilla/secops/parser/ParserIdentityTest.java
+++ b/src/test/java/com/mozilla/secops/parser/ParserIdentityTest.java
@@ -84,4 +84,45 @@ public class ParserIdentityTest {
     assertNull(n.getSourceAddressCity());
     assertNull(n.getSourceAddressCountry());
   }
+
+  @Test
+  public void testDuopullStackdriverAdminLoginWithIdentity() throws Exception {
+    String buf =
+        "{\"insertId\": \"gh39djdfyz4lya\",\"jsonPayload\": {\"Fields\": {\"event_object\": null,"
+            + "\"event_username\": \"riker\",\"event_description_factor\": \"push\",\"msg\": \"duopull event\","
+            + "\"event_timestamp\": 1556216112,\"event_description_device\": \"555-555-5555\","
+            + "\"event_action\": \"admin_login\",\"event_description_primary_auth_method\": \"Password\","
+            + "\"path\": \"/admin/v1/logs/administrator\",\"event_description_ip_address\": \"127.0.0.1\""
+            + "},\"Pid\": 1,\"Hostname\": \"localhost\","
+            + "\"EnvVersion\": \"2.0\",\"Type\": \"app.log\",\"Timestamp\": 1556216660526927000,"
+            + "\"Severity\": 6,\"Logger\": \"duopull\",\"Time\": \"2019-04-25T18:24:20Z\"},"
+            + "\"resource\": {\"type\": \"project\",\"labels\": {\"project_id\": \"pipeline\"}},"
+            + "\"timestamp\": \"2019-04-25T18:24:20.527024712Z\","
+            + "\"logName\": \"projects/pipeline/logs/duopull\","
+            + "\"receiveTimestamp\": \"2019-04-25T18:24:20.555273442Z\"}";
+
+    IdentityManager mgr = IdentityManager.load("/testdata/identitymanager.json");
+    Parser p = new Parser();
+    p.setIdentityManager(mgr);
+    assertNotNull(p);
+    Event e = p.parse(buf);
+    assertNotNull(e);
+    assertEquals(Payload.PayloadType.DUOPULL, e.getPayloadType());
+    assertEquals("2019-04-25T18:15:12.000Z", e.getTimestamp().toString());
+    Duopull d = e.getPayload();
+    assertNotNull(d);
+    com.mozilla.secops.parser.models.duopull.Duopull data = d.getDuopullData();
+    assertNotNull(data);
+    assertEquals("riker", data.getEventUsername());
+    assertEquals("127.0.0.1", data.getEventDescriptionIpAddress());
+    Normalized n = e.getNormalized();
+    assertNotNull(n);
+    assertTrue(n.isOfType(Normalized.Type.AUTH));
+    assertEquals("riker", n.getSubjectUser());
+    assertEquals("127.0.0.1", n.getSourceAddress());
+    assertEquals("wriker@mozilla.com", n.getSubjectUserIdentity());
+    assertEquals("admin_login", n.getObject());
+    assertNull(n.getSourceAddressCity());
+    assertNull(n.getSourceAddressCountry());
+  }
 }

--- a/src/test/java/com/mozilla/secops/parser/ParserTest.java
+++ b/src/test/java/com/mozilla/secops/parser/ParserTest.java
@@ -574,6 +574,42 @@ public class ParserTest {
   }
 
   @Test
+  public void testParseStackdriverJsonDuopullAdminLogin() {
+    String buf =
+        "{\"insertId\": \"gh39djdfyz4lya\",\"jsonPayload\": {\"Fields\": {\"event_object\": null,"
+            + "\"event_username\": \"riker\",\"event_description_factor\": \"push\",\"msg\": \"duopull event\","
+            + "\"event_timestamp\": 1556216112,\"event_description_device\": \"555-555-5555\","
+            + "\"event_action\": \"admin_login\",\"event_description_primary_auth_method\": \"Password\","
+            + "\"path\": \"/admin/v1/logs/administrator\",\"event_description_ip_address\": \"127.0.0.1\""
+            + "},\"Pid\": 1,\"Hostname\": \"localhost\","
+            + "\"EnvVersion\": \"2.0\",\"Type\": \"app.log\",\"Timestamp\": 1556216660526927000,"
+            + "\"Severity\": 6,\"Logger\": \"duopull\",\"Time\": \"2019-04-25T18:24:20Z\"},"
+            + "\"resource\": {\"type\": \"project\",\"labels\": {\"project_id\": \"pipeline\"}},"
+            + "\"timestamp\": \"2019-04-25T18:24:20.527024712Z\","
+            + "\"logName\": \"projects/pipeline/logs/duopull\","
+            + "\"receiveTimestamp\": \"2019-04-25T18:24:20.555273442Z\"}";
+
+    Parser p = getTestParser();
+    assertNotNull(p);
+    Event e = p.parse(buf);
+    assertNotNull(e);
+    assertEquals(Payload.PayloadType.DUOPULL, e.getPayloadType());
+    assertEquals("2019-04-25T18:15:12.000Z", e.getTimestamp().toString());
+    Duopull d = e.getPayload();
+    assertNotNull(d);
+    com.mozilla.secops.parser.models.duopull.Duopull data = d.getDuopullData();
+    assertNotNull(data);
+    assertEquals("riker", data.getEventUsername());
+    assertEquals("127.0.0.1", data.getEventDescriptionIpAddress());
+    Normalized n = e.getNormalized();
+    assertNotNull(n);
+    assertTrue(n.isOfType(Normalized.Type.AUTH));
+    assertEquals("riker", n.getSubjectUser());
+    assertEquals("127.0.0.1", n.getSourceAddress());
+    assertEquals("admin_login", n.getObject());
+  }
+
+  @Test
   public void testParseISO8601() throws Exception {
     String[] datelist = {
       "2018-09-28T18:55:12.469",

--- a/src/test/resources/testdata/identitymanager.json
+++ b/src/test/resources/testdata/identitymanager.json
@@ -1,7 +1,7 @@
 {
     "identities": {
         "testuser@mozilla.com": {
-            "aliases": [ "testuser" ]
+            "aliases": [ "testuser", "test user" ]
         },
 
         "wcrusher@mozilla.com": {


### PR DESCRIPTION
Fill in `Event.Normalized` as an `AUTH` event for admin login events. Brings AuthProfile/Duopull up to par with the auth_lastx sandbox.

Also, adds test case of alias with a space in it (as this is the case for some admin login events from Duo).