### PR TITLE
cfgtick generation

### DIFF
--- a/src/main/java/com/mozilla/secops/InputOptions.java
+++ b/src/main/java/com/mozilla/secops/InputOptions.java
@@ -66,4 +66,16 @@ public interface InputOptions extends PipelineOptions, PubsubOptions, GcpOptions
   String getParserFastMatcher();
 
   void setParserFastMatcher(String value);
+
+  @Description("Configuration tick interval, 0 to disable; seconds")
+  @Default.Integer(0)
+  Integer getGenerateConfigurationTicksInterval();
+
+  void setGenerateConfigurationTicksInterval(Integer value);
+
+  @Description("Maximum number of configuration ticks to generate, -1 for forever; long")
+  @Default.Long(-1)
+  Long getGenerateConfigurationTicksMaximum();
+
+  void setGenerateConfigurationTicksMaximum(Long value);
 }

--- a/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
+++ b/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
@@ -1203,7 +1203,7 @@ public class HTTPRequest implements Serializable {
               events
                   .apply(
                       "cfgtick processor",
-                      ParDo.of(new CfgTickProcessor("httprequest", "category")))
+                      ParDo.of(new CfgTickProcessor("httprequest-cfgtick", "category")))
                   .apply(new GlobalTriggers<Alert>(5)));
     }
 

--- a/src/main/java/com/mozilla/secops/metrics/CfgTickBuilder.java
+++ b/src/main/java/com/mozilla/secops/metrics/CfgTickBuilder.java
@@ -38,6 +38,10 @@ public class CfgTickBuilder {
     cfgData = new HashMap<String, String>();
   }
 
