### PR TITLE
Refactor ETDFinding subclasses + override equals and hashcode

### DIFF
--- a/src/main/java/com/mozilla/secops/parser/models/etd/DetectionCategory.java
+++ b/src/main/java/com/mozilla/secops/parser/models/etd/DetectionCategory.java
@@ -1,0 +1,59 @@
+package com.mozilla.secops.parser.models.etd;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.Serializable;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DetectionCategory implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  private String indicator;
+  private String ruleName;
+  private String technique;
+
+  /**
+   * Get indicator
+   *
+   * @return String
+   */
+  @JsonProperty("indicator")
+  public String getIndicator() {
+    return indicator;
+  }
+
+  /**
+   * Get rule name which triggered finding
+   *
+   * @return String
+   */
+  @JsonProperty("ruleName")
+  public String getRuleName() {
+    return ruleName;
+  }
+
+  /**
+   * Get bad-actor's suspected technique, i.e. "Malware", "Bruteforce", etc...
+   *
+   * @return String
+   */
+  @JsonProperty("technique")
+  public String getTechnique() {
+    return technique;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    DetectionCategory dc = (DetectionCategory) o;
+    return dc.getIndicator().equals(indicator)
+        && dc.getRuleName().equals(ruleName)
+        && dc.getTechnique().equals(technique);
+  }
+
+  @Override
+  public int hashCode() {
+    return indicator.hashCode();
+  }
+
+  public DetectionCategory() {}
+}

