### PR TITLE
optionally use host networking in docker container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: required
 
+env:
+  - DOCKER_HOST_NETWORK=1
+
 services:
   - docker
 

--- a/bin/m
+++ b/bin/m
@@ -13,6 +13,11 @@ if [[ `uname` == 'Darwin' ]]; then
 	CACHEFLAGS=':cached'
 fi
 
+NETFLAGS=''
+if [[ ! -z "$DOCKER_HOST_NETWORK" ]]; then
+	NETFLAGS='--network=host'
+fi
+
 # If using WSL, the developer is likely using a symlink to a directory
 # on the Windows fs.
 if [[ `uname -a` == *"Microsoft"* ]]; then
@@ -23,6 +28,7 @@ fi
 mkdir -p .m2
 
 docker run -it --rm \
+    $NETFLAGS \
     -v $PWD/.m2:/root/.m2${CACHEFLAGS} \
     -v $PWD:/root/project${CACHEFLAGS} \
     -e GOOGLE_APPLICATION_CREDENTIALS \


### PR DESCRIPTION
Optionally use host networking in docker container to work around
network stability issues in TravisCI.