### PR TITLE
dont handle timestamps in event filter

### DIFF
--- a/src/main/java/com/mozilla/secops/InputOptions.java
+++ b/src/main/java/com/mozilla/secops/InputOptions.java
@@ -2,11 +2,18 @@ package com.mozilla.secops;
 
 import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubOptions;
+import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.options.PipelineOptions;
 
 /** Standard input options for pipelines. */
 public interface InputOptions extends PipelineOptions, PubsubOptions, GcpOptions {
+  @Description("Use event timestamps on output in parser DoFn")
+  @Default.Boolean(false)
+  Boolean getUseEventTimestamp();
+
+  void setUseEventTimestamp(Boolean value);
+
   @Description("Read from Pubsub (multiple allowed); Pubsub topic")
   String[] getInputPubsub();
 

--- a/src/main/java/com/mozilla/secops/customs/CustomsCfg.java
+++ b/src/main/java/com/mozilla/secops/customs/CustomsCfg.java
@@ -2,7 +2,6 @@ package com.mozilla.secops.customs;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.mozilla.secops.parser.eventfiltercfg.EventFilterCfg;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
@@ -53,18 +52,6 @@ public class CustomsCfg implements Serializable {
   @JsonProperty("detectors")
   public Map<String, CustomsCfgEntry> getDetectors() {
     return detectors;
-  }
-
-  /**
-   * Override timestamp emission settings for all detectors
-   *
-   * @param flag True to enable timestamp emission, false to disable
-   */
-  public void setTimestampOverride(Boolean flag) {
-    for (CustomsCfgEntry entry : detectors.values()) {
-      EventFilterCfg efc = entry.getEventFilterCfg();
-      efc.setTimestampOverride(flag);
-    }
   }
 
   public CustomsCfg() {

--- a/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
+++ b/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
@@ -71,7 +71,6 @@ public class HTTPRequest implements Serializable {
   public static class Parse extends PTransform<PCollection<String>, PCollection<Event>> {
     private static final long serialVersionUID = 1L;
 
-    private final Boolean emitEventTimestamps;
     private final String stackdriverProjectFilter;
     private final String[] filterRequestPath;
     private final String[] stackdriverLabelFilters;
@@ -87,7 +86,6 @@ public class HTTPRequest implements Serializable {
      * @param options Pipeline options
      */
     public Parse(HTTPRequestOptions options) {
-      emitEventTimestamps = options.getUseEventTimestamp();
       stackdriverProjectFilter = options.getStackdriverProjectFilter();
       stackdriverLabelFilters = options.getStackdriverLabelFilters();
       filterRequestPath = options.getFilterRequestPath();
@@ -100,8 +98,7 @@ public class HTTPRequest implements Serializable {
 
     @Override
     public PCollection<Event> expand(PCollection<String> col) {
-      EventFilter filter =
-          new EventFilter().setWantUTC(true).setOutputWithTimestamp(emitEventTimestamps);
+      EventFilter filter = new EventFilter().setWantUTC(true);
       EventFilterRule rule = new EventFilterRule().wantNormalizedType(Normalized.Type.HTTP_REQUEST);
       if (stackdriverProjectFilter != null) {
         rule.wantStackdriverProject(stackdriverProjectFilter);
@@ -1126,12 +1123,6 @@ public class HTTPRequest implements Serializable {
     String[] getIncludeUrlHostRegex();
 
     void setIncludeUrlHostRegex(String[] value);
-
-    @Description("Use timestamp parsed from event instead of timestamp set in input transform")
-    @Default.Boolean(false)
-    Boolean getUseEventTimestamp();
-
-    void setUseEventTimestamp(Boolean value);
 
     @Description("Load CIDR exclusion list; resource path, gcs path")
     String getCidrExclusionList();

--- a/src/main/java/com/mozilla/secops/parser/EventFilter.java
+++ b/src/main/java/com/mozilla/secops/parser/EventFilter.java
@@ -17,7 +17,6 @@ public class EventFilter implements Serializable {
   private ArrayList<EventFilterRule> keySelectors;
 
   private Boolean wantUTC;
-  private Boolean outputWithTimestamp;
   private Boolean matchAny; // If true, match on any input event
 
   private static final String keyChar = " ";
@@ -45,11 +44,7 @@ public class EventFilter implements Serializable {
                   public void processElement(ProcessContext c) {
                     Event e = c.element();
                     if (filter.matches(e)) {
-                      if (filter.getOutputWithTimestamp()) {
-                        c.outputWithTimestamp(e, e.getTimestamp().toInstant());
-                      } else {
-                        c.output(e);
-                      }
+                      c.output(e);
                     }
                   }
                 }));
@@ -172,26 +167,6 @@ public class EventFilter implements Serializable {
   }
 
   /**
-   * Set timestamp handling for event output
-   *
-   * @param flag If true use event timestamp on output
-   * @return EventFilter for chaining
-   */
-  public EventFilter setOutputWithTimestamp(Boolean flag) {
-    outputWithTimestamp = flag;
-    return this;
-  }
-
-  /**
-   * Get timestamp handling for event output
-   *
-   * @return True if events should be emitted with timestamp
-   */
-  public Boolean getOutputWithTimestamp() {
-    return outputWithTimestamp;
-  }
-
-  /**
    * Choose to ignore non-UTC timezone events
    *
    * @param flag If true, drop events with parsed timezones that are not UTC
@@ -222,6 +197,5 @@ public class EventFilter implements Serializable {
     keySelectors = new ArrayList<EventFilterRule>();
     wantUTC = false;
     matchAny = false;
-    outputWithTimestamp = false;
   }
 }

--- a/src/main/java/com/mozilla/secops/parser/ParserCfg.java
+++ b/src/main/java/com/mozilla/secops/parser/ParserCfg.java
@@ -15,6 +15,7 @@ public class ParserCfg implements Serializable {
   private String fastMatcher;
   private ArrayList<String> xffAddressSelectorSubnets;
   private String idmanagerPath;
+  private Boolean useEventTimestamp;
 
   /**
    * Create a parser configuration from pipeline {@link InputOptions}
@@ -24,6 +25,7 @@ public class ParserCfg implements Serializable {
    */
   public static ParserCfg fromInputOptions(InputOptions options) {
     ParserCfg cfg = new ParserCfg();
+    cfg.setUseEventTimestamp(options.getUseEventTimestamp());
     cfg.setMaxmindCityDbPath(options.getMaxmindCityDbPath());
     cfg.setMaxmindIspDbPath(options.getMaxmindIspDbPath());
     cfg.setIdentityManagerPath(options.getIdentityManagerPath());
@@ -156,6 +158,29 @@ public class ParserCfg implements Serializable {
    */
   public void setParserFastMatcher(String fastMatcher) {
     this.fastMatcher = fastMatcher;
+  }
+
+  /**
+   * Get event timestamp emission setting
+   *
+   * @return Boolean
+   */
+  public Boolean getUseEventTimestamp() {
+    return useEventTimestamp;
+  }
+
+  /**
+   * Set event timestamp emission setting
+   *
+   * <p>This option is only applicable when the parser is being used within {@link ParserDoFn}.
+   *
+   * <p>If true, events will be output in the pipeline using the timestamp within the event rather
+   * than the default timestamp that would be assigned.
+   *
+   * @param useEventTimestamp Boolean
+   */
+  public void setUseEventTimestamp(Boolean useEventTimestamp) {
+    this.useEventTimestamp = useEventTimestamp;
   }
 
   /** Construct default parser configuration */

--- a/src/main/java/com/mozilla/secops/parser/ParserDoFn.java
+++ b/src/main/java/com/mozilla/secops/parser/ParserDoFn.java
@@ -53,12 +53,12 @@ public class ParserDoFn extends DoFn<String, Event> {
         if (!(inlineFilter.matches(e))) {
           return;
         }
-        if (inlineFilter.getOutputWithTimestamp()) {
-          c.outputWithTimestamp(e, e.getTimestamp().toInstant());
-          return;
-        }
       }
-      c.output(e);
+      if ((cfg != null) && cfg.getUseEventTimestamp()) {
+        c.outputWithTimestamp(e, e.getTimestamp().toInstant());
+      } else {
+        c.output(e);
+      }
     }
   }
 }

--- a/src/main/java/com/mozilla/secops/parser/eventfiltercfg/EventFilterCfg.java
+++ b/src/main/java/com/mozilla/secops/parser/eventfiltercfg/EventFilterCfg.java
@@ -78,7 +78,6 @@ class FilterCfg implements Serializable {
 
   private ArrayList<FilterRule> filterRules;
   private ArrayList<FilterRule> keyingRules;
-  private Boolean outputWithTimestamp;
 
   @JsonProperty("rules")
   public ArrayList<FilterRule> getFilterRules() {
@@ -88,11 +87,6 @@ class FilterCfg implements Serializable {
   @JsonProperty("keying")
   public ArrayList<FilterRule> getKeyingRules() {
     return keyingRules;
-  }
-
-  @JsonProperty("output_with_timestamp")
-  public Boolean getOutputWithTimestamp() {
-    return outputWithTimestamp;
   }
 
   /** Validate filter configuration */
@@ -106,7 +100,6 @@ class FilterCfg implements Serializable {
   }
 
   FilterCfg() {
-    outputWithTimestamp = false;
     filterRules = new ArrayList<FilterRule>();
     keyingRules = new ArrayList<FilterRule>();
   }
@@ -142,15 +135,6 @@ public class EventFilterCfg implements Serializable {
     for (FilterCfg cfg : filterCfgs.values()) {
       cfg.validate();
     }
-  }
-
-  /**
-   * Set to manually override timestamp emission setting in filter configuration
-   *
-   * @param flag True to emit with timestamps, false to disable
-   */
-  public void setTimestampOverride(Boolean flag) {
-    timestampOverride = flag;
   }
 
   @SuppressWarnings("unchecked")
@@ -206,12 +190,7 @@ public class EventFilterCfg implements Serializable {
       return null;
     }
 
-    EventFilter ret;
-    if (timestampOverride == null) {
-      ret = new EventFilter().setOutputWithTimestamp(cfg.getOutputWithTimestamp());
-    } else {
-      ret = new EventFilter().setOutputWithTimestamp(timestampOverride);
-    }
+    EventFilter ret = new EventFilter();
 
     for (FilterRule rule : cfg.getFilterRules()) {
       ret.addRule(processRuleConfiguration(rule));

--- a/src/main/resources/customs/customsdefault.json
+++ b/src/main/resources/customs/customsdefault.json
@@ -8,7 +8,6 @@
             "filter": {
                 "filters": {
                     "default": {
-                        "output_with_timestamp": false,
                         "rules": [
                             {
                                 "subtype": "FXAAUTH",
@@ -50,7 +49,6 @@
             "filter": {
                 "filters": {
                     "default": {
-                        "output_with_timestamp": false,
                         "rules": [
                             {
                                 "subtype": "FXAAUTH",
@@ -91,7 +89,6 @@
             "filter": {
                 "filters": {
                     "default": {
-                        "output_with_timestamp": false,
                         "rules": [
                             {
                                 "subtype": "FXAAUTH",
@@ -132,7 +129,6 @@
             "filter": {
                 "filters": {
                     "default": {
-                        "output_with_timestamp": false,
                         "rules": [
                             {
                                 "subtype": "FXAAUTH",
@@ -173,7 +169,6 @@
             "filter": {
                 "filters": {
                     "default": {
-                        "output_with_timestamp": false,
                         "rules": [
                             {
                                 "subtype": "FXAAUTH",
@@ -214,7 +209,6 @@
             "filter": {
                 "filters": {
                     "default": {
-                        "output_with_timestamp": false,
                         "rules": [
                             {
                                 "subtype": "FXAAUTH",

--- a/src/test/java/com/mozilla/secops/customs/TestCustoms.java
+++ b/src/test/java/com/mozilla/secops/customs/TestCustoms.java
@@ -28,6 +28,7 @@ public class TestCustoms {
 
   private Customs.CustomsOptions getTestOptions() {
     Customs.CustomsOptions ret = PipelineOptionsFactory.as(Customs.CustomsOptions.class);
+    ret.setUseEventTimestamp(true);
     ret.setMonitoredResourceIndicator("test");
     ret.setMaxmindCityDbPath(ParserTest.TEST_GEOIP_DBPATH);
     return ret;
@@ -72,8 +73,6 @@ public class TestCustoms {
             .advanceWatermarkToInfinity();
 
     CustomsCfg cfg = CustomsCfg.loadFromResource("/customs/customsdefault.json");
-    // Force use of event timestamp for testing purposes
-    cfg.setTimestampOverride(true);
 
     // Should create two alerts given the sliding window configuration, however one will
     // be suppressed
@@ -115,8 +114,6 @@ public class TestCustoms {
   @Test
   public void rlLoginFailureSourceAddressTestStream() throws Exception {
     CustomsCfg cfg = CustomsCfg.loadFromResource("/customs/customsdefault.json");
-    // Force use of event timestamp for testing purposes
-    cfg.setTimestampOverride(true);
 
     String[] eb1 = TestUtil.getTestInputArray("/testdata/customs_rl_badlogin_simple1.txt");
     String[] eb2 = TestUtil.getTestInputArray("/testdata/customs_rl_badlogin_simple2.txt");
@@ -160,8 +157,6 @@ public class TestCustoms {
   @Test
   public void rlLoginFailureSourceAddressSuppressTestStream() throws Exception {
     CustomsCfg cfg = CustomsCfg.loadFromResource("/customs/customsdefault.json");
-    // Force use of event timestamp for testing purposes
-    cfg.setTimestampOverride(true);
 
     String[] eb1 = TestUtil.getTestInputArray("/testdata/customs_rl_badlogin_simple1.txt");
     String[] eb2 = TestUtil.getTestInputArray("/testdata/customs_rl_badlogin_suppress.txt");
@@ -194,8 +189,6 @@ public class TestCustoms {
             .advanceWatermarkToInfinity();
 
     CustomsCfg cfg = CustomsCfg.loadFromResource("/customs/customsdefault.json");
-    // Force use of event timestamp for testing purposes
-    cfg.setTimestampOverride(true);
 
     PCollection<Alert> alerts = Customs.executePipeline(p, p.apply(s), getTestOptions());
 
@@ -221,8 +214,6 @@ public class TestCustoms {
             .advanceWatermarkToInfinity();
 
     CustomsCfg cfg = CustomsCfg.loadFromResource("/customs/customsdefault.json");
-    // Force use of event timestamp for testing purposes
-    cfg.setTimestampOverride(true);
 
     Customs.CustomsOptions options = getTestOptions();
     options.setEnableRateLimitDetectors(false);
@@ -265,8 +256,6 @@ public class TestCustoms {
             .advanceWatermarkToInfinity();
 
     CustomsCfg cfg = CustomsCfg.loadFromResource("/customs/customsdefault.json");
-    // Force use of event timestamp for testing purposes
-    cfg.setTimestampOverride(true);
 
     Customs.CustomsOptions options = getTestOptions();
     options.setEnableRateLimitDetectors(false);


### PR DESCRIPTION
Currently the setting associated with using the event timestamp during
pipeline stage emission is set within the event filter.

Change this so the setting is associated with ParserDoFn and happens
early in the process, since it shouldn't be associated with event
filtering at all.

This also makes it simpler to enable/disable as it just becomes an input
option.