### PR TITLE
add common input filter

### DIFF
--- a/src/main/java/com/mozilla/secops/InputOptions.java
+++ b/src/main/java/com/mozilla/secops/InputOptions.java
@@ -14,6 +14,18 @@ public interface InputOptions extends PipelineOptions, PubsubOptions, GcpOptions
 
   void setUseEventTimestamp(Boolean value);
 
+  @Description(
+      "Only inspect Stackdriver events generated for specified project identifier in parser DoFn")
+  String getStackdriverProjectFilter();
+
+  void setStackdriverProjectFilter(String value);
+
+  @Description(
+      "Only inspect Stackdriver events that have the provided labels in parser DoFn; key:value")
+  String[] getStackdriverLabelFilters();
+
+  void setStackdriverLabelFilters(String[] value);
+
   @Description("Read from Pubsub (multiple allowed); Pubsub topic")
   String[] getInputPubsub();
 

--- a/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
+++ b/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
@@ -71,9 +71,7 @@ public class HTTPRequest implements Serializable {
   public static class Parse extends PTransform<PCollection<String>, PCollection<Event>> {
     private static final long serialVersionUID = 1L;
 
-    private final String stackdriverProjectFilter;
     private final String[] filterRequestPath;
-    private final String[] stackdriverLabelFilters;
     private final String cidrExclusionList;
     private final String[] includeUrlHostRegex;
     private final Boolean ignoreCp;
@@ -86,8 +84,6 @@ public class HTTPRequest implements Serializable {
      * @param options Pipeline options
      */
     public Parse(HTTPRequestOptions options) {
-      stackdriverProjectFilter = options.getStackdriverProjectFilter();
-      stackdriverLabelFilters = options.getStackdriverLabelFilters();
       filterRequestPath = options.getFilterRequestPath();
       cidrExclusionList = options.getCidrExclusionList();
       includeUrlHostRegex = options.getIncludeUrlHostRegex();
@@ -100,19 +96,6 @@ public class HTTPRequest implements Serializable {
     public PCollection<Event> expand(PCollection<String> col) {
       EventFilter filter = new EventFilter().setWantUTC(true);
       EventFilterRule rule = new EventFilterRule().wantNormalizedType(Normalized.Type.HTTP_REQUEST);
-      if (stackdriverProjectFilter != null) {
-        rule.wantStackdriverProject(stackdriverProjectFilter);
-      }
-      if (stackdriverLabelFilters != null) {
-        for (String labelFilter : stackdriverLabelFilters) {
-          String parts[] = labelFilter.split(":");
-          if (parts.length != 2) {
-            throw new IllegalArgumentException(
-                "invalid format for Stackdriver label filter, must be <key>:<value>");
-          }
-          rule.wantStackdriverLabel(parts[0], parts[1]);
-        }
-      }
       if (filterRequestPath != null) {
         for (String s : filterRequestPath) {
           String[] parts = s.split(":");
@@ -1080,16 +1063,6 @@ public class HTTPRequest implements Serializable {
     String getUserAgentBlacklistPath();
 
     void setUserAgentBlacklistPath(String value);
-
-    @Description("Only inspect Stackdriver events generated for specified project identifier")
-    String getStackdriverProjectFilter();
-
-    void setStackdriverProjectFilter(String value);
-
-    @Description("Only inspect Stackdriver events that have the provided labels; key:value")
-    String[] getStackdriverLabelFilters();
-
-    void setStackdriverLabelFilters(String[] value);
 
     @Description(
         "Endpoint abuse analysis paths for monitoring (multiple allowed); e.g., threshold:method:/path")

--- a/src/main/java/com/mozilla/secops/parser/ParserCfg.java
+++ b/src/main/java/com/mozilla/secops/parser/ParserCfg.java
@@ -17,6 +17,9 @@ public class ParserCfg implements Serializable {
   private String idmanagerPath;
   private Boolean useEventTimestamp;
 
+  private String stackdriverProjectFilter;
+  private String[] stackdriverLabelFilters;
+
   /**
    * Create a parser configuration from pipeline {@link InputOptions}
    *
@@ -36,6 +39,8 @@ public class ParserCfg implements Serializable {
         cfg.setXffAddressSelector(new ArrayList<String>(Arrays.asList(parts)));
       }
     }
+    cfg.setStackdriverProjectFilter(options.getStackdriverProjectFilter());
+    cfg.setStackdriverLabelFilters(options.getStackdriverLabelFilters());
     return cfg;
   }
 
@@ -181,6 +186,50 @@ public class ParserCfg implements Serializable {
    */
   public void setUseEventTimestamp(Boolean useEventTimestamp) {
     this.useEventTimestamp = useEventTimestamp;
+  }
+
+  /**
+   * Get Stackdriver label filters
+   *
+   * @return Array of key:value labels that must match
+   */
+  public String[] getStackdriverLabelFilters() {
+    return stackdriverLabelFilters;
+  }
+
+  /**
+   * Set Stackdriver label filters
+   *
+   * <p>This option is only applicable when the parser is being used within {@link ParserDoFn}.
+   *
+   * <p>If set, events that do not match the label specification will be dropped.
+   *
+   * @param stackdriverLabelFilters Array of key:value labels that must match
+   */
+  public void setStackdriverLabelFilters(String[] stackdriverLabelFilters) {
+    this.stackdriverLabelFilters = stackdriverLabelFilters;
+  }
+
+  /**
+   * Get Stackdriver project filter
+   *
+   * @return Project filter value
+   */
+  public String getStackdriverProjectFilter() {
+    return stackdriverProjectFilter;
+  }
+
+  /**
+   * Set Stackdriver project filter
+   *
+   * <p>This option is only applicable when the parser is being used within {@link ParserDoFn}
+   *
+   * <p>If set, events that do not have the specified Stackdriver project value will be dropped.
+   *
+   * @param stackdriverProjectFilter Project value
+   */
+  public void setStackdriverProjectFilter(String stackdriverProjectFilter) {
+    this.stackdriverProjectFilter = stackdriverProjectFilter;
   }
 
   /** Construct default parser configuration */


### PR DESCRIPTION
The HTTPRequest has pipeline configuration options that more generally
filter events based on Stackdriver properties such as the project ID or
labels. This filtering would be useful for other pipelines as well.

Remove the common project/label filter configuration from HTTPRequest
and make it a property of InputOptions. They can then be more generally
applied to any pipeline that uses ParserDoFn.