### PR TITLE
Prepend "duo_" onto Duopull's Normalized.object

### DIFF
--- a/src/main/java/com/mozilla/secops/parser/Duopull.java
+++ b/src/main/java/com/mozilla/secops/parser/Duopull.java
@@ -16,6 +16,8 @@ import org.joda.time.DateTime;
 public class Duopull extends PayloadBase implements Serializable {
   private static final long serialVersionUID = 1L;
 
+  private static final String DUO_OBJECT = "duo";
+
   private static final String ADMIN_LOGIN_EVENT = "admin_login";
 
   private com.mozilla.secops.parser.models.duopull.Duopull duoPullData;
@@ -88,7 +90,7 @@ public class Duopull extends PayloadBase implements Serializable {
         Normalized n = e.getNormalized();
         n.addType(Normalized.Type.AUTH);
         n.setSubjectUser(user);
-        n.setObject(duoPullData.getEventAction());
+        n.setObject(String.format("duo_%s", duoPullData.getEventAction()));
         n.setSourceAddress(sourceAddress);
 
         // If we have an instance of IdentityManager in the parser, see if we can

--- a/src/test/java/com/mozilla/secops/parser/ParserIdentityTest.java
+++ b/src/test/java/com/mozilla/secops/parser/ParserIdentityTest.java
@@ -121,7 +121,7 @@ public class ParserIdentityTest {
     assertEquals("riker", n.getSubjectUser());
     assertEquals("127.0.0.1", n.getSourceAddress());
     assertEquals("wriker@mozilla.com", n.getSubjectUserIdentity());
-    assertEquals("admin_login", n.getObject());
+    assertEquals("duo_admin_login", n.getObject());
     assertNull(n.getSourceAddressCity());
     assertNull(n.getSourceAddressCountry());
   }

--- a/src/test/java/com/mozilla/secops/parser/ParserTest.java
+++ b/src/test/java/com/mozilla/secops/parser/ParserTest.java
@@ -606,7 +606,7 @@ public class ParserTest {
     assertTrue(n.isOfType(Normalized.Type.AUTH));
     assertEquals("riker", n.getSubjectUser());
     assertEquals("127.0.0.1", n.getSourceAddress());
-    assertEquals("admin_login", n.getObject());
+    assertEquals("duo_admin_login", n.getObject());
   }
 
   @Test


### PR DESCRIPTION
Mainly to help with the alert message in a simple way. At the moment,
the alert will read "An authentication event for user ajvb was
detected to access admin_login" which is too vague.