### PR TITLE
Remove Duplicate Pipeline Option

### DIFF
--- a/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
+++ b/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
@@ -609,11 +609,6 @@ public class AuthProfile implements Serializable {
     String[] getCritObjects();
 
     void setCritObjects(String[] value);
-
-    @Description("Email address to receive critical alert notifications")
-    String getCriticalNotificationEmail();
-
-    void setCriticalNotificationEmail(String value);
   }
 
   /**


### PR DESCRIPTION
The critical notification email was added as a global output option. There is no need for these getters and setters to be here.

This change had already been done in https://github.com/mozilla-services/foxsec-pipeline/pull/189 but got lost in failure to squash properly