### PR TITLE
Include GeoIP metadata in alerts in AlertFormatter

### DIFF
--- a/src/main/java/com/mozilla/secops/IOOptions.java
+++ b/src/main/java/com/mozilla/secops/IOOptions.java
@@ -1,0 +1,4 @@
+package com.mozilla.secops;
+
+/** Interface to allow for passing both input and output options to a class or function. */
+public interface IOOptions extends OutputOptions, InputOptions {}

--- a/src/main/java/com/mozilla/secops/InputOptions.java
+++ b/src/main/java/com/mozilla/secops/InputOptions.java
@@ -23,10 +23,15 @@ public interface InputOptions extends PipelineOptions, PubsubOptions, GcpOptions
 
   void setInputKinesis(String[] value);
 
-  @Description("Path to load Maxmind database; resource path, gcs path")
-  String getMaxmindDbPath();
+  @Description("Path to load Maxmind City database; resource path, gcs path")
+  String getMaxmindCityDbPath();
 
-  void setMaxmindDbPath(String value);
+  void setMaxmindCityDbPath(String value);
+
+  @Description("Path to load Maxmind ISP database; resource path, gcs path")
+  String getMaxmindIspDbPath();
+
+  void setMaxmindIspDbPath(String value);
 
   @Description("Enable XFF address selector; comma delimited list of trusted CIDR format subnets")
   String getXffAddressSelector();

