### PR TITLE
SourcePayloadBase, unify GeoIP processing

### DIFF
--- a/src/main/java/com/mozilla/secops/parser/Cloudtrail.java
+++ b/src/main/java/com/mozilla/secops/parser/Cloudtrail.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.api.client.json.JsonParser;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.logging.v2.model.LogEntry;
-import com.maxmind.geoip2.model.CityResponse;
 import com.mozilla.secops.identity.IdentityManager;
 import com.mozilla.secops.parser.models.cloudtrail.CloudtrailEvent;
 import com.mozilla.secops.parser.models.cloudtrail.UserIdentity;
@@ -18,15 +17,12 @@ import java.util.Map;
 import org.joda.time.DateTime;
 
 /** Payload parser for Cloudtrail events */
-public class Cloudtrail extends PayloadBase implements Serializable {
+public class Cloudtrail extends SourcePayloadBase implements Serializable {
   private static final long serialVersionUID = 1L;
 
   private ObjectMapper mapper;
 
   private CloudtrailEvent event;
-
-  private String sourceAddressCity;
-  private String sourceAddressCountry;
 
   @Override
   public Boolean matcher(String input, ParserState state) {
@@ -67,11 +63,14 @@ public class Cloudtrail extends PayloadBase implements Serializable {
           e.setTimestamp(t);
         }
       }
+      // If we have a source address field in the model, pull that into the inherited field
+      if (event.getSourceIPAddress() != null) {
+        setSourceAddress(event.getSourceIPAddress(), state, e.getNormalized());
+      }
       if (isAuthEvent()) {
         Normalized n = e.getNormalized();
         n.setType(Normalized.Type.AUTH);
         n.setSubjectUser(getUser());
-        n.setSourceAddress(getSourceAddress());
         n.setObject(event.getRecipientAccountId());
 
         // TODO: Consider moving identity management into Normalized
@@ -89,16 +88,6 @@ public class Cloudtrail extends PayloadBase implements Serializable {
           String accountName = m.get(event.getRecipientAccountId());
           if (accountName != null) {
             n.setObject(accountName);
-          }
-        }
-
-        if (getSourceAddress() != null) {
-          CityResponse cr = state.getParser().geoIp(getSourceAddress());
-          if (cr != null) {
-            sourceAddressCity = cr.getCity().getName();
-            sourceAddressCountry = cr.getCountry().getIsoCode();
-            n.setSourceAddressCity(sourceAddressCity);
-            n.setSourceAddressCountry(sourceAddressCountry);
           }
         }
       }
@@ -154,33 +143,6 @@ public class Cloudtrail extends PayloadBase implements Serializable {
    */
   public String getUser() {
     return event.getIdentityName();
-  }
-
-  /**
-   * Get source address
-   *
-   * @return Source address
-   */
-  public String getSourceAddress() {
-    return event.getSourceIPAddress();
-  }
-
-  /**
-   * Get source address city field
-   *
-   * @return Source address city string
-   */
-  public String getSourceAddressCity() {
-    return sourceAddressCity;
-  }
-
-  /**
-   * Get source address country field
-   *
-   * @return Source address country string
-   */
-  public String getSourceAddressCountry() {
-    return sourceAddressCountry;
   }
 
   private Boolean isAuthEvent() {

--- a/src/main/java/com/mozilla/secops/parser/Normalized.java
+++ b/src/main/java/com/mozilla/secops/parser/Normalized.java
@@ -23,6 +23,8 @@ public class Normalized implements Serializable {
   private String sourceAddress;
   private String sourceAddressCity;
   private String sourceAddressCountry;
+  private Double sourceAddressLatitude;
+  private Double sourceAddressLongitude;
   private String object;
   private String requestMethod;
   private String requestUrl;
@@ -211,6 +213,42 @@ public class Normalized implements Serializable {
    */
   public void setSourceAddressCountry(String sourceAddressCountry) {
     this.sourceAddressCountry = sourceAddressCountry;
+  }
+
+  /**
+   * Get source address latitude
+   *
+   * @return Source address latitude
+   */
+  public Double getSourceAddressLatitude() {
+    return sourceAddressLatitude;
+  }
+
+  /**
+   * Set source address latitude
+   *
+   * @param sourceAddressLatitude Latitude value
+   */
+  void setSourceAddressLatitude(Double sourceAddressLatitude) {
+    this.sourceAddressLatitude = sourceAddressLatitude;
+  }
+
+  /**
+   * Get source address longitude
+   *
+   * @return Source address longitude
+   */
+  public Double getSourceAddressLongitude() {
+    return sourceAddressLongitude;
+  }
+
+  /**
+   * Set source address longitude
+   *
+   * @param sourceAddressLongitude Longitude value
+   */
+  void setSourceAddressLongitude(Double sourceAddressLongitude) {
+    this.sourceAddressLongitude = sourceAddressLongitude;
   }
 
   /**

--- a/src/main/java/com/mozilla/secops/parser/SourcePayloadBase.java
+++ b/src/main/java/com/mozilla/secops/parser/SourcePayloadBase.java
@@ -1,0 +1,115 @@
+package com.mozilla.secops.parser;
+
+import com.maxmind.geoip2.model.CityResponse;
+
+/**
+ * Extension of {@link PayloadBase} that unifies source address field handling
+ *
+ * <p>Payload types that manipulate some indication of a source address field should likely inherit
+ * from this class.
+ */
+public abstract class SourcePayloadBase extends PayloadBase {
+  private String sourceAddress;
+  private String sourceAddressCity;
+  private String sourceAddressCountry;
+  private Double sourceAddressLatitude;
+  private Double sourceAddressLongitude;
+
+  /**
+   * Set source address field
+   *
+   * <p>If the state value is non-null, this function will also attempt to utilize the parser GeoIP
+   * instance to set the city and country fields.
+   *
+   * <p>If n is non-null, the values will also be mirrored into the normalized event fields.*
+   *
+   * @param sourceAddress Source address
+   * @param state Parser state
+   * @param n Normalized field from base event
+   */
+  public void setSourceAddress(String sourceAddress, ParserState state, Normalized n) {
+    if (sourceAddress == null) {
+      return;
+    }
+    this.sourceAddress = sourceAddress;
+
+    if (state != null) {
+      // If we have parser state attempt to resolve GeoIP information
+      CityResponse cr = state.getParser().geoIp(sourceAddress);
+      if (cr != null) {
+        sourceAddressCity = cr.getCity().getName();
+        sourceAddressCountry = cr.getCountry().getIsoCode();
+
+        if ((cr.getLocation() != null)
+            && (cr.getLocation().getLatitude() != null)
+            && (cr.getLocation().getLongitude() != null)) {
+          sourceAddressLatitude = cr.getLocation().getLatitude();
+          sourceAddressLongitude = cr.getLocation().getLongitude();
+        }
+      }
+    }
+
+    // If our normalized event is non-null, also set information there
+    if (n != null) {
+      n.setSourceAddress(sourceAddress);
+      n.setSourceAddressCity(sourceAddressCity);
+      n.setSourceAddressCountry(sourceAddressCountry);
+      n.setSourceAddressLatitude(sourceAddressLatitude);
+      n.setSourceAddressLongitude(sourceAddressLongitude);
+    }
+  }
+
+  /**
+   * Set source address field
+   *
+   * @param sourceAddress Source address
+   */
+  public void setSourceAddress(String sourceAddress) {
+    setSourceAddress(sourceAddress, null, null);
+  }
+
+  /**
+   * Get source address
+   *
+   * @return Source address string or null if unset
+   */
+  public String getSourceAddress() {
+    return sourceAddress;
+  }
+
+  /**
+   * Get source address city
+   *
+   * @return Source address city field or null if unset
+   */
+  public String getSourceAddressCity() {
+    return sourceAddressCity;
+  }
+
+  /**
+   * Get source address country
+   *
+   * @return Source address country field or null if unset
+   */
+  public String getSourceAddressCountry() {
+    return sourceAddressCountry;
+  }
+
+  /**
+   * Get source address latitude
+   *
+   * @return Latitude or null if unset
+   */
+  public Double getSourceAddressLatitude() {
+    return sourceAddressLatitude;
+  }
+
+  /**
+   * Get source address longitude
+   *
+   * @return Longitude or null if unset
+   */
+  public Double getSourceAddressLongitude() {
+    return sourceAddressLongitude;
+  }
+}

--- a/src/test/java/com/mozilla/secops/parser/ParserTest.java
+++ b/src/test/java/com/mozilla/secops/parser/ParserTest.java
@@ -232,6 +232,8 @@ public class ParserTest {
     assertEquals("216.160.83.56", o.getSourceAddress());
     assertEquals("Milton", o.getSourceAddressCity());
     assertEquals("US", o.getSourceAddressCountry());
+    assertEquals(47.25, o.getSourceAddressLatitude(), 0.5);
+    assertEquals(-122.31, o.getSourceAddressLongitude(), 0.5);
     Normalized n = e.getNormalized();
     assertNotNull(n);
     assertTrue(n.isOfType(Normalized.Type.AUTH));
@@ -239,6 +241,8 @@ public class ParserTest {
     assertEquals("216.160.83.56", n.getSourceAddress());
     assertEquals("Milton", n.getSourceAddressCity());
     assertEquals("US", n.getSourceAddressCountry());
+    assertEquals(47.25, n.getSourceAddressLatitude(), 0.5);
+    assertEquals(-122.31, n.getSourceAddressLongitude(), 0.5);
   }
 
   @Test
@@ -376,6 +380,10 @@ public class ParserTest {
     assertEquals(BmoAudit.AuditType.LOGIN, b.getAuditType());
     assertEquals("spock@mozilla.com", b.getUser());
     assertEquals("Mozilla/5.0", b.getUserAgent());
+    assertEquals("Milton", b.getSourceAddressCity());
+    assertEquals("US", b.getSourceAddressCountry());
+    assertEquals(47.25, b.getSourceAddressLatitude(), 0.5);
+    assertEquals(-122.31, b.getSourceAddressLongitude(), 0.5);
     Normalized n = e.getNormalized();
     assertNotNull(n);
     assertTrue(n.isOfType(Normalized.Type.AUTH));
@@ -383,6 +391,8 @@ public class ParserTest {
     assertEquals("216.160.83.56", n.getSourceAddress());
     assertEquals("Milton", n.getSourceAddressCity());
     assertEquals("US", n.getSourceAddressCountry());
+    assertEquals(47.25, n.getSourceAddressLatitude(), 0.5);
+    assertEquals(-122.31, n.getSourceAddressLongitude(), 0.5);
   }
 
   @Test
@@ -814,6 +824,8 @@ public class ParserTest {
     assertEquals("216.160.83.56", n.getSourceAddress());
     assertEquals("Milton", n.getSourceAddressCity());
     assertEquals("US", n.getSourceAddressCountry());
+    assertEquals(47.25, n.getSourceAddressLatitude(), 0.5);
+    assertEquals(-122.31, n.getSourceAddressLongitude(), 0.5);
     assertEquals("taskcluster-/v1/claim-work/test-provisioner/macos-workers", n.getObject());
   }
 
@@ -1291,6 +1303,8 @@ public class ParserTest {
     assertEquals("216.160.83.56", n.getSourceAddress());
     assertEquals("Milton", n.getSourceAddressCity());
     assertEquals("US", n.getSourceAddressCountry());
+    assertEquals(47.25, n.getSourceAddressLatitude(), 0.5);
+    assertEquals(-122.31, n.getSourceAddressLongitude(), 0.5);
   }
 
   @Test


### PR DESCRIPTION
Unifies processing of source IP GeoIP fields in extended payload base
class; this ensures the GeoIP fields are available both from the payload
type and also normalized fields.