### PR TITLE
use JacksonFactory from parser state for nginx

### DIFF
--- a/src/main/java/com/mozilla/secops/parser/Nginx.java
+++ b/src/main/java/com/mozilla/secops/parser/Nginx.java
@@ -19,7 +19,7 @@ import org.joda.time.DateTime;
 public class Nginx extends PayloadBase implements Serializable {
   private static final long serialVersionUID = 1L;
 
-  private final JacksonFactory jfmatcher;
+  private final transient JacksonFactory jfmatcher;
 
   private String xForwardedProto;
   private String remoteAddr;
@@ -108,7 +108,7 @@ public class Nginx extends PayloadBase implements Serializable {
     if (entry == null) {
       // Use method local JacksonFactory as the object is not serializable, and this event
       // may be passed around
-      JacksonFactory jf = new JacksonFactory();
+      JacksonFactory jf = state.getGoogleJacksonFactory();
       try {
         JsonParser jp = jf.createJsonParser(input);
         entry = jp.parse(LogEntry.class);


### PR DESCRIPTION
Use JacksonFactory from parser state to avoid needing to reallocate it
each time when processing nginx logs.

Also mark JacksonFactory field that is used by matcher as transient in
object.