### PR TITLE
Gatekeeper - Fix null ptr exception

### DIFF
--- a/src/main/java/com/mozilla/secops/gatekeeper/ETDTransforms.java
+++ b/src/main/java/com/mozilla/secops/gatekeeper/ETDTransforms.java
@@ -96,7 +96,7 @@ public class ETDTransforms implements Serializable {
 
     private static final String alertCategory = "gatekeeper:gcp";
 
-    private static List<Pattern> escalate;
+    private static List<Pattern> escalate = new ArrayList<Pattern>();
     private static String critNotifyEmail;
 
     /**
@@ -108,7 +108,6 @@ public class ETDTransforms implements Serializable {
       critNotifyEmail = opts.getCriticalNotificationEmail();
       String[] escalateRegexes = opts.getEscalateETDFindingRuleRegex();
 
-      escalate = new ArrayList<Pattern>();
       if (escalateRegexes != null) {
         for (String s : escalateRegexes) {
           escalate.add(Pattern.compile(s));

--- a/src/main/java/com/mozilla/secops/gatekeeper/GuardDutyTransforms.java
+++ b/src/main/java/com/mozilla/secops/gatekeeper/GuardDutyTransforms.java
@@ -92,7 +92,7 @@ public class GuardDutyTransforms implements Serializable {
 
     private static final String alertCategory = "gatekeeper:aws";
 
-    private static List<Pattern> escalate;
+    private static List<Pattern> escalate = new ArrayList<Pattern>();
     private static String critNotifyEmail;
 
     /**
@@ -104,7 +104,6 @@ public class GuardDutyTransforms implements Serializable {
       critNotifyEmail = opts.getCriticalNotificationEmail();
       String[] escalateRegexes = opts.getEscalateGDFindingTypeRegex();
 
-      escalate = new ArrayList<Pattern>();
       if (escalateRegexes != null) {
         for (String s : escalateRegexes) {
           escalate.add(Pattern.compile(s));


### PR DESCRIPTION
Without this change, dataflow gives me: 
<img width="1154" alt="Screen Shot 2019-07-24 at 3 52 05 PM" src="https://user-images.githubusercontent.com/16856511/61834623-833bb380-ae2d-11e9-8c6f-4fa482e15f8a.png">
Which is strange; there really shouldnt be a null pointer exception here given that I am initializing the escalate array it in the static initializer / constructor for the transform.
```
for (Pattern p : escalate) {
    if (p.matcher(f.getType()).matches()) {
        addEscalationMetadata(a);
        break;
    }
}
```
... but oh well. Thoughts?
