### PR TITLE
update jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,12 +122,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.8</version>
+            <version>2.9.9</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-joda</artifactId>
-	    <version>2.9.8</version>
+	    <version>2.9.9</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
Update jackson to 2.9.9 to address CVE-2019-12086.