### PR TITLE
composite persistor with bigquery as initial persistor

### DIFF
--- a/src/main/java/com/mozilla/secops/CompositePersistence.java
+++ b/src/main/java/com/mozilla/secops/CompositePersistence.java
@@ -1,0 +1,33 @@
+package com.mozilla.secops;
+
+import com.mozilla.secops.parser.Event;
+import com.mozilla.secops.persistence.PersistInBiqQuery;
+import java.io.Serializable;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PDone;
+
+/** {@link CompositePersistence} provides a standardized composite persistence transform */
+public class CompositePersistence extends PTransform<PCollection<Event>, PDone>
+    implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  private final PersistenceOptions opts;
+
+  /**
+   * Initialize new {@link CompositePersistence} transform
+   *
+   * @param options {@link PersistenceOptions} options
+   */
+  public CompositePersistence(PersistenceOptions options) {
+    opts = options;
+  }
+
+  @Override
+  public PDone expand(PCollection<Event> events) {
+    if (opts.getPersistenceBigQuery() != null) {
+      events.apply(new PersistInBiqQuery(opts.getPersistenceBigQuery()));
+    }
+    return PDone.in(events.getPipeline());
+  }
+}

--- a/src/main/java/com/mozilla/secops/IOOptions.java
+++ b/src/main/java/com/mozilla/secops/IOOptions.java
@@ -1,4 +1,4 @@
 package com.mozilla.secops;
 
 /** Interface to allow for passing both input and output options to a class or function. */
-public interface IOOptions extends OutputOptions, InputOptions {}
+public interface IOOptions extends OutputOptions, InputOptions, PersistenceOptions {}

--- a/src/main/java/com/mozilla/secops/PersistenceOptions.java
+++ b/src/main/java/com/mozilla/secops/PersistenceOptions.java
@@ -1,0 +1,11 @@
+package com.mozilla.secops;
+
+import org.apache.beam.sdk.options.Description;
+import org.apache.beam.sdk.options.PipelineOptions;
+
+public interface PersistenceOptions extends PipelineOptions {
+  @Description("Write payloads to BigQuery; BigQuery table specification")
+  String getPersistenceBigQuery();
+
+  void setPersistenceBigQuery(String value);
+}

--- a/src/main/java/com/mozilla/secops/gatekeeper/GatekeeperPipeline.java
+++ b/src/main/java/com/mozilla/secops/gatekeeper/GatekeeperPipeline.java
@@ -1,6 +1,7 @@
 package com.mozilla.secops.gatekeeper;
 
 import com.mozilla.secops.CompositeInput;
+import com.mozilla.secops.CompositePersistence;
 import com.mozilla.secops.OutputOptions;
 import com.mozilla.secops.alert.Alert;
 import com.mozilla.secops.alert.AlertFormatter;
@@ -39,6 +40,8 @@ public class GatekeeperPipeline implements Serializable {
         input
             .apply("parse input", new GatekeeperParser.Parse(options))
             .apply("window input", new GlobalTriggers<Event>(60));
+
+    events.apply("persist events", new CompositePersistence(options));
 
     PCollection<Alert> gdAlerts =
         events

--- a/src/main/java/com/mozilla/secops/persistence/PersistInBiqQuery.java
+++ b/src/main/java/com/mozilla/secops/persistence/PersistInBiqQuery.java
@@ -1,0 +1,65 @@
+package com.mozilla.secops.persistence;
+
+import com.google.api.services.bigquery.model.TableRow;
+import com.mozilla.secops.parser.*;
+import java.io.Serializable;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PDone;
+
+/** Composite transform to persist a {@link PCollection} containing {@link Event} objects */
+public class PersistInBiqQuery extends PTransform<PCollection<Event>, PDone>
+    implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  private final String persistenceBQ;
+
+  /**
+   * Initialize new {@link PersistInBiqQuery} transform
+   *
+   * @param bigQuerySpec the bigquery specification where to persist events
+   */
+  public PersistInBiqQuery(String bigQuerySpec) {
+    persistenceBQ = bigQuerySpec;
+  }
+
+  private TableRow buildTableRow(Event e) {
+    TableRow r = new TableRow();
+    r.set("event_id", e.getEventId());
+    r.set("event_type", e.getPayloadType().name());
+    r.set("event_time", e.getTimestamp());
+    r.set("raw", e.getPayload().toString());
+    return r;
+  }
+
+  @Override
+  public PDone expand(PCollection<Event> events) {
+    if (persistenceBQ != null) {
+      events
+          .apply(
+              ParDo.of(
+                  new DoFn<Event, TableRow>() {
+                    private static final long serialVersionUID = 1L;
+
+                    @ProcessElement
+                    public void processElement(ProcessContext c) {
+                      Event e = c.element();
+                      if (e == null) {
+                        return;
+                      }
+                      TableRow r = buildTableRow(e);
+                      c.output(r);
+                    }
+                  }))
+          .apply(
+              BigQueryIO.writeTableRows()
+                  .to(persistenceBQ)
+                  .withCreateDisposition(BigQueryIO.Write.CreateDisposition.CREATE_NEVER)
+                  .withWriteDisposition(BigQueryIO.Write.WriteDisposition.WRITE_APPEND));
+    }
+    return PDone.in(events.getPipeline());
+  }
+}

--- a/src/main/java/com/mozilla/secops/persistence/package-info.java
+++ b/src/main/java/com/mozilla/secops/persistence/package-info.java
@@ -1,0 +1,2 @@
+/** Event persistence transforms package */
+package com.mozilla.secops.persistence;


### PR DESCRIPTION
closes https://github.com/mozilla-services/foxsec-pipeline/issues/229

This PR:

- **New** PersistenceOptions interface to get external datastore options where to persist events
- **New** CompositePersitence class which persists events in all provided persistors
- **New** PersistInBigQuery class (transform) which persists events in BigQuery
- Using composite persistence in the Gatekeeper Pipeline