--- a/src/main/java/com/mozilla/secops/OutputOptions.java
+++ b/src/main/java/com/mozilla/secops/OutputOptions.java
@@ -126,6 +126,12 @@ public interface OutputOptions extends PipelineOptions, GcpOptions {
   @Hidden
   void setOutputAlertTemplates(String[] value);
 
+  @Description(
+      "Adds GeoIP metadata to all fields specified (multiple allowed); keys names for alert metadata with an IP address, for example: sourceaddress")
+  String[] getAlertAddressFields();
+
+  void setAlertAddressFields(String[] value);
+
   public static PTransform<PCollection<String>, PDone> compositeOutput(OutputOptions o) {
     return CompositeOutput.withOptions(o);
   }

--- a/src/main/java/com/mozilla/secops/alert/AlertFormatter.java
+++ b/src/main/java/com/mozilla/secops/alert/AlertFormatter.java
@@ -1,6 +1,9 @@
 package com.mozilla.secops.alert;
 
-import com.mozilla.secops.OutputOptions;
+import com.maxmind.geoip2.model.CityResponse;
+import com.maxmind.geoip2.model.IspResponse;
+import com.mozilla.secops.IOOptions;
+import com.mozilla.secops.parser.GeoIP;
 import org.apache.beam.sdk.transforms.DoFn;
 
 /**
@@ -13,15 +16,61 @@ public class AlertFormatter extends DoFn<Alert, String> {
   private static final long serialVersionUID = 1L;
 
   private String monitoredResourceIndicator;
+  private String[] addressFields;
+  private String maxmindCityDbPath;
+  private String maxmindIspDbPath;
+  private GeoIP geoip;
 
-  public AlertFormatter(OutputOptions options) {
+  public AlertFormatter(IOOptions options) {
     monitoredResourceIndicator = options.getMonitoredResourceIndicator();
+    addressFields = options.getAlertAddressFields();
+    maxmindCityDbPath = options.getMaxmindCityDbPath();
+    maxmindIspDbPath = options.getMaxmindIspDbPath();
+  }
+
+  // Add additional GeoIP data if not already present
+  private void addGeoIPData(Alert a) {
+    if (geoip == null || addressFields == null) {
+      return;
+    }
+
+    for (String addressField : addressFields) {
+      String address = a.getMetadataValue(addressField);
+      if (address != null) {
+        if (a.getMetadataValue(addressField + "_city") == null
+            && a.getMetadataValue(addressField + "_country") == null) {
+          CityResponse cr = geoip.lookupCity(address);
+          if (cr != null) {
+            a.addMetadata(addressField + "_city", cr.getCity().getName());
+            a.addMetadata(addressField + "_country", cr.getCountry().getIsoCode());
+          }
+        }
+        if (a.getMetadataValue(addressField + "_isp") == null
+            && a.getMetadataValue(addressField + "_asn") == null
+            && a.getMetadataValue(addressField + "_as_org") == null) {
+          IspResponse ir = geoip.lookupIsp(address);
+          if (ir != null) {
+            a.addMetadata(addressField + "_isp", ir.getIsp());
+            a.addMetadata(addressField + "_asn", ir.getAutonomousSystemNumber().toString());
+            a.addMetadata(addressField + "_as_org", ir.getAutonomousSystemOrganization());
+          }
+        }
+      }
+    }
+  }
+
+  @Setup
+  public void setup() {
+    if (maxmindCityDbPath != null || maxmindIspDbPath != null) {
+      geoip = new GeoIP(maxmindCityDbPath, maxmindIspDbPath);
+    }
   }
 
   @ProcessElement
   public void processElement(ProcessContext c) {
     Alert a = c.element();
     a.addMetadata("monitored_resource", monitoredResourceIndicator);
+    addGeoIPData(a);
     c.output(a.toJSON());
   }
 }

--- a/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
+++ b/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
@@ -2,7 +2,7 @@ package com.mozilla.secops.authprofile;
 
 import com.mozilla.secops.CidrUtil;
 import com.mozilla.secops.CompositeInput;
-import com.mozilla.secops.InputOptions;
+import com.mozilla.secops.IOOptions;
 import com.mozilla.secops.OutputOptions;
 import com.mozilla.secops.alert.Alert;
 import com.mozilla.secops.alert.AlertFormatter;
@@ -565,7 +565,7 @@ public class AuthProfile implements Serializable {
   }
 
   /** Runtime options for {@link AuthProfile} pipeline. */
-  public interface AuthProfileOptions extends PipelineOptions, InputOptions, OutputOptions {
+  public interface AuthProfileOptions extends PipelineOptions, IOOptions {
     @Description("Enable state analysis")
     @Default.Boolean(true)
     Boolean getEnableStateAnalysis();

--- a/src/main/java/com/mozilla/secops/awsbehavior/AwsBehavior.java
+++ b/src/main/java/com/mozilla/secops/awsbehavior/AwsBehavior.java
@@ -1,7 +1,7 @@
 package com.mozilla.secops.awsbehavior;
 
 import com.mozilla.secops.CompositeInput;
-import com.mozilla.secops.InputOptions;
+import com.mozilla.secops.IOOptions;
 import com.mozilla.secops.OutputOptions;
 import com.mozilla.secops.alert.Alert;
 import com.mozilla.secops.alert.AlertFormatter;
@@ -172,7 +172,7 @@ public class AwsBehavior implements Serializable {
   }
 
   /** Runtime options for {@link AwsBehavior} pipeline. */
-  public interface AwsBehaviorOptions extends PipelineOptions, InputOptions, OutputOptions {
+  public interface AwsBehaviorOptions extends PipelineOptions, IOOptions {
     @Description("Override default identity manager configuration; resource path")
     String getIdentityManagerPath();
 

--- a/src/main/java/com/mozilla/secops/customs/Customs.java
+++ b/src/main/java/com/mozilla/secops/customs/Customs.java
@@ -1,7 +1,7 @@
 package com.mozilla.secops.customs;
 
 import com.mozilla.secops.CompositeInput;
-import com.mozilla.secops.InputOptions;
+import com.mozilla.secops.IOOptions;
 import com.mozilla.secops.OutputOptions;
 import com.mozilla.secops.alert.Alert;
 import com.mozilla.secops.alert.AlertFormatter;
@@ -262,7 +262,7 @@ public class Customs implements Serializable {
   }
 
   /** Runtime options for {@link Customs} pipeline. */
-  public interface CustomsOptions extends PipelineOptions, InputOptions, OutputOptions {
+  public interface CustomsOptions extends PipelineOptions, IOOptions {
     @Description("path to customs rate limit configuration; resource path")
     @Default.String("/customs/customsdefault.json")
     String getConfigurationResourcePath();

--- a/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
+++ b/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
@@ -4,7 +4,7 @@ import com.mozilla.secops.CidrUtil;
 import com.mozilla.secops.CompositeInput;
 import com.mozilla.secops.DetectNat;
 import com.mozilla.secops.FileUtil;
-import com.mozilla.secops.InputOptions;
+import com.mozilla.secops.IOOptions;
 import com.mozilla.secops.IprepdIO;
 import com.mozilla.secops.OutputOptions;
 import com.mozilla.secops.Stats;
@@ -1004,7 +1004,7 @@ public class HTTPRequest implements Serializable {
   }
 
   /** Runtime options for {@link HTTPRequest} pipeline. */
-  public interface HTTPRequestOptions extends PipelineOptions, InputOptions, OutputOptions {
+  public interface HTTPRequestOptions extends PipelineOptions, IOOptions {
     @Description("Enable threshold analysis")
     @Default.Boolean(false)
     Boolean getEnableThresholdAnalysis();

--- a/src/main/java/com/mozilla/secops/parser/GeoIP.java
+++ b/src/main/java/com/mozilla/secops/parser/GeoIP.java
@@ -3,6 +3,7 @@ package com.mozilla.secops.parser;
 import com.maxmind.geoip2.DatabaseReader;
 import com.maxmind.geoip2.exception.GeoIp2Exception;
 import com.maxmind.geoip2.model.CityResponse;
+import com.maxmind.geoip2.model.IspResponse;
 import com.mozilla.secops.GcsUtil;
 import java.io.IOException;
 import java.io.InputStream;
@@ -11,8 +12,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 /** GeoIP resolution */
 public class GeoIP {
-  private static DatabaseReader geoipDb = null;
-  private static AtomicBoolean initialized = new AtomicBoolean(false);
+  private static DatabaseReader geoipCityDb = null;
+  private static DatabaseReader geoipIspDb = null;
+  private static AtomicBoolean cityInitialized = new AtomicBoolean(false);
+  private static AtomicBoolean ispInitialized = new AtomicBoolean(false);
 
   /**
    * Lookup city/country from IP address string
@@ -20,14 +23,14 @@ public class GeoIP {
    * @param ip IP address string
    * @return MaxmindDB {@link CityResponse}, or null on failure
    */
-  public CityResponse lookup(String ip) {
-    if (!initialized.get()) {
+  public CityResponse lookupCity(String ip) {
+    if (!cityInitialized.get()) {
       return null;
     }
 
     try {
       InetAddress ia = InetAddress.getByName(ip);
-      return geoipDb.city(ia);
+      return geoipCityDb.city(ia);
     } catch (IOException exc) {
       return null;
     } catch (GeoIp2Exception exc) {
@@ -35,34 +38,71 @@ public class GeoIP {
     }
   }
 
-  private static synchronized void initialize(String path) throws IOException {
-    InputStream in;
-
-    if (initialized.get()) {
-      return;
+  /**
+   * Lookup ISP from IP address string
+   *
+   * @param ip IP address string
+   * @return MaxmindDB {@link IspResponse}, or null on failure
+   */
+  public IspResponse lookupIsp(String ip) {
+    if (!ispInitialized.get()) {
+      return null;
     }
 
+    try {
+      InetAddress ia = InetAddress.getByName(ip);
+      return geoipIspDb.isp(ia);
+    } catch (IOException exc) {
+      return null;
+    } catch (GeoIp2Exception exc) {
+      return null;
+    }
+  }
+
+  private static DatabaseReader getDatabaseFromPath(String path) throws IOException {
+    if (path == null) {
+      return null;
+    }
+
+    InputStream in;
     if (GcsUtil.isGcsUrl(path)) {
       in = GcsUtil.fetchInputStreamContent(path);
     } else {
       in = GeoIP.class.getResourceAsStream(path);
     }
     if (in == null) {
+      return null;
+    }
+
+    return new DatabaseReader.Builder(in).build();
+  }
+
+  private static synchronized void initialize(String cityPath, String ispPath) throws IOException {
+    if (cityInitialized.get() || ispInitialized.get()) {
       return;
     }
 
-    geoipDb = new DatabaseReader.Builder(in).build();
-    initialized.set(true);
+    geoipCityDb = getDatabaseFromPath(cityPath);
+    if (geoipCityDb != null) {
+      cityInitialized.set(true);
+    }
+    geoipIspDb = getDatabaseFromPath(ispPath);
+    if (geoipIspDb != null) {
+      ispInitialized.set(true);
+    }
   }
 
   /**
-   * Initialize new {@link GeoIP}, load database from specified path
+   * Initialize new {@link GeoIP}, load databases from specified paths
    *
-   * @param path Resource or GCS path to load database from
+   * <p>If you don't want to initialize one of the DB's (City or ISP), pass in `null` as the path.
+   *
+   * @param cityPath Resource or GCS path to load City database from
+   * @param ispPath Resource or GCS path to load ISP database from
    */
-  public GeoIP(String path) {
+  public GeoIP(String cityPath, String ispPath) {
     try {
-      initialize(path);
+      initialize(cityPath, ispPath);
     } catch (IOException exc) {
       throw new RuntimeException(exc.getMessage());
     }

--- a/src/main/java/com/mozilla/secops/parser/Parser.java
+++ b/src/main/java/com/mozilla/secops/parser/Parser.java
@@ -277,7 +277,7 @@ public class Parser {
     if (geoip == null) {
       return null;
     }
-    return geoip.lookup(ip);
+    return geoip.lookupCity(ip);
   }
 
   /**
@@ -369,8 +369,8 @@ public class Parser {
     googleJacksonFactory = new JacksonFactory();
 
     this.cfg = cfg;
-    if (cfg.getMaxmindDbPath() != null) {
-      geoip = new GeoIP(cfg.getMaxmindDbPath());
+    if (cfg.getMaxmindCityDbPath() != null || cfg.getMaxmindIspDbPath() != null) {
+      geoip = new GeoIP(cfg.getMaxmindCityDbPath(), cfg.getMaxmindIspDbPath());
     }
     payloads = new ArrayList<PayloadBase>();
     payloads.add(new GLB());

--- a/src/main/java/com/mozilla/secops/parser/ParserCfg.java
+++ b/src/main/java/com/mozilla/secops/parser/ParserCfg.java
@@ -10,7 +10,8 @@ import java.util.Arrays;
 public class ParserCfg implements Serializable {
   private static final long serialVersionUID = 1L;
 
-  private String maxmindDbPath;
+  private String maxmindCityDbPath;
+  private String maxmindIspDbPath;
   private String fastMatcher;
   private ArrayList<String> xffAddressSelectorSubnets;
   private String idmanagerPath;
@@ -23,7 +24,8 @@ public class ParserCfg implements Serializable {
    */
   public static ParserCfg fromInputOptions(InputOptions options) {
     ParserCfg cfg = new ParserCfg();
-    cfg.setMaxmindDbPath(options.getMaxmindDbPath());
+    cfg.setMaxmindCityDbPath(options.getMaxmindCityDbPath());
+    cfg.setMaxmindIspDbPath(options.getMaxmindIspDbPath());
     cfg.setIdentityManagerPath(options.getIdentityManagerPath());
     cfg.setParserFastMatcher(options.getParserFastMatcher());
     if (options.getXffAddressSelector() != null) {
@@ -81,21 +83,39 @@ public class ParserCfg implements Serializable {
   }
 
   /**
-   * Get Maxmind database path
+   * Get Maxmind City database path
    *
    * @return String or null if not specified
    */
-  public String getMaxmindDbPath() {
-    return maxmindDbPath;
+  public String getMaxmindCityDbPath() {
+    return maxmindCityDbPath;
   }
 
   /**
-   * Set Maxmind database path
+   * Set Maxmind City database path
    *
    * @param path Path
    */
-  public void setMaxmindDbPath(String path) {
-    maxmindDbPath = path;
+  public void setMaxmindCityDbPath(String path) {
+    maxmindCityDbPath = path;
+  }
+
+  /**
+   * Get Maxmind ISP database path
+   *
+   * @return String or null if not specified
+   */
+  public String getMaxmindIspDbPath() {
+    return maxmindIspDbPath;
+  }
+
+  /**
+   * Set Maxmind ISP database path
+   *
+   * @param path Path
+   */
+  public void setMaxmindIspDbPath(String path) {
+    maxmindIspDbPath = path;
   }
 
   /**

--- a/src/test/java/com/mozilla/secops/alert/TestAlertFormatter.java
+++ b/src/test/java/com/mozilla/secops/alert/TestAlertFormatter.java
@@ -1,0 +1,76 @@
+package com.mozilla.secops.alert;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import com.mozilla.secops.IOOptions;
+import com.mozilla.secops.parser.ParserTest;
+import java.util.Arrays;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.PCollection;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class TestAlertFormatter {
+
+  public TestAlertFormatter() {}
+
+  @Rule public final transient TestPipeline p = TestPipeline.create();
+
+  private PCollection<Alert> getTestInput(TestPipeline p) {
+    Alert testAlert = new Alert();
+    testAlert.addMetadata("sourceaddress", "216.160.83.56");
+    return p.apply(Create.of(Arrays.asList(new Alert[] {testAlert})));
+  }
+
+  @Test
+  public void runFormatter() {
+    IOOptions options = PipelineOptionsFactory.as(IOOptions.class);
+    PCollection<String> res = getTestInput(p).apply(ParDo.of(new AlertFormatter(options)));
+
+    PAssert.that(res)
+        .satisfies(
+            results -> {
+              for (String s : results) {
+                Alert a = Alert.fromJSON(s);
+                assertNotNull(a);
+                assertNull(a.getMetadataValue("sourceaddress_city"));
+                assertNull(a.getMetadataValue("sourceaddress_country"));
+              }
+              return null;
+            });
+
+    p.run().waitUntilFinish();
+  }
+
+  @Test
+  public void runFormatterWithSettings() {
+    IOOptions options = PipelineOptionsFactory.as(IOOptions.class);
+    options.setMaxmindCityDbPath(ParserTest.TEST_GEOIP_DBPATH);
+    options.setMonitoredResourceIndicator("formatter_test");
+    options.setAlertAddressFields(new String[] {"sourceaddress"});
+
+    PCollection<String> res = getTestInput(p).apply(ParDo.of(new AlertFormatter(options)));
+
+    PAssert.that(res)
+        .satisfies(
+            results -> {
+              for (String s : results) {
+                Alert a = Alert.fromJSON(s);
+                assertNotNull(a);
+                assertEquals("216.160.83.56", a.getMetadataValue("sourceaddress"));
+                assertEquals("Milton", a.getMetadataValue("sourceaddress_city"));
+                assertEquals("US", a.getMetadataValue("sourceaddress_country"));
+                assertEquals("formatter_test", a.getMetadataValue("monitored_resource"));
+              }
+              return null;
+            });
+
+    p.run().waitUntilFinish();
+  }
+}

--- a/src/test/java/com/mozilla/secops/authprofile/TestAuthProfile.java
+++ b/src/test/java/com/mozilla/secops/authprofile/TestAuthProfile.java
@@ -76,7 +76,7 @@ public class TestAuthProfile {
     ret.setDatastoreNamespace("testauthprofileanalyze");
     ret.setDatastoreKind("authprofile");
     ret.setIdentityManagerPath("/testdata/identitymanager.json");
-    ret.setMaxmindDbPath(ParserTest.TEST_GEOIP_DBPATH);
+    ret.setMaxmindCityDbPath(ParserTest.TEST_GEOIP_DBPATH);
     return ret;
   }
 

--- a/src/test/java/com/mozilla/secops/authprofile/TestCritObject.java
+++ b/src/test/java/com/mozilla/secops/authprofile/TestCritObject.java
@@ -25,7 +25,7 @@ public class TestCritObject {
         PipelineOptionsFactory.as(AuthProfile.AuthProfileOptions.class);
     ret.setIdentityManagerPath("/testdata/identitymanager.json");
     ret.setEnableStateAnalysis(false);
-    ret.setMaxmindDbPath(ParserTest.TEST_GEOIP_DBPATH);
+    ret.setMaxmindCityDbPath(ParserTest.TEST_GEOIP_DBPATH);
     ret.setCritObjects(new String[] {"^projects/test$"});
     ret.setCriticalNotificationEmail("section31@mozilla.com");
     ret.setIgnoreUserRegex(new String[] {"^riker@mozilla.com$"});

--- a/src/test/java/com/mozilla/secops/awsbehavior/TestAwsBehavior.java
+++ b/src/test/java/com/mozilla/secops/awsbehavior/TestAwsBehavior.java
@@ -29,7 +29,7 @@ public class TestAwsBehavior {
         PipelineOptionsFactory.as(AwsBehavior.AwsBehaviorOptions.class);
     ret.setIdentityManagerPath("/testdata/identitymanager.json");
     ret.setCloudtrailMatcherManagerPath("/testdata/event_matchers.json");
-    ret.setMaxmindDbPath(ParserTest.TEST_GEOIP_DBPATH);
+    ret.setMaxmindCityDbPath(ParserTest.TEST_GEOIP_DBPATH);
     return ret;
   }
 

--- a/src/test/java/com/mozilla/secops/customs/TestCustoms.java
+++ b/src/test/java/com/mozilla/secops/customs/TestCustoms.java
@@ -28,7 +28,7 @@ public class TestCustoms {
   private Customs.CustomsOptions getTestOptions() {
     Customs.CustomsOptions ret = PipelineOptionsFactory.as(Customs.CustomsOptions.class);
     ret.setMonitoredResourceIndicator("test");
-    ret.setMaxmindDbPath(ParserTest.TEST_GEOIP_DBPATH);
+    ret.setMaxmindCityDbPath(ParserTest.TEST_GEOIP_DBPATH);
     return ret;
   }
 

--- a/src/test/java/com/mozilla/secops/parser/ParserTest.java
+++ b/src/test/java/com/mozilla/secops/parser/ParserTest.java
@@ -18,7 +18,7 @@ public class ParserTest {
 
   private Parser getTestParser() {
     ParserCfg cfg = new ParserCfg();
-    cfg.setMaxmindDbPath(TEST_GEOIP_DBPATH);
+    cfg.setMaxmindCityDbPath(TEST_GEOIP_DBPATH);
     return new Parser(cfg);
   }
 
@@ -1065,7 +1065,7 @@ public class ParserTest {
             + ":\"i-00000000000000000\",\"project_id\":\"test\",\"region\":\"aws:us-west-2c\"},\"type\":"
             + "\"aws_ec2_instance\"},\"timestamp\":\"2019-01-31T17:49:57Z\"}";
     ParserCfg cfg = new ParserCfg();
-    cfg.setMaxmindDbPath(TEST_GEOIP_DBPATH);
+    cfg.setMaxmindCityDbPath(TEST_GEOIP_DBPATH);
     Parser p = new Parser(cfg);
     assertNotNull(p);
     Event e = p.parse(buf);
@@ -1097,7 +1097,7 @@ public class ParserTest {
             + " 3697 \"https://mozilla.org/item/10\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:"
             + "65.0) Gecko/20100101 Firefox/65.0\"";
     ParserCfg cfg = new ParserCfg();
-    cfg.setMaxmindDbPath(TEST_GEOIP_DBPATH);
+    cfg.setMaxmindCityDbPath(TEST_GEOIP_DBPATH);
     Parser p = new Parser(cfg);
     assertNotNull(p);
     Event e = p.parse(buf);
@@ -1134,7 +1134,7 @@ public class ParserTest {
             + " 3697 \"https://mozilla.org/item/10\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:"
             + "65.0) Gecko/20100101 Firefox/65.0\"";
     ParserCfg cfg = new ParserCfg();
-    cfg.setMaxmindDbPath(TEST_GEOIP_DBPATH);
+    cfg.setMaxmindCityDbPath(TEST_GEOIP_DBPATH);
     Parser p = new Parser(cfg);
     assertNotNull(p);
     Event e = p.parse(buf);
@@ -1180,7 +1180,7 @@ public class ParserTest {
             + ":\"test\",\"zone\":\"us-west-2c\"},\"type\":\"gce_instance\"},\"timestamp\":\"20"
             + "19-02-15T16:56:33.121592986Z\"}";
     ParserCfg cfg = new ParserCfg();
-    cfg.setMaxmindDbPath(TEST_GEOIP_DBPATH);
+    cfg.setMaxmindCityDbPath(TEST_GEOIP_DBPATH);
     ArrayList<String> xffa = new ArrayList<>();
     xffa.add("127.0.0.1/32");
     cfg.setXffAddressSelector(xffa);


### PR DESCRIPTION
* Adds support for Maxmind's ISP db in GeoIP
* AlertFormatter now adds GeoIP metadata to alerts
* Add test for AlertFormatter


Can look up Alert with `id = "4f408b09-4769-41ae-a0a2-85b0fe1187b7"` in nonprod bigquery to look at an example.

Fixes #100