### PR TITLE
GuardDuty Finding Parser + CloudWatch Event Wrapper Functions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,12 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-sqs</artifactId>
-            <version>1.11.255</version>
+            <version>1.11.571</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-guardduty</artifactId>
+            <version>1.11.571</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>

--- a/src/main/java/com/mozilla/secops/parser/GuardDuty.java
+++ b/src/main/java/com/mozilla/secops/parser/GuardDuty.java
@@ -1,0 +1,82 @@
+package com.mozilla.secops.parser;
+
+import com.amazonaws.services.guardduty.model.Finding;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mozilla.secops.parser.models.cloudwatch.CloudWatchEvent;
+import java.io.IOException;
+import java.io.Serializable;
+
+/** Payload parser for AWS GuardDuty Finding data */
+public class GuardDuty extends PayloadBase implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+  private static final String CLOUDWATCH_EVENT_SOURCE = "aws.guardduty";
+
+  private static ObjectMapper mapper =
+      new ObjectMapper()
+          // our input JSON may have properties not represented in {@link Finding} e.g. ignore
+          // errors such as 'Unrecognized field "affectedResources"....'
+          .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+  private Finding gdf;
+
+  @Override
+  public Boolean matcher(String input, ParserState state) {
+    CloudWatchEvent cwe = state.getCloudWatchEvent();
+    if (cwe != null && cwe.getSource() != null) {
+      return (cwe.getSource().equals(CLOUDWATCH_EVENT_SOURCE));
+    }
+    // we do not expect to get GuardDuty Findings outside of a CloudWatchEvent event
+    // wrapper, and thus we do not expect to reach the code below often
+    //
+    // It is included as an effort to maintain consistent behavior across the parsers
+    try {
+      Finding f = mapper.readValue(input, Finding.class);
+      // the AWS GD Finding JSON model does not have -ANY- mandatory JSON fields, and thus we
+      // check that the finding has certain GuardDuty-specific fields set.
+      // Not doing so results in a generic JSON payload successfully being read onto a Finding.
+      // All Findings will contain an associated finding type, ARN, account ID, title, and
+      // description
+      return ((f != null)
+          && (f.getType() != null)
+          && (f.getArn() != null)
+          && (f.getAccountId() != null)
+          && (f.getTitle() != null)
+          && (f.getDescription() != null));
+    } catch (IOException exc) {
+      return false;
+    }
+  }
+
+  @Override
+  public Payload.PayloadType getType() {
+    return Payload.PayloadType.GUARDDUTY;
+  }
+
+  /**
+   * Get underlying GuardDuty Finding
+   *
+   * @return {@link Finding}
+   */
+  public Finding getFinding() {
+    return gdf;
+  }
+
+  /** Construct matcher object. */
+  public GuardDuty() {}
+
+  /**
+   * Construct parser object.
+   *
+   * @param input Input string
+   */
+  public GuardDuty(String input, Event e, ParserState s) {
+    try {
+      gdf = mapper.readValue(input, Finding.class);
+    } catch (IOException exc) {
+      // pass
+    }
+    return;
+  }
+}

--- a/src/main/java/com/mozilla/secops/parser/ParserState.java
+++ b/src/main/java/com/mozilla/secops/parser/ParserState.java
@@ -1,11 +1,13 @@
 package com.mozilla.secops.parser;
 
 import com.google.api.services.logging.v2.model.LogEntry;
