### PR TITLE
Add GuardDuty Finding Resource metadata to GuardDuty alerts

### DIFF
--- a/src/test/java/com/mozilla/secops/gatekeeper/TestGatekeeper.java
+++ b/src/test/java/com/mozilla/secops/gatekeeper/TestGatekeeper.java
@@ -125,6 +125,24 @@ public class TestGatekeeper {
                       assertNotNull(a.getMetadataValue("remote_ip_org"));
                       break;
                   }
+                  assertNotNull(a.getMetadataValue("resource_type"));
+                  switch (a.getMetadataValue("resource_type")) {
+                    case "AccessKey":
+                      assertNotNull(a.getMetadataValue("access_key_id"));
+                      assertNotNull(a.getMetadataValue("principal_id"));
+                      assertNotNull(a.getMetadataValue("user_name"));
+                      assertNotNull(a.getMetadataValue("user_type"));
+                      break;
+                    case "Instance":
+                      assertNotNull(a.getMetadataValue("instance_availability_zone"));
+                      assertNotNull(a.getMetadataValue("instance_image_description"));
+                      assertNotNull(a.getMetadataValue("instance_image_id"));
+                      assertNotNull(a.getMetadataValue("instance_id"));
+                      assertNotNull(a.getMetadataValue("instance_state"));
+                      assertNotNull(a.getMetadataValue("instance_type"));
+                      assertNotNull(a.getMetadataValue("instance_launch_time"));
+                      break;
+                  }
                 } else if (a.getCategory().equals("gatekeeper:gcp")) {
                   assertTrue(a.getSummary().startsWith("suspicious activity detected in gcp org"));
                   // the three project numbers in the sample data


### PR DESCRIPTION
closes https://github.com/mozilla-services/foxsec-pipeline/issues/219 and prepares the code base for https://github.com/mozilla-services/foxsec-pipeline/issues/220

### More context:

We want to be able to suppress alerts for given EC2 instances. e.g. if we know instance X needs to talk to bad-cryptomining-domain.com then we dont want to raise alerts for DNS based crypto findings. We need to know the instance id to implement this suppression; that info is included in the Resource obj within the Finding obj.

This PR adds resource info contained in the findings to the alerts metadata.