### PR TITLE
Implement tryAddMetadata()

### DIFF
--- a/src/main/java/com/mozilla/secops/alert/Alert.java
+++ b/src/main/java/com/mozilla/secops/alert/Alert.java
@@ -248,6 +248,24 @@ public class Alert implements Serializable {
   }
 
   /**
+   * A best effort addMetadata(k,v)
+   *
+   * <p>If a null or empty key or value is provided, this function will not add anything. Do NOT use
+   * this function for metadata entries that are not purely informational.
+   *
+   * @param k String key
+   * @param v String value
+   * @return true if metadata entry was set, false otherwise
+   */
+  public boolean tryAddMetadata(String k, String v) {
+    if (k == null || v == null || k.equals("") || v.equals("")) {
+      return false;
+    }
+    addMetadata(k, v);
+    return true;
+  }
+
+  /**
    * Override alert timestamp
    *
    * @param timestamp Alert timestamp


### PR DESCRIPTION
Currently, we call ```a.addMetadata(k, v)``` everywhere. In some cases, it is possible that v is null here. 

With the additions in this PR, it is no longer necessary to check whether a value is null before setting it, and we have more control over what to do if the value is in fact null

### Before:
```
String x = someObj.getSomeFieldWhichMayBeNull();
if (x != null) {
    a.addMetadata("the_x", x);
} else { // optionally if you need "the_x" to be set
    a.addMetadata("the_x", "some_default_unknown_value");
}
```
### Now:

If you know for a fact that x will not be null OR you dont care whether x gets set:

```
a.tryAddMetadata("the_x", someObj.getSomeFieldWhichMayBeNull());
```

Otherwise if you dont know if x will be null and you DO care that it gets set
```
try {
    a.mustAddMetadata("the_x", someObj.getSomeFieldWhichMayBeNull());
} catch (IllegalArgumentException e) {
    a.tryAddMetadata("the_x", "unknown");
}
```

### Why is this necessary?

In some cases when we want to add a lot of "interesting yet not critical" metadata to alerts, we find ourselves doing the following:
```
String asn = org.getAsn();
if (asn != null) {
    a.addMetadata("asn", asn);
}
String asnorg = org.getAsnOrg();
if (asnorg null) {
    a.addMetadata("asn_org", asnorg);
}
String isp = org.getIsp();
if (isp != null) {
    a.addMetadata("isp", isp);
}
String org = org.getOrg();
if (org != null) {
   a.addMetadata("org", org);
}
```

With this PR, the block above would become:

```
 a.tryAddMetadata("asn", org.getAsn());
 a.tryAddMetadata("asn_org", org.getAsnOrg());
 a.tryAddMetadata("isp", org.getIsp());
 a.tryAddMetadata("org", org.getOrg());
```
