### PR TITLE
Gatekeeper - Implicit escalate all findings + remove bad static declaration

### DIFF
--- a/src/main/java/com/mozilla/secops/gatekeeper/ETDTransforms.java
+++ b/src/main/java/com/mozilla/secops/gatekeeper/ETDTransforms.java
@@ -96,8 +96,8 @@ public class ETDTransforms implements Serializable {
 
     private static final String alertCategory = "gatekeeper:gcp";
 
-    private static List<Pattern> escalate;
-    private static String critNotifyEmail;
+    private List<Pattern> escalate;
+    private String critNotifyEmail;
 
     /**
      * static initializer for alert generation / escalation
@@ -113,6 +113,8 @@ public class ETDTransforms implements Serializable {
         for (String s : escalateRegexes) {
           escalate.add(Pattern.compile(s));
         }
+      } else {
+        escalate.add(Pattern.compile(".+"));
       }
     }
 

--- a/src/main/java/com/mozilla/secops/gatekeeper/GuardDutyTransforms.java
+++ b/src/main/java/com/mozilla/secops/gatekeeper/GuardDutyTransforms.java
@@ -92,8 +92,8 @@ public class GuardDutyTransforms implements Serializable {
 
     private static final String alertCategory = "gatekeeper:aws";
 
-    private static List<Pattern> escalate;
-    private static String critNotifyEmail;
+    private List<Pattern> escalate;
+    private String critNotifyEmail;
 
     /**
      * static initializer for alert generation / escalation
@@ -109,6 +109,8 @@ public class GuardDutyTransforms implements Serializable {
         for (String s : escalateRegexes) {
           escalate.add(Pattern.compile(s));
         }
+      } else {
+        escalate.add(Pattern.compile(".+"));
       }
     }
 


### PR DESCRIPTION
We want the default alert escalation setting to include all finding types if no alert escalation regexes are provided.

This had already been implemented in https://github.com/mozilla-services/foxsec-pipeline/pull/189, but the change got removed when squashing