--- a/src/main/java/com/mozilla/secops/parser/models/etd/EventThreatDetectionFinding.java
+++ b/src/main/java/com/mozilla/secops/parser/models/etd/EventThreatDetectionFinding.java
@@ -10,195 +10,6 @@ import java.util.ArrayList;
 public class EventThreatDetectionFinding implements Serializable {
   private static final long serialVersionUID = 1L;
 
-  @JsonIgnoreProperties(ignoreUnknown = true)
-  public class DetectionCategory implements Serializable {
-    private static final long serialVersionUID = 1L;
-
-    private String indicator;
-    private String ruleName;
-    private String technique;
-
-    /**
-     * Get indicator
-     *
-     * @return String
-     */
-    @JsonProperty("indicator")
-    public String getIndicator() {
-      return indicator;
-    }
-
-    /**
-     * Get rule name which triggered finding
-     *
-     * @return String
-     */
-    @JsonProperty("ruleName")
-    public String getRuleName() {
-      return ruleName;
-    }
-
-    /**
-     * Get bad-actor's suspected technique, i.e. "Malware", "Bruteforce", etc...
-     *
-     * @return String
-     */
-    @JsonProperty("technique")
-    public String getTechnique() {
-      return technique;
-    }
-
-    public DetectionCategory() {}
-  }
-
-  @JsonIgnoreProperties(ignoreUnknown = true)
-  public static class Evidence implements Serializable {
-    private static final long serialVersionUID = 1L;
-
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    public class SourceLogId implements Serializable {
-      private static final long serialVersionUID = 1L;
-
-      private String insertId;
-      private String timestamp;
-
-      /**
-       * Get insert id
-       *
-       * @return String
-       */
-      @JsonProperty("insertId")
-      public String getInsertId() {
-        return insertId;
-      }
-
-      /**
-       * Get timestamp
-       *
-       * @return String
-       */
-      @JsonProperty("timestamp")
-      public String getTimestamp() {
-        return timestamp;
-      }
-
-      public SourceLogId() {}
-    }
-
-    private SourceLogId sourceLogId;
-
-    @JsonProperty("sourceLogId")
-    public SourceLogId getSourceLogId() {
-      return sourceLogId;
-    }
-
-    public Evidence() {}
-  }
-
-  @JsonIgnoreProperties(ignoreUnknown = true)
-  public class Properties implements Serializable {
-    private static final long serialVersionUID = 1L;
-
-    private String ip;
-    private String location;
-    private String project_id;
-    private String subnetwork_id;
-    private String subnetwork_name;
-    private ArrayList<String> domain;
-
-    /**
-     * Get IP
-     *
-     * @return String
-     */
-    @JsonProperty("ip")
-    public String getIp() {
-      return ip;
-    }
-
-    /**
-     * Get GCP location (analogous to AWS region)
-     *
-     * @return String
-     */
-    @JsonProperty("location")
-    public String getLocation() {
-      return location;
-    }
-
-    /**
-     * Get GCP project id for ETD
-     *
-     * @return String
-     */
-    @JsonProperty("project_id")
-    public String getProject_id() {
-      return project_id;
-    }
-
-    /**
-     * Get subnet id
-     *
-     * @return String
-     */
-    @JsonProperty("subnetwork_id")
-    public String getSubnetwork_id() {
-      return subnetwork_id;
-    }
-
-    /**
-     * Get subnet name
-     *
-     * @return String
-     */
-    @JsonProperty("subnetwork_name")
-    public String getSubnetwork_name() {
-      return subnetwork_name;
-    }
-
-    /**
-     * Get domain list
-     *
-     * @return ArrayList<String>
-     */
-    @JsonProperty("domain")
-    public ArrayList<String> getDomain() {
-      return domain;
-    }
-
-    public Properties() {}
-  }
-
-  @JsonIgnoreProperties(ignoreUnknown = true)
-  public class SourceId implements Serializable {
-    private static final long serialVersionUID = 1L;
-
-    private String customerOrganizationNumber;
-    private String projectId;
-
-    /**
-     * Get GCP org number
-     *
-     * @return String
-     */
-    @JsonProperty("customerOrganizationNumber")
-    public String getCustomerOrganizationNumber() {
-      return customerOrganizationNumber;
-    }
-
-    /**
-     * Get GCP project id for source of Finding
-     *
-     * @return String
-     */
-    @JsonProperty("projectId")
-    public String getProjectId() {
-      return projectId;
-    }
-
-    public SourceId() {}
-  }
-
   private String detectionPriority;
   private String eventTime;
   private DetectionCategory detectionCategory;
@@ -264,6 +75,17 @@ public class EventThreatDetectionFinding implements Serializable {
   @JsonProperty("sourceId")
   public SourceId getSourceId() {
     return sourceId;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    EventThreatDetectionFinding etdf = (EventThreatDetectionFinding) o;
+    return etdf.getEventTime().equals(eventTime) && (etdf.getEvidence().equals(evidence));
+  }
+
+  @Override
+  public int hashCode() {
+    return evidence.hashCode();
   }
 
   public EventThreatDetectionFinding() {}

--- a/src/main/java/com/mozilla/secops/parser/models/etd/Evidence.java
+++ b/src/main/java/com/mozilla/secops/parser/models/etd/Evidence.java
@@ -1,0 +1,30 @@
+package com.mozilla.secops.parser.models.etd;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.Serializable;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Evidence implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  private SourceLogId sourceLogId;
+
+  @JsonProperty("sourceLogId")
+  public SourceLogId getSourceLogId() {
+    return sourceLogId;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    Evidence ev = (Evidence) o;
+    return ev.getSourceLogId().equals(sourceLogId);
+  }
+
+  @Override
+  public int hashCode() {
+    return sourceLogId.hashCode();
+  }
+
+  public Evidence() {}
+}

--- a/src/main/java/com/mozilla/secops/parser/models/etd/Properties.java
+++ b/src/main/java/com/mozilla/secops/parser/models/etd/Properties.java
@@ -1,0 +1,97 @@
+package com.mozilla.secops.parser.models.etd;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.Serializable;
+import java.util.ArrayList;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Properties implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  private String ip;
+  private String location;
+  private String project_id;
+  private String subnetwork_id;
+  private String subnetwork_name;
+  private ArrayList<String> domain;
+
+  /**
+   * Get IP
+   *
+   * @return String
+   */
+  @JsonProperty("ip")
+  public String getIp() {
+    return ip;
+  }
+
+  /**
+   * Get GCP location (analogous to AWS region)
+   *
+   * @return String
+   */
+  @JsonProperty("location")
+  public String getLocation() {
+    return location;
+  }
+
+  /**
+   * Get GCP project id for ETD
+   *
+   * @return String
+   */
+  @JsonProperty("project_id")
+  public String getProject_id() {
+    return project_id;
+  }
+
+  /**
+   * Get subnet id
+   *
+   * @return String
+   */
+  @JsonProperty("subnetwork_id")
+  public String getSubnetwork_id() {
+    return subnetwork_id;
+  }
+
+  /**
+   * Get subnet name
+   *
+   * @return String
+   */
+  @JsonProperty("subnetwork_name")
+  public String getSubnetwork_name() {
+    return subnetwork_name;
+  }
+
+  /**
+   * Get domain list
+   *
+   * @return ArrayList<String>
+   */
+  @JsonProperty("domain")
+  public ArrayList<String> getDomain() {
+    return domain;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    Properties pr = (Properties) o;
+    return pr.getProject_id().equals(project_id)
+        && pr.getLocation().equals(location)
+        && pr.getSubnetwork_id().equals(subnetwork_id)
+        && pr.getSubnetwork_name().equals(subnetwork_name);
+  }
+
+  @Override
+  public int hashCode() {
+    return project_id.hashCode()
+        * location.hashCode()
+        * subnetwork_id.hashCode()
+        * subnetwork_id.hashCode();
+  }
+
+  public Properties() {}
+}

