### PR TITLE
fix isp npe in AlertFormatter

### DIFF
--- a/src/main/java/com/mozilla/secops/alert/AlertFormatter.java
+++ b/src/main/java/com/mozilla/secops/alert/AlertFormatter.java
@@ -50,9 +50,15 @@ public class AlertFormatter extends DoFn<Alert, String> {
             && a.getMetadataValue(addressField + "_as_org") == null) {
           IspResponse ir = geoip.lookupIsp(address);
           if (ir != null) {
-            a.addMetadata(addressField + "_isp", ir.getIsp());
-            a.addMetadata(addressField + "_asn", ir.getAutonomousSystemNumber().toString());
-            a.addMetadata(addressField + "_as_org", ir.getAutonomousSystemOrganization());
+            if (ir.getIsp() != null) {
+              a.addMetadata(addressField + "_isp", ir.getIsp());
+            }
+            if (ir.getAutonomousSystemNumber() != null) {
+              a.addMetadata(addressField + "_asn", ir.getAutonomousSystemNumber().toString());
+            }
+            if (ir.getAutonomousSystemOrganization() != null) {
+              a.addMetadata(addressField + "_as_org", ir.getAutonomousSystemOrganization());
+            }
           }
         }
       }


### PR DESCRIPTION
Fixes a null pointer exception that can occur if the ISP response is
non-null but contains partial information (getAutonomousSystemNumber may
still return null).