+import com.mozilla.secops.parser.models.cloudwatch.CloudWatchEvent;
 
 /** Stores per-event state of parser */
 class ParserState {
   private final Parser parser;
   private LogEntry logEntryHint;
+  private CloudWatchEvent cloudwatchEvent;
   private Mozlog mozLogHint;
   private com.google.api.client.json.jackson2.JacksonFactory googleJacksonFactory;
 
@@ -25,6 +27,24 @@ class ParserState {
    */
   public void setLogEntryHint(LogEntry entry) {
     logEntryHint = entry;
+  }
+
+  /**
+   * Get cloudwatch event value
+   *
+   * @return {@link CloudWatchEvent} value or null if not available
+   */
+  public CloudWatchEvent getCloudWatchEvent() {
+    return cloudwatchEvent;
+  }
+
+  /**
+   * Set cloudwatch event value
+   *
+   * @param cwe CloudWatchEvent encapsulating generic AWS event
+   */
+  public void setCloudWatchEvent(CloudWatchEvent cwe) {
+    this.cloudwatchEvent = cwe;
   }
 
   /**

--- a/src/main/java/com/mozilla/secops/parser/Payload.java
+++ b/src/main/java/com/mozilla/secops/parser/Payload.java
@@ -12,6 +12,8 @@ public class Payload<T extends PayloadBase> implements Serializable {
     GLB,
     /** AWS CloudTrail */
     CLOUDTRAIL,
+    /** AWS GuardDuty */
+    GUARDDUTY,
     /** OpenSSH */
     OPENSSH,
     /** Duopull */

--- a/src/main/java/com/mozilla/secops/parser/models/cloudwatch/CloudWatchEvent.java
+++ b/src/main/java/com/mozilla/secops/parser/models/cloudwatch/CloudWatchEvent.java
@@ -1,0 +1,124 @@
+package com.mozilla.secops.parser.models.cloudwatch;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.Serializable;
+import java.util.ArrayList;
+
+/**
+ * Describes the format of an AWS CloudWatch Event
+ *
+ * <p>See also
+ * https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/CloudWatchEventsandEventPatterns.html
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CloudWatchEvent implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  private String version;
+  private String id;
+  private String detailType;
+  private String source;
+  private String account;
+  private String time;
+  private String region;
+  private ArrayList<String> resources;
+  private Object detail;
+
+  /**
+   * Get event message version
+   *
+   * @return String
+   */
+  @JsonProperty("version")
+  public String getVersion() {
+    return version;
+  }
+
+  /**
+   * Get event id
+   *
+   * @return String
+   */
+  @JsonProperty("id")
+  public String getId() {
+    return id;
+  }
+
+  /**
+   * Get event detail type, e.g. GuardDuty Finding, AWS Health Event, etc...
+   *
+   * <p>See also https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/EventTypes.html
+   *
+   * @return String source ip
+   */
+  @JsonProperty("detail-type")
+  public String getDetailType() {
+    return detailType;
+  }
+
+  /**
+   * Get event source service, e.g. aws.guardduty, aws.ec2, etc...
+   *
+   * @return String
+   */
+  @JsonProperty("source")
+  public String getSource() {
+    return source;
+  }
+
+  /**
+   * Get event AWS account id
+   *
+   * @return String
+   */
+  @JsonProperty("account")
+  public String getAccount() {
+    return account;
+  }
+
+  /**
+   * Get event timestamp
+   *
+   * @return String
+   */
+  @JsonProperty("time")
+  public String getTime() {
+    return time;
+  }
+
+  /**
+   * Get event AWS region
+   *
+   * @return String
+   */
+  @JsonProperty("region")
+  public String getRegion() {
+    return region;
+  }
+
+  /**
+   * Get event resources, typically in the form of ARNs
+   *
+   * @return ArrayList<String>
+   */
+  @JsonProperty("resources")
+  public ArrayList<String> getResources() {
+    return resources;
+  }
+
+  /**
+   * Get event detail
+   *
+   * <p>This is a JSON format payload which must be parsed further in accordance to the "source" or
+   * "detail-type" of the CloudWatch Event
+   *
+   * @return Object
+   */
+  @JsonProperty("detail")
+  public Object getDetail() {
+    return detail;
+  }
+
+  public CloudWatchEvent() {}
+}

--- a/src/main/java/com/mozilla/secops/parser/models/cloudwatch/package-info.java
+++ b/src/main/java/com/mozilla/secops/parser/models/cloudwatch/package-info.java
@@ -1,0 +1,2 @@
+/** generic JSON model for AWS CloudWatch events */
+package com.mozilla.secops.parser.models.cloudwatch;

--- a/src/test/java/com/mozilla/secops/TestCidrUtil.java
+++ b/src/test/java/com/mozilla/secops/TestCidrUtil.java
@@ -42,8 +42,8 @@ public class TestCidrUtil {
   @Test
   public void resolvedHostMatchesTest() throws Exception {
     assertFalse(CidrUtil.resolvedCanonicalHostMatches("8.8.8.8", "test"));
-    assertTrue(CidrUtil.resolvedCanonicalHostMatches("8.8.8.8", ".*google.com$"));
-    assertFalse(CidrUtil.resolvedCanonicalHostMatches("127.0.0.1", ".*google.com$"));
+    assertTrue(CidrUtil.resolvedCanonicalHostMatches("8.8.8.8", "dns\\.google$"));
+    assertFalse(CidrUtil.resolvedCanonicalHostMatches("127.0.0.1", "dns\\.google$"));
     assertFalse(CidrUtil.resolvedCanonicalHostMatches("0.0.0.0", ".*"));
   }
 


### PR DESCRIPTION
...opened after closing https://github.com/mozilla-services/foxsec-pipeline/pull/157

### In This PR:
* A parser for GuardDuty Findings
* A JSON model for a CloudWatchEvent (since the AWS sdk does not have one)
* Functions to remove the wrapping cloudwatch event from GuardDuty Findings (and other aws service events / input wrapped in cloudwatch fields)