--- a/src/main/java/com/mozilla/secops/parser/models/etd/SourceId.java
+++ b/src/main/java/com/mozilla/secops/parser/models/etd/SourceId.java
@@ -1,0 +1,47 @@
+package com.mozilla.secops.parser.models.etd;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.Serializable;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SourceId implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  private String customerOrganizationNumber;
+  private String projectId;
+
+  /**
+   * Get GCP org number
+   *
+   * @return String
+   */
+  @JsonProperty("customerOrganizationNumber")
+  public String getCustomerOrganizationNumber() {
+    return customerOrganizationNumber;
+  }
+
+  /**
+   * Get GCP project id for source of Finding
+   *
+   * @return String
+   */
+  @JsonProperty("projectId")
+  public String getProjectId() {
+    return projectId;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    SourceId sid = (SourceId) o;
+    return sid.getCustomerOrganizationNumber().equals(customerOrganizationNumber)
+        && sid.getProjectId().equals(projectId);
+  }
+
+  @Override
+  public int hashCode() {
+    return customerOrganizationNumber.hashCode() * projectId.hashCode();
+  }
+
+  public SourceId() {}
+}

--- a/src/main/java/com/mozilla/secops/parser/models/etd/SourceLogId.java
+++ b/src/main/java/com/mozilla/secops/parser/models/etd/SourceLogId.java
@@ -1,0 +1,46 @@
+package com.mozilla.secops.parser.models.etd;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.Serializable;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SourceLogId implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  private String insertId;
+  private String timestamp;
+
+  /**
+   * Get insert id
+   *
+   * @return String
+   */
+  @JsonProperty("insertId")
+  public String getInsertId() {
+    return insertId;
+  }
+
+  /**
+   * Get timestamp
+   *
+   * @return String
+   */
+  @JsonProperty("timestamp")
+  public String getTimestamp() {
+    return timestamp;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    SourceLogId sli = (SourceLogId) o;
+    return sli.getInsertId().equals(insertId) && sli.getTimestamp().equals(timestamp);
+  }
+
+  @Override
+  public int hashCode() {
+    return insertId.hashCode();
+  }
+
+  public SourceLogId() {}
+}


### PR DESCRIPTION
* Moving all the inner classes inside the EventThreatDetectionFinding object out to different files for readability
* Override equals and hashcode for etd object + inner classes to allow us to construct PCollection<EventThreatDetectionFinding> without having to deal with the warning message:

```
WARNING: Coder of type class org.apache.beam.sdk.coders.SerializableCoder has a #structuralValue method which does not return true when the encoding of the elements is equal. Element com.mozilla.secops.parser.models.etd.EventThreatDetectionFinding@4704aed
```