+  private void removeUndesirable() {
+    cfgData.remove("filesToStage"); // Just remove the staged jar list if present
+  }
+
   /**
    * Generate configuration tick message from builder contents
    *
@@ -45,6 +49,7 @@ public class CfgTickBuilder {
    */
   public String build() throws IOException {
     cfgData.put("configuration_tick", "true");
+    removeUndesirable();
     try {
       return mapper.writeValueAsString(cfgData);
     } catch (JsonProcessingException exc) {

--- a/src/main/java/com/mozilla/secops/metrics/CfgTickBuilder.java
+++ b/src/main/java/com/mozilla/secops/metrics/CfgTickBuilder.java
@@ -1,0 +1,72 @@
+package com.mozilla.secops.metrics;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mozilla.secops.parser.CfgTick;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.beam.sdk.options.PipelineOptions;
+
+/** Builder class for initializating configuration tick messages */
+public class CfgTickBuilder {
+  private final ObjectMapper mapper;
+
+  private HashMap<String, String> cfgData;
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  private static class PipelineOptionsJson {
+    private Map<String, Object> options;
+
+    @JsonProperty("options")
+    public Map<String, Object> getOptions() {
+      return options;
+    }
+  }
+
+  private void mergeData(HashMap<String, String> in) {
+    in.forEach((k, v) -> cfgData.merge(k, v, (v1, v2) -> new String(v2)));
+  }
+
+  /** Initialize new {@link CfgTickBuilder} */
+  public CfgTickBuilder() {
+    mapper = new ObjectMapper();
+    mapper.setSerializationInclusion(Include.NON_NULL);
+    cfgData = new HashMap<String, String>();
+  }
+
+  /**
+   * Generate configuration tick message from builder contents
+   *
+   * @return JSON message string
+   */
+  public String build() throws IOException {
+    cfgData.put("configuration_tick", "true");
+    try {
+      return mapper.writeValueAsString(cfgData);
+    } catch (JsonProcessingException exc) {
+      throw new IOException(exc);
+    }
+  }
+
+  /**
+   * Populate builder with pipeline options to include in messages
+   *
+   * @param opt {@link PipelineOptions}
+   * @return CfgTickBuilder
+   */
+  public CfgTickBuilder includePipelineOptions(PipelineOptions opt) throws IOException {
+    String jsonOpt;
+    try {
+      jsonOpt = mapper.writeValueAsString(opt);
+    } catch (JsonProcessingException exc) {
+      throw new IOException(exc);
+    }
+    PipelineOptionsJson p = mapper.readValue(jsonOpt, PipelineOptionsJson.class);
+    mergeData(CfgTick.flattenObjectMapToStringMap(p.getOptions()));
+    return this;
+  }
+}

--- a/src/main/java/com/mozilla/secops/metrics/CfgTickGenerator.java
+++ b/src/main/java/com/mozilla/secops/metrics/CfgTickGenerator.java
@@ -1,5 +1,8 @@
 package com.mozilla.secops.metrics;
 
+import com.mozilla.secops.parser.Event;
+import com.mozilla.secops.parser.Parser;
+import com.mozilla.secops.parser.Payload;
 import org.apache.beam.sdk.io.Read;
 import org.apache.beam.sdk.io.Read.Unbounded;
 import org.apache.beam.sdk.transforms.PTransform;
@@ -29,6 +32,21 @@ public class CfgTickGenerator extends PTransform<PBegin, PCollection<String>> {
     this.message = message;
     this.interval = interval;
     this.maxNumRecords = maxNumRecords;
+
+    validateMessageFormat();
+  }
+
+  private void validateMessageFormat() {
+    // Make sure we can parse the message that has been generated
+    Parser p = new Parser();
+    Event e = p.parse(message);
+    if (e == null) {
+      throw new RuntimeException("generated configuration tick failed parse validation");
+    }
+    if (!e.getPayloadType().equals(Payload.PayloadType.CFGTICK)) {
+      throw new RuntimeException(
+          "generated configuration tick failed parser event type validation");
+    }
   }
 
   @Override

--- a/src/main/java/com/mozilla/secops/metrics/CfgTickGenerator.java
+++ b/src/main/java/com/mozilla/secops/metrics/CfgTickGenerator.java
@@ -1,0 +1,47 @@
+package com.mozilla.secops.metrics;
+
+import org.apache.beam.sdk.io.Read;
+import org.apache.beam.sdk.io.Read.Unbounded;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
+
+/** Generate periodic configuration ticks */
+public class CfgTickGenerator extends PTransform<PBegin, PCollection<String>> {
+  private static final long serialVersionUID = 1L;
+
+  private final String message;
+  private final Integer interval;
+  private final long maxNumRecords;
+
+  /**
+   * Initialize new {@link CfgTickGenerator}
+   *
+   * <p>The source for this transform is unbounded. The maxNumRecords parameter is intended to place
+   * an upper limit on the number of records generated for testing purposes; under normal
+   * circumstances this parameter should be set to -1.
+   *
+   * @param message Message to emit
+   * @param interval Seconds between emissions
+   * @param maxNumRecords Only generate specified number of records and stop
+   */
+  public CfgTickGenerator(String message, Integer interval, long maxNumRecords) {
+    this.message = message;
+    this.interval = interval;
+    this.maxNumRecords = maxNumRecords;
+  }
+
+  @Override
+  public PCollection<String> expand(PBegin begin) {
+    Unbounded<String> unbounded = Read.from(new CfgTickUnboundedSource(message, interval));
+
+    PTransform<PBegin, PCollection<String>> transform;
+    if (maxNumRecords <= 0) {
+      transform = unbounded;
+    } else {
+      transform = unbounded.withMaxNumRecords(maxNumRecords);
+    }
+
+    return begin.getPipeline().apply(transform);
+  }
+}

--- a/src/main/java/com/mozilla/secops/metrics/CfgTickProcessor.java
+++ b/src/main/java/com/mozilla/secops/metrics/CfgTickProcessor.java
@@ -1,0 +1,52 @@
+package com.mozilla.secops.metrics;
+
+import com.mozilla.secops.alert.Alert;
+import com.mozilla.secops.parser.CfgTick;
+import com.mozilla.secops.parser.Event;
+import com.mozilla.secops.parser.Payload;
+import java.util.Map;
+import org.apache.beam.sdk.transforms.DoFn;
+
+/** Convert configuration ticks into alerts */
+public class CfgTickProcessor extends DoFn<Event, Alert> {
+  private static final long serialVersionUID = 1L;
+
+  private String category;
+  private String subcategory;
+
+  /**
+   * Initialize new {@link CfgTickProcessor}
+   *
+   * @param category Category field to set on alert
+   * @param subcategory Metadata category field to set to cfgtick
+   */
+  public CfgTickProcessor(String category, String subcategory) {
+    this.category = category;
+    this.subcategory = subcategory;
+  }
+
+  @ProcessElement
+  public void processElement(ProcessContext c) {
+    Event e = c.element();
+    if (!(e.getPayloadType().equals(Payload.PayloadType.CFGTICK))) {
+      return;
+    }
+    CfgTick ct = e.getPayload();
+    if (ct == null) {
+      return;
+    }
+    Map<String, String> configMap = ct.getConfigurationMap();
+    if (configMap == null) {
+      return;
+    }
+
+    Alert a = new Alert();
+    a.setCategory(category);
+    a.setSummary("configuration tick");
+    a.addMetadata(subcategory, "cfgtick");
+    for (Map.Entry<String, String> entry : configMap.entrySet()) {
+      a.addMetadata(entry.getKey(), entry.getValue());
+    }
+    c.output(a);
+  }
+}

--- a/src/main/java/com/mozilla/secops/metrics/CfgTickProcessor.java
+++ b/src/main/java/com/mozilla/secops/metrics/CfgTickProcessor.java
@@ -1,6 +1,7 @@
 package com.mozilla.secops.metrics;
 
 import com.mozilla.secops.alert.Alert;
+import com.mozilla.secops.alert.AlertIO;
 import com.mozilla.secops.parser.CfgTick;
 import com.mozilla.secops.parser.Event;
 import com.mozilla.secops.parser.Payload;
@@ -44,6 +45,7 @@ public class CfgTickProcessor extends DoFn<Event, Alert> {
     a.setCategory(category);
     a.setSummary("configuration tick");
     a.addMetadata(subcategory, "cfgtick");
+    a.addMetadata(AlertIO.ALERTIO_IGNORE_EVENT, "true");
     for (Map.Entry<String, String> entry : configMap.entrySet()) {
       a.addMetadata(entry.getKey(), entry.getValue());
     }

--- a/src/main/java/com/mozilla/secops/metrics/CfgTickUnboundedReader.java
+++ b/src/main/java/com/mozilla/secops/metrics/CfgTickUnboundedReader.java
@@ -1,0 +1,90 @@
+package com.mozilla.secops.metrics;
+
+import java.io.Serializable;
+import java.util.NoSuchElementException;
+import org.apache.beam.sdk.io.UnboundedSource;
+import org.apache.beam.sdk.io.UnboundedSource.CheckpointMark;
+import org.apache.beam.sdk.io.UnboundedSource.CheckpointMark.NoopCheckpointMark;
+import org.joda.time.Instant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Unbounded reader for use with {@link CfgTickGenerator} */
+class CfgTickUnboundedReader extends UnboundedSource.UnboundedReader<String>
+    implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  private CfgTickUnboundedSource source;
+  private Instant lastTick;
+  private String current;
+  private Logger log;
+
+  /**
+   * Initialize new {@link CfgTickUnboundedReader}
+   *
+   * @param source Source for reader
+   */
+  public CfgTickUnboundedReader(CfgTickUnboundedSource source) {
+    this.source = source;
+    current = null;
+    lastTick = null;
+    log = LoggerFactory.getLogger(CfgTickUnboundedReader.class);
+  }
+
+  private void generateCurrent() {
+    log.info("generating new configuration tick");
+    current = source.generateNewRecord();
+    lastTick = source.getRecordTimestamp();
+  }
+
+  @Override
+  public String getCurrent() throws NoSuchElementException {
+    if (current == null) {
+      throw new NoSuchElementException();
+    }
+    return current;
+  }
+
+  @Override
+  public Instant getCurrentTimestamp() throws NoSuchElementException {
+    if (current == null) {
+      throw new NoSuchElementException();
+    }
+    return lastTick;
+  }
+
+  @Override
+  public boolean start() {
+    generateCurrent();
+    return true;
+  }
+
+  @Override
+  public void close() {}
+
+  @Override
+  public boolean advance() {
+    try {
+      Thread.sleep(source.getInterval() * 1000);
+    } catch (InterruptedException exc) {
+      throw new RuntimeException(exc);
+    }
+    generateCurrent();
+    return true;
+  }
+
+  @Override
+  public Instant getWatermark() {
+    return lastTick;
+  }
+
+  @Override
+  public CheckpointMark getCheckpointMark() {
+    return new NoopCheckpointMark();
+  }
+
+  @Override
+  public CfgTickUnboundedSource getCurrentSource() {
+    return source;
+  }
+}

--- a/src/main/java/com/mozilla/secops/metrics/CfgTickUnboundedSource.java
+++ b/src/main/java/com/mozilla/secops/metrics/CfgTickUnboundedSource.java
@@ -1,0 +1,102 @@
+package com.mozilla.secops.metrics;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.io.UnboundedSource;
+import org.apache.beam.sdk.io.UnboundedSource.CheckpointMark;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.joda.time.Instant;
+
+/** Unbounded source for use with {@link CfgTickGenerator} */
+class CfgTickUnboundedSource extends UnboundedSource<String, CheckpointMark> {
+  private static final long serialVersionUID = 1L;
+
+  private final String message;
+  private final Integer interval;
+  private Instant lastRecordTimestamp;
+
+  private final int magic = 0xfe0013ae;
+
+  /**
+   * Initialize new {@link CfgTickUnboundedSource}
+   *
+   * @param message Configuration tick message to emit
+   * @param interval Emission interval in seconds
+   */
+  public CfgTickUnboundedSource(String message, Integer interval) {
+    this.message = message;
+    this.interval = interval;
+  }
+
+  /**
+   * Generate a new configuration tick
+   *
+   * @return Record string
+   */
+  public String generateNewRecord() {
+    lastRecordTimestamp = new Instant();
+    return message;
+  }
+
+  /**
+   * Return emission interval
+   *
+   * @return Integer
+   */
+  public Integer getInterval() {
+    return interval;
+  }
+
+  /**
+   * Request the timestamp associated with the last generated configuration tick
+   *
+   * @return Instant
+   */
+  public Instant getRecordTimestamp() {
+    return lastRecordTimestamp;
+  }
+
+  @Override
+  public Coder<CheckpointMark> getCheckpointMarkCoder() {
+    return null;
+  }
+
+  @Override
+  public Coder<String> getOutputCoder() {
+    return StringUtf8Coder.of();
+  }
+
+  @Override
+  public List<? extends UnboundedSource<String, CheckpointMark>> split(
+      int desired, PipelineOptions options) {
+    return Collections.<UnboundedSource<String, CheckpointMark>>singletonList(this);
+  }
+
+  @Override
+  public boolean requiresDeduping() {
+    return false;
+  }
+
+  @Override
+  public UnboundedSource.UnboundedReader<String> createReader(
+      PipelineOptions options, CheckpointMark checkpointMark) {
+    return new CfgTickUnboundedReader(this);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof CfgTickUnboundedSource)) {
+      return false;
+    }
+    CfgTickUnboundedSource t = (CfgTickUnboundedSource) o;
+    return this.magic == t.magic;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(magic);
+  }
+}

--- a/src/main/java/com/mozilla/secops/metrics/package-info.java
+++ b/src/main/java/com/mozilla/secops/metrics/package-info.java
@@ -1,0 +1,2 @@
+/** Metrics support classes */
+package com.mozilla.secops.metrics;

--- a/src/main/java/com/mozilla/secops/parser/CfgTick.java
+++ b/src/main/java/com/mozilla/secops/parser/CfgTick.java
@@ -1,0 +1,123 @@
+package com.mozilla.secops.parser;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+/** Payload parser for configuration ticks */
+public class CfgTick extends PayloadBase implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  private Map<String, String> configMap;
+
+  @Override
+  public Boolean matcher(String input, ParserState state) {
+    Map<String, Object> fields = Parser.convertJsonToMap(input);
+    if (fields == null) {
+      return false;
+    }
+    if (fields.get("configuration_tick") != null) {
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Get configuration map
+   *
+   * @return Map of key/value string pairs
+   */
+  public Map<String, String> getConfigurationMap() {
+    return configMap;
+  }
+
+  @Override
+  @JsonProperty("type")
+  public Payload.PayloadType getType() {
+    return Payload.PayloadType.CFGTICK;
+  }
+
+  /** Construct matcher object. */
+  public CfgTick() {}
+
+  private static String convertArray(Object o) {
+    ArrayList<String> buf = new ArrayList<>();
+    if (o instanceof ArrayList<?>) {
+      ArrayList<?> a = (ArrayList<?>) o;
+      for (int i = 0; i < a.size(); i++) {
+        Object v = a.get(i);
+        // XXX Just support conversion of string and integer here right now
+        if (v instanceof String) {
+          buf.add((String) v);
+        } else if (v instanceof Integer) {
+          buf.add(((Integer) v).toString());
+        } else {
+          return null;
+        }
+      }
+    } else {
+      return null;
+    }
+    return String.join(", ", buf);
+  }
+
+  /**
+   * Convert a map of type String, Object into a map of type String, String
+   *
+   * <p>Any arrays that are present in the input are flattened into a root level value with each
+   * element delimited by a comma.
+   *
+   * <p>This is a local implementation that has support for basic types that are expected to be seen
+   * in pipeline options and is likely not suitable for more general use.
+   *
+   * @param in Input map
+   * @return Converted map
+   */
+  public static HashMap<String, String> flattenObjectMapToStringMap(Map<String, Object> in)
+      throws IOException {
+    HashMap<String, String> ret = new HashMap<>();
+
+    for (Map.Entry<String, Object> entry : in.entrySet()) {
+      Object o = entry.getValue();
+      if (o instanceof Boolean) {
+        ret.put(entry.getKey(), ((Boolean) o).toString());
+      } else if (o instanceof Integer) {
+        ret.put(entry.getKey(), ((Integer) o).toString());
+      } else if (o instanceof String) {
+        ret.put(entry.getKey(), (String) o);
+      } else if (o instanceof ArrayList) {
+        String abuf = convertArray(o);
+        if (abuf == null) {
+          throw new IOException("map had array which could not be converted");
+        }
+        ret.put(entry.getKey(), abuf);
+      } else {
+        throw new IOException("map had value type that could not be converted");
+      }
+    }
+
+    return ret;
+  }
+
+  /**
+   * Construct parser object.
+   *
+   * @param input Input string.
+   * @param e Parent {@link Event}.
+   * @param state State
+   */
+  public CfgTick(String input, Event e, ParserState state) {
+    Map<String, Object> fields = Parser.convertJsonToMap(input);
+    if (fields == null) {
+      return;
+    }
+    try {
+      configMap = flattenObjectMapToStringMap(fields);
+    } catch (IOException exc) {
+      // pass
+    }
+  }
+}

--- a/src/main/java/com/mozilla/secops/parser/CfgTick.java
+++ b/src/main/java/com/mozilla/secops/parser/CfgTick.java
@@ -88,6 +88,8 @@ public class CfgTick extends PayloadBase implements Serializable {
         ret.put(entry.getKey(), ((Integer) o).toString());
       } else if (o instanceof String) {
         ret.put(entry.getKey(), (String) o);
+      } else if (o instanceof Double) {
+        ret.put(entry.getKey(), ((Double) o).toString());
       } else if (o instanceof ArrayList) {
         String abuf = convertArray(o);
         if (abuf == null) {
@@ -95,7 +97,9 @@ public class CfgTick extends PayloadBase implements Serializable {
         }
         ret.put(entry.getKey(), abuf);
       } else {
-        throw new IOException("map had value type that could not be converted");
+        throw new IOException(
+            String.format(
+                "map had value type that could not be converted, %s", o.getClass().toString()));
       }
     }
 

--- a/src/main/java/com/mozilla/secops/parser/EventFilter.java
+++ b/src/main/java/com/mozilla/secops/parser/EventFilter.java
@@ -23,6 +23,18 @@ public class EventFilter implements Serializable {
   private static final String splitChar = "\\ ";
 
   /**
+   * Configure filter to pass configuration ticks
+   *
+   * <p>Adds a rule to the filter that will pass configuration ticks.
+   *
+   * @return EventFilter
+   */
+  public EventFilter passConfigurationTicks() {
+    addRule(new EventFilterRule().wantSubtype(Payload.PayloadType.CFGTICK));
+    return this;
+  }
+
+  /**
    * Get composite transform to apply filter to event stream
    *
    * @param filter Event filter

--- a/src/main/java/com/mozilla/secops/parser/Parser.java
+++ b/src/main/java/com/mozilla/secops/parser/Parser.java
@@ -444,6 +444,7 @@ public class Parser {
     payloads.add(new Alert());
     payloads.add(new GuardDuty());
     payloads.add(new ETDBeta());
+    payloads.add(new CfgTick());
     payloads.add(new Raw());
 
     if (cfg.getIdentityManagerPath() != null) {

--- a/src/main/java/com/mozilla/secops/parser/Parser.java
+++ b/src/main/java/com/mozilla/secops/parser/Parser.java
@@ -363,9 +363,10 @@ public class Parser {
   public Event parse(String input) {
     String fm = cfg.getParserFastMatcher();
     // If a fast matcher is set, test the input immediately against it and discard the
-    // event if it does not match
+    // event if it does not match. A special case exists here to always pass messages that
+    // appear to be configuration ticks from CompositeInput.
     if (fm != null && input != null) {
-      if (!input.contains(fm)) {
+      if (!input.contains(fm) && !input.contains("configuration_tick")) {
         return null;
       }
     }

--- a/src/main/java/com/mozilla/secops/parser/ParserCfg.java
+++ b/src/main/java/com/mozilla/secops/parser/ParserCfg.java
@@ -159,6 +159,10 @@ public class ParserCfg implements Serializable {
    * contains the supplied substring. If not, the event is dropped prior to performing the bulk of
    * the parsing/filtering operations.
    *
+   * <p>Note that this is intended to reduce pressure on the parser and should not be treated as a
+   * filter, as there are certain cases (such as with configuration tick events) that messages that
+   * do not match the fast matcher will still be returned.
+   *
    * @param fastMatcher Matcher substring
    */
   public void setParserFastMatcher(String fastMatcher) {

--- a/src/main/java/com/mozilla/secops/parser/ParserDoFn.java
+++ b/src/main/java/com/mozilla/secops/parser/ParserDoFn.java
@@ -52,7 +52,7 @@ public class ParserDoFn extends DoFn<String, Event> {
     if ((cfg != null)
         && ((cfg.getStackdriverLabelFilters() != null)
             || (cfg.getStackdriverProjectFilter() != null))) {
-      commonInputFilter = new EventFilter();
+      commonInputFilter = new EventFilter().passConfigurationTicks();
       EventFilterRule rule = new EventFilterRule();
 
       if (cfg.getStackdriverLabelFilters() != null) {

--- a/src/main/java/com/mozilla/secops/parser/Payload.java
+++ b/src/main/java/com/mozilla/secops/parser/Payload.java
@@ -38,6 +38,8 @@ public class Payload<T extends PayloadBase> implements Serializable {
     AMODOCKER,
     /** Alert */
     ALERT,
+    /** Internal configuration tick */
+    CFGTICK,
     /** Raw */
     RAW
   }

--- a/src/test/java/com/mozilla/secops/httprequest/TestErrorRate1.java
+++ b/src/test/java/com/mozilla/secops/httprequest/TestErrorRate1.java
@@ -70,6 +70,8 @@ public class TestErrorRate1 {
     options.setGenerateConfigurationTicksInterval(1);
     options.setGenerateConfigurationTicksMaximum(5L);
     options.setInputFile(new String[] {"./target/test-classes/testdata/httpreq_errorrate1.txt"});
+    // Also set a fast matcher configuration to verify the cfgtick events are passed
+    options.setParserFastMatcher("prod-send");
     PCollection<Event> events =
         p.apply(
                 new CompositeInput(

--- a/src/test/java/com/mozilla/secops/httprequest/TestErrorRate1.java
+++ b/src/test/java/com/mozilla/secops/httprequest/TestErrorRate1.java
@@ -86,7 +86,7 @@ public class TestErrorRate1 {
     alertList =
         alertList.and(
             events
-                .apply(ParDo.of(new CfgTickProcessor("httprequest", "category")))
+                .apply(ParDo.of(new CfgTickProcessor("httprequest-cfgtick", "category")))
                 .apply("cfgtick global triggers", new GlobalTriggers<Alert>(1)));
     PCollection<Alert> results = alertList.apply(Flatten.<Alert>pCollections());
 
@@ -107,6 +107,7 @@ public class TestErrorRate1 {
                   assertEquals(30L, Long.parseLong(a.getMetadataValue("error_threshold"), 10));
                   assertEquals("1970-01-01T00:00:59.999Z", a.getMetadataValue("window_timestamp"));
                 } else if (a.getMetadataValue("category").equals("cfgtick")) {
+                  assertEquals("httprequest-cfgtick", a.getCategory());
                   assertEquals("test", a.getMetadataValue("monitoredResourceIndicator"));
                   assertEquals(
                       "./target/test-classes/testdata/httpreq_errorrate1.txt",

--- a/src/test/java/com/mozilla/secops/httprequest/TestErrorRate1.java
+++ b/src/test/java/com/mozilla/secops/httprequest/TestErrorRate1.java
@@ -70,8 +70,10 @@ public class TestErrorRate1 {
     options.setGenerateConfigurationTicksInterval(1);
     options.setGenerateConfigurationTicksMaximum(5L);
     options.setInputFile(new String[] {"./target/test-classes/testdata/httpreq_errorrate1.txt"});
-    // Also set a fast matcher configuration to verify the cfgtick events are passed
+    // Also set a fast matcher configuration and other filters to verify the cfgtick events are
+    // passed
     options.setParserFastMatcher("prod-send");
+    options.setStackdriverProjectFilter("test");
     PCollection<Event> events =
         p.apply(
                 new CompositeInput(

--- a/src/test/java/com/mozilla/secops/metrics/TestCfgTickGenerator.java
+++ b/src/test/java/com/mozilla/secops/metrics/TestCfgTickGenerator.java
@@ -1,0 +1,71 @@
+package com.mozilla.secops.metrics;
+
+import static org.junit.Assert.*;
+
+import com.mozilla.secops.CompositeInput;
+import com.mozilla.secops.InputOptions;
+import com.mozilla.secops.parser.CfgTick;
+import com.mozilla.secops.parser.Event;
+import com.mozilla.secops.parser.ParserDoFn;
+import com.mozilla.secops.parser.Payload;
+import java.io.Serializable;
+import org.apache.beam.runners.direct.DirectOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.PCollection;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class TestCfgTickGenerator implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  public TestCfgTickGenerator() {}
+
+  public interface CfgTickGeneratorOptions extends InputOptions, DirectOptions {}
+
+  private static CfgTickGeneratorOptions getOptions() {
+    CfgTickGeneratorOptions o = PipelineOptionsFactory.as(CfgTickGeneratorOptions.class);
+    o.setGenerateConfigurationTicksInterval(1);
+    o.setGenerateConfigurationTicksMaximum(2L);
+    o.setInputFile(new String[] {"./target/test-classes/testdata/inputtype_buffer1.txt"});
+    return o;
+  }
+
+  @Rule public final transient TestPipeline pipeline = TestPipeline.fromOptions(getOptions());
+
+  @Test
+  public void cfgTickGeneratorTest() throws Exception {
+    CfgTickGeneratorOptions o = getOptions();
+
+    CfgTickBuilder builder = new CfgTickBuilder().includePipelineOptions(getOptions());
+
+    PCollection<Event> results =
+        pipeline
+            .apply(new CompositeInput((InputOptions) o, builder.build()))
+            .apply(ParDo.of(new ParserDoFn()));
+
+    PAssert.that(results)
+        .satisfies(
+            i -> {
+              int cnt = 0;
+              for (Event e : i) {
+                if (e.getPayloadType() != Payload.PayloadType.CFGTICK) {
+                  continue;
+                }
+                CfgTick ct = e.getPayload();
+                assertEquals(
+                    "./target/test-classes/testdata/inputtype_buffer1.txt",
+                    ct.getConfigurationMap().get("inputFile"));
+                assertEquals(
+                    "1", ct.getConfigurationMap().get("generateConfigurationTicksInterval"));
+                cnt++;
+              }
+              assertEquals(2, cnt);
+              return null;
+            });
+
+    pipeline.run().waitUntilFinish();
+  }
+}

--- a/src/test/java/com/mozilla/secops/parser/ParserTest.java
+++ b/src/test/java/com/mozilla/secops/parser/ParserTest.java
@@ -6,6 +6,7 @@ import com.amazonaws.services.guardduty.model.Finding;
 import com.maxmind.geoip2.model.CityResponse;
 import com.mozilla.secops.parser.models.etd.EventThreatDetectionFinding;
 import java.util.ArrayList;
+import java.util.Map;
 import org.joda.time.DateTime;
 import org.junit.Test;
 
@@ -1861,6 +1862,28 @@ public class ParserTest {
 
     assertEquals(m.getHostname(), m2.getHostname());
     assertEquals(m.getLogger(), m2.getLogger());
+  }
+
+  @Test
+  public void testParseCfgTick() {
+    String buf =
+        "{\"configuration_tick\": true, \"string\": \"test\", \"integer\": 100, \"boolean\": true,"
+            + "\"array_string\": [\"one\", \"two\"], \"array_int\": [1, 2]}";
+
+    Parser p = getTestParser();
+    assertNotNull(p);
+    Event e = p.parse(buf);
+    assertNotNull(e);
+    assertEquals(Payload.PayloadType.CFGTICK, e.getPayloadType());
+    CfgTick c = e.getPayload();
+    assertNotNull(c);
+    Map<String, String> configMap = c.getConfigurationMap();
+    assertNotNull(configMap);
+    assertEquals("true", configMap.get("boolean"));
+    assertEquals("100", configMap.get("integer"));
+    assertEquals("test", configMap.get("string"));
+    assertEquals("one, two", configMap.get("array_string"));
+    assertEquals("1, 2", configMap.get("array_int"));
   }
 
   @Test


### PR DESCRIPTION
Adds initial support for generation of periodic configuration ticks from
CompositeInput.

The messages are currently limited to current pipeline runtime options,
but are intended to be expanded to allow transforms to describe
functionality as well for inclusion in these messages.

By default, the new functionality is disabled.

The HTTPRequest pipeline has been modified to demonstrate use of the
generator.