### PR TITLE
Skip AlertIO on untracked identity

### DIFF
--- a/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
+++ b/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
@@ -590,6 +590,8 @@ public class AuthProfile implements Serializable {
           // We do not keep state for untracked identities, but just use the known address
           // list here to filter any duplicates that are part of this batch
           seenKnownAddresses.add(e.getNormalized().getSourceAddress());
+          // We also want to skip AlertIO for untracked identities here
+          a.addMetadata(AlertIO.ALERTIO_IGNORE_EVENT, "true");
         } else {
           StateCursor cur = state.newCursor();
 

--- a/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
+++ b/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
@@ -97,6 +97,9 @@ public class AuthProfile implements Serializable {
             "system:serviceaccount:kube-system:daemon-set-controller",
             "system:serviceaccount:kube-system:horizontal-pod-autoscaler",
             "system:serviceaccount:kube-system:node-controller",
+            "system:serviceaccount:kube-system:certificate-controller",
+            "system:serviceaccount:kube-system:ttl-controller",
+            "system:serviceaccount:kube-system:cronjob-controller",
             "system:kube-proxy"
           };
       auth0ClientIds = options.getAuth0ClientIds();

--- a/src/test/java/com/mozilla/secops/authprofile/TestAuthProfile.java
+++ b/src/test/java/com/mozilla/secops/authprofile/TestAuthProfile.java
@@ -256,7 +256,6 @@ public class TestAuthProfile {
                 assertEquals("email/authprofile.ftlh", a.getEmailTemplate());
                 assertEquals("slack/authprofile.ftlh", a.getSlackTemplate());
                 assertEquals("state_analyze", a.getMetadataValue("category"));
-                assertNull(a.getMetadataValue(AlertIO.ALERTIO_IGNORE_EVENT));
                 String actualSummary = a.getSummary();
                 if (actualSummary.contains("new source")) {
                   newCnt++;
@@ -274,6 +273,7 @@ public class TestAuthProfile {
                   assertEquals(Alert.AlertSeverity.INFORMATIONAL, a.getSeverity());
                   assertEquals("127.0.0.1", a.getMetadataValue("sourceaddress"));
                   assertEquals("laforge@mozilla.com", a.getMetadataValue("username"));
+                  assertEquals("true", a.getMetadataValue(AlertIO.ALERTIO_IGNORE_EVENT));
                   assertThat(a.getSummary(), containsString("untracked"));
                   assertEquals("2019-01-03T20:52:04.782Z", a.getMetadataValue("event_timestamp"));
                 } else if ((iKey != null) && (iKey.equals("wriker@mozilla.com"))) {
@@ -286,6 +286,7 @@ public class TestAuthProfile {
                     assertEquals("slack/authprofile.ftlh", a.getSlackTemplate());
                     assertEquals("2019-01-03T20:52:04.782Z", a.getMetadataValue("event_timestamp"));
                     assertEquals("picard@mozilla.com", a.getMetadataValue("escalate_to"));
+                    assertNull(a.getMetadataValue(AlertIO.ALERTIO_IGNORE_EVENT));
                   }
                 }
               }


### PR DESCRIPTION
Since we do not escalate on untracked, skip `AlertIO` in these cases.

This PR also adds some additional auto-ignored users.