### PR TITLE
Remove duplicate alert metadata setting of key:status

### DIFF
--- a/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
+++ b/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
@@ -416,8 +416,6 @@ public class AuthProfile implements Serializable {
         a.addMetadata("notify_slack_direct", a.getMetadataValue("identity_key"));
         if (identity.getSlackConfirmationAlertFeatureFlag(idmanager.getDefaultFeatureFlags())) {
           a.addMetadata("alert_notification_type", "slack_confirmation");
-          // This is used outside of dataflow to keep track of the users response.
-          a.addMetadata("status", "NEW");
         } else {
           a.addMetadata("alert_notification_type", "slack_notification");
         }


### PR DESCRIPTION
Already gets set here: https://github.com/mozilla-services/foxsec-pipeline/blob/master/src/main/java/com/mozilla/secops/alert/AlertSlack.java#L142