### PR TITLE
aws cidr match, internal match, ignore in httprequest

### DIFF
--- a/src/test/java/com/mozilla/secops/TestCidrUtil.java
+++ b/src/test/java/com/mozilla/secops/TestCidrUtil.java
@@ -46,4 +46,24 @@ public class TestCidrUtil {
     assertFalse(CidrUtil.resolvedCanonicalHostMatches("127.0.0.1", ".*google.com$"));
     assertFalse(CidrUtil.resolvedCanonicalHostMatches("0.0.0.0", ".*"));
   }
+
+  public void cidrLoadAwsSubnetsTest() throws Exception {
+    CidrUtil c = new CidrUtil();
+    c.add("192.168.1.0/24");
+    assertFalse(c.contains("52.204.100.1"));
+    assertTrue(c.contains("192.168.1.25"));
+    c.loadAwsSubnets();
+    assertTrue(c.contains("52.204.100.1"));
+    assertTrue(c.contains("192.168.1.25"));
+  }
+
+  @Test
+  public void cidrLoadInternalSubnetsTest() throws Exception {
+    CidrUtil c = new CidrUtil();
+    assertFalse(c.contains("52.204.100.1"));
+    assertFalse(c.contains("192.168.1.25"));
+    c.loadInternalSubnets();
+    assertFalse(c.contains("52.204.100.1"));
+    assertTrue(c.contains("192.168.1.25"));
+  }
 }

--- a/src/test/java/com/mozilla/secops/httprequest/TestEndpointAbuse1.java
+++ b/src/test/java/com/mozilla/secops/httprequest/TestEndpointAbuse1.java
@@ -31,6 +31,7 @@ public class TestEndpointAbuse1 {
     ret.setUseEventTimestamp(true); // Use timestamp from events for our testing
     ret.setMonitoredResourceIndicator("test");
     ret.setSessionGapDurationMinutes(20L);
+    ret.setIgnoreInternalRequests(false); // Tests use internal subnets
     return ret;
   }
 

--- a/src/test/java/com/mozilla/secops/httprequest/TestErrorRate1.java
+++ b/src/test/java/com/mozilla/secops/httprequest/TestErrorRate1.java
@@ -35,6 +35,7 @@ public class TestErrorRate1 {
     ret.setMonitoredResourceIndicator("test");
     ret.setUseEventTimestamp(true); // Use timestamp from events for our testing
     ret.setMaxClientErrorRate(30L);
+    ret.setIgnoreInternalRequests(false); // Tests use internal subnets
     return ret;
   }
 

--- a/src/test/java/com/mozilla/secops/httprequest/TestFilter.java
+++ b/src/test/java/com/mozilla/secops/httprequest/TestFilter.java
@@ -22,6 +22,7 @@ public class TestFilter {
     HTTPRequest.HTTPRequestOptions ret =
         PipelineOptionsFactory.as(HTTPRequest.HTTPRequestOptions.class);
     ret.setUseEventTimestamp(true); // Use timestamp from events for our testing
+    ret.setIgnoreInternalRequests(false); // Tests use internal subnets
     return ret;
   }
 

--- a/src/test/java/com/mozilla/secops/httprequest/TestHardLimit1.java
+++ b/src/test/java/com/mozilla/secops/httprequest/TestHardLimit1.java
@@ -33,6 +33,7 @@ public class TestHardLimit1 {
     ret.setUseEventTimestamp(true); // Use timestamp from events for our testing
     ret.setHardLimitRequestCount(10L);
     ret.setMonitoredResourceIndicator("test");
+    ret.setIgnoreInternalRequests(false); // Tests use internal subnets
     return ret;
   }
 

--- a/src/test/java/com/mozilla/secops/httprequest/TestThresholdAnalysis1.java
+++ b/src/test/java/com/mozilla/secops/httprequest/TestThresholdAnalysis1.java
@@ -33,6 +33,7 @@ public class TestThresholdAnalysis1 {
     ret.setUseEventTimestamp(true); // Use timestamp from events for our testing
     ret.setAnalysisThresholdModifier(1.0);
     ret.setMonitoredResourceIndicator("test");
+    ret.setIgnoreInternalRequests(false); // Tests use internal subnets
     return ret;
   }
 

--- a/src/test/java/com/mozilla/secops/httprequest/TestUserAgentBlacklist1.java
+++ b/src/test/java/com/mozilla/secops/httprequest/TestUserAgentBlacklist1.java
@@ -30,6 +30,7 @@ public class TestUserAgentBlacklist1 {
     ret.setUseEventTimestamp(true); // Use timestamp from events for our testing
     ret.setUserAgentBlacklistPath("/testdata/uablacklist1.txt");
     ret.setMonitoredResourceIndicator("test");
+    ret.setIgnoreInternalRequests(false); // Tests use internal subnets
     return ret;
   }
 


### PR DESCRIPTION
Update CidrUtil with support for loading known AWS public subnets, and internal subnets.

Modify HttpRequest to optionally ignore known provider subnet ranges and internal subnets,
enabled by default.