### PR TITLE
revert beam sdk back to 2.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,28 +71,28 @@
         <dependency>
             <groupId>org.apache.beam</groupId>
             <artifactId>beam-sdks-java-core</artifactId>
-            <version>2.14.0</version>
+            <version>2.13.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.beam</groupId>
             <artifactId>beam-sdks-java-io-google-cloud-platform</artifactId>
-            <version>2.14.0</version>
+            <version>2.13.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.beam</groupId>
             <artifactId>beam-sdks-java-io-kinesis</artifactId>
-            <version>2.14.0</version>
+            <version>2.13.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.beam</groupId>
             <artifactId>beam-runners-direct-java</artifactId>
-            <version>2.14.0</version>
+            <version>2.13.0</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.beam</groupId>
             <artifactId>beam-runners-google-cloud-dataflow-java</artifactId>
-            <version>2.14.0</version>
+            <version>2.13.0</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Beam 2.14 contains a regression associated with Kinesis watermark
calculation and fetching backlog bytes.

Reverting the SDK version for now, for additional information on the bug
see https://issues.apache.org/jira/browse/BEAM-7978.