### PR TITLE
Multi-service processing in HTTPRequest

### DIFF
--- a/src/main/java/com/mozilla/secops/DetectNat.java
+++ b/src/main/java/com/mozilla/secops/DetectNat.java
@@ -34,6 +34,22 @@ public class DetectNat extends PTransform<PCollection<Event>, PCollection<KV<Str
 
   private static final Long UAMARKPROBABLE = 2L;
 
+  private final String stepPrefix;
+
+  /**
+   * Create new DetectNat
+   *
+   * @param stepPrefix Prefix for transform step or null for none
+   */
+  public DetectNat(String stepPrefix) {
+    this.stepPrefix = stepPrefix;
+  }
+
+  /** Create new DetectNat */
+  public DetectNat() {
+    this(null);
+  }
+
   /**
    * Return an empty NAT view, suitable as a placeholder if NAT detection is not desired
    *
@@ -52,18 +68,29 @@ public class DetectNat extends PTransform<PCollection<Event>, PCollection<KV<Str
    * Execute the transform returning a {@link PCollectionView} suitable for use as a side input
    *
    * @param events Input events
+   * @param prefix Prefix for step name or null for none
    * @return {@link PCollectionView} representing output of analysis
    */
-  public static PCollectionView<Map<String, Boolean>> getView(PCollection<Event> events) {
-    return events.apply("nat view", new DetectNat()).apply(View.<String, Boolean>asMap());
+  public static PCollectionView<Map<String, Boolean>> getView(
+      PCollection<Event> events, String prefix) {
+    if (prefix == null) {
+      prefix = "";
+    }
+    return events
+        .apply(String.format("%s nat view", prefix), new DetectNat(prefix))
+        .apply(String.format("%s nat map view", prefix), View.<String, Boolean>asMap());
   }
 
   @Override
   public PCollection<KV<String, Boolean>> expand(PCollection<Event> events) {
+    String p = "";
+    if (stepPrefix != null) {
+      p = stepPrefix;
+    }
     PCollection<KV<String, Long>> perSourceUACounts =
         events
             .apply(
-                "detectnat extract user agents",
+                String.format("%s detectnat extract user agents", p),
                 ParDo.of(
                     new DoFn<Event, KV<String, String>>() {
                       private static final long serialVersionUID = 1L;
@@ -82,13 +109,16 @@ public class DetectNat extends PTransform<PCollection<Event>, PCollection<KV<Str
                         }
                       }
                     }))
-            .apply("detectnat distinct ua map", Distinct.<KV<String, String>>create())
-            .apply("detectnat ua count per key", Count.<String, String>perKey());
+            .apply(
+                String.format("%s detectnat distinct ua map", p),
+                Distinct.<KV<String, String>>create())
+            .apply(
+                String.format("%s detectnat ua count per key", p), Count.<String, String>perKey());
 
     // Operate solely on the UA output right now here, but this should be expanded with more
     // detailed analysis
     return perSourceUACounts.apply(
-        "detect nat",
+        String.format("%s detect nat", p),
         ParDo.of(
             new DoFn<KV<String, Long>, KV<String, Boolean>>() {
               private static final long serialVersionUID = 1L;

--- a/src/main/java/com/mozilla/secops/alert/AlertFormatter.java
+++ b/src/main/java/com/mozilla/secops/alert/AlertFormatter.java
@@ -75,7 +75,15 @@ public class AlertFormatter extends DoFn<Alert, String> {
   @ProcessElement
   public void processElement(ProcessContext c) {
     Alert a = c.element();
-    a.addMetadata("monitored_resource", monitoredResourceIndicator);
+
+    // Add the monitored_resource metadata if missing
+    if (a.getMetadataValue("monitored_resource") == null) {
+      if (monitoredResourceIndicator == null) {
+        throw new RuntimeException("monitored resource indicator was null in AlertFormatter");
+      }
+      a.addMetadata("monitored_resource", monitoredResourceIndicator);
+    }
+
     addGeoIPData(a);
     c.output(a.toJSON());
   }

--- a/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
+++ b/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
@@ -247,7 +247,7 @@ public class HTTPRequest implements Serializable {
 
                       a.addMetadata("error_count", c.element().getValue().toString());
                       a.addMetadata("error_threshold", maxErrorRate.toString());
-                      a.setNotifyMergeKey("error_count");
+                      a.setNotifyMergeKey(String.format("%s error_count", monitoredResource));
                       a.addMetadata(
                           "window_timestamp", (new DateTime(w.maxTimestamp())).toString());
                       if (!a.hasCorrectFields()) {
@@ -370,7 +370,8 @@ public class HTTPRequest implements Serializable {
 
                           a.addMetadata("count", c.element().getValue().toString());
                           a.addMetadata("request_threshold", maxCount.toString());
-                          a.setNotifyMergeKey("hard_limit_count");
+                          a.setNotifyMergeKey(
+                              String.format("%s hard_limit_count", monitoredResource));
                           a.addMetadata(
                               "window_timestamp", (new DateTime(w.maxTimestamp())).toString());
                           if (!a.hasCorrectFields()) {
@@ -514,7 +515,8 @@ public class HTTPRequest implements Serializable {
                             return;
                           }
 
-                          a.setNotifyMergeKey("useragent_blacklist");
+                          a.setNotifyMergeKey(
+                              String.format("%s useragent_blacklist", monitoredResource));
                           a.addMetadata(
                               "window_timestamp", (new DateTime(w.maxTimestamp())).toString());
 
@@ -755,7 +757,7 @@ public class HTTPRequest implements Serializable {
                       a.addMetadata("method", compareMethod);
                       a.addMetadata("count", Integer.toString(count));
                       a.addMetadata("useragent", userAgent);
-                      a.setNotifyMergeKey("endpoint_abuse");
+                      a.setNotifyMergeKey(String.format("%s endpoint_abuse", monitoredResource));
                       a.addMetadata(
                           "window_timestamp", (new DateTime(w.maxTimestamp())).toString());
                       if (!a.hasCorrectFields()) {
@@ -958,7 +960,8 @@ public class HTTPRequest implements Serializable {
                             a.addMetadata("mean", sOutput.getMean().toString());
                             a.addMetadata("count", c.element().getValue().toString());
                             a.addMetadata("threshold_modifier", thresholdModifier.toString());
-                            a.setNotifyMergeKey("threshold_analysis");
+                            a.setNotifyMergeKey(
+                                String.format("%s threshold_analysis", monitoredResource));
                             a.addMetadata(
                                 "window_timestamp", (new DateTime(w.maxTimestamp())).toString());
                             if (!a.hasCorrectFields()) {

--- a/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
+++ b/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
@@ -1115,11 +1115,6 @@ public class HTTPRequest implements Serializable {
     String getPipelineMultimodeConfiguration();
 
     void setPipelineMultimodeConfiguration(String value);
-
-    @Description("Wired input stream; used only in testing")
-    Boolean getWiredInputStream();
-
-    void setWiredInputStream(Boolean value);
   }
 
   /**

--- a/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
+++ b/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
@@ -179,7 +179,7 @@ public class HTTPRequest implements Serializable {
      */
     public ErrorRateAnalysis(HTTPRequestOptions options, HTTPRequestToggles toggles) {
       maxErrorRate = toggles.getMaxClientErrorRate();
-      monitoredResource = options.getMonitoredResourceIndicator();
+      monitoredResource = toggles.getMonitoredResource();
       enableIprepdDatastoreWhitelist = options.getOutputIprepdEnableDatastoreWhitelist();
       iprepdDatastoreWhitelistProject = options.getOutputIprepdDatastoreWhitelistProject();
     }
@@ -280,7 +280,7 @@ public class HTTPRequest implements Serializable {
      */
     public HardLimitAnalysis(HTTPRequestOptions options, HTTPRequestToggles toggles) {
       maxCount = toggles.getHardLimitRequestCount();
-      monitoredResource = options.getMonitoredResourceIndicator();
+      monitoredResource = toggles.getMonitoredResource();
       enableIprepdDatastoreWhitelist = options.getOutputIprepdEnableDatastoreWhitelist();
       iprepdDatastoreWhitelistProject = options.getOutputIprepdDatastoreWhitelistProject();
       log = LoggerFactory.getLogger(HardLimitAnalysis.class);
@@ -405,7 +405,7 @@ public class HTTPRequest implements Serializable {
      * @param toggles Pipeline toggles
      */
     public UserAgentBlacklistAnalysis(HTTPRequestOptions options, HTTPRequestToggles toggles) {
-      monitoredResource = options.getMonitoredResourceIndicator();
+      monitoredResource = toggles.getMonitoredResource();
       enableIprepdDatastoreWhitelist = options.getOutputIprepdEnableDatastoreWhitelist();
       iprepdDatastoreWhitelistProject = options.getOutputIprepdDatastoreWhitelistProject();
       uaBlacklistPath = toggles.getUserAgentBlacklistPath();
@@ -584,7 +584,7 @@ public class HTTPRequest implements Serializable {
     public EndpointAbuseAnalysis(HTTPRequestOptions options, HTTPRequestToggles toggles) {
       log = LoggerFactory.getLogger(EndpointAbuseAnalysis.class);
 
-      monitoredResource = options.getMonitoredResourceIndicator();
+      monitoredResource = toggles.getMonitoredResource();
       enableIprepdDatastoreWhitelist = options.getOutputIprepdEnableDatastoreWhitelist();
       iprepdDatastoreWhitelistProject = options.getOutputIprepdDatastoreWhitelistProject();
       varianceSupportingOnly = toggles.getEndpointAbuseExtendedVariance();
@@ -825,7 +825,7 @@ public class HTTPRequest implements Serializable {
       this.requiredMinimumAverage = toggles.getRequiredMinimumAverage();
       this.requiredMinimumClients = toggles.getRequiredMinimumClients();
       this.clampThresholdMaximum = toggles.getClampThresholdMaximum();
-      this.monitoredResource = options.getMonitoredResourceIndicator();
+      this.monitoredResource = toggles.getMonitoredResource();
       this.enableIprepdDatastoreWhitelist = options.getOutputIprepdEnableDatastoreWhitelist();
       this.iprepdDatastoreWhitelistProject = options.getOutputIprepdDatastoreWhitelistProject();
       log = LoggerFactory.getLogger(ThresholdAnalysis.class);

--- a/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
+++ b/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
@@ -1,6 +1,5 @@
 package com.mozilla.secops.httprequest;
 
-import com.mozilla.secops.CidrUtil;
 import com.mozilla.secops.DetectNat;
 import com.mozilla.secops.DocumentingTransform;
 import com.mozilla.secops.FileUtil;
@@ -12,23 +11,22 @@ import com.mozilla.secops.alert.Alert;
 import com.mozilla.secops.alert.AlertFormatter;
 import com.mozilla.secops.alert.AlertSuppressorCount;
 import com.mozilla.secops.input.Input;
+import com.mozilla.secops.input.InputElement;
 import com.mozilla.secops.metrics.CfgTickBuilder;
 import com.mozilla.secops.metrics.CfgTickProcessor;
 import com.mozilla.secops.parser.Event;
-import com.mozilla.secops.parser.EventFilter;
-import com.mozilla.secops.parser.EventFilterPayload;
-import com.mozilla.secops.parser.EventFilterPayloadOr;
-import com.mozilla.secops.parser.EventFilterRule;
 import com.mozilla.secops.parser.Normalized;
 import com.mozilla.secops.parser.ParserCfg;
-import com.mozilla.secops.parser.ParserDoFn;
 import com.mozilla.secops.window.GlobalTriggers;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.options.PipelineOptions;
@@ -64,105 +62,19 @@ import org.slf4j.LoggerFactory;
 public class HTTPRequest implements Serializable {
   private static final long serialVersionUID = 1L;
 
+  private static transient ConcurrentHashMap<String, HTTPRequestToggles> toggleCache =
+      new ConcurrentHashMap<>();
+
   /**
-   * Composite transform to parse a {@link PCollection} containing events as strings and emit a
-   * {@link PCollection} of {@link Event} objects.
+   * Add an entry to the HTTPRequest toggle cache
    *
-   * <p>This transform currently discards events that do not contain the HTTP_REQUEST normalized
-   * field.
+   * <p>For use in tests, should not be called under normal use.
+   *
+   * @param name Cache key name
+   * @param entry Cache entry
    */
-  public static class Parse extends PTransform<PCollection<String>, PCollection<Event>> {
-    private static final long serialVersionUID = 1L;
-
-    private final String[] filterRequestPath;
-    private final String cidrExclusionList;
-    private final String[] includeUrlHostRegex;
-    private final Boolean ignoreCp;
-    private final Boolean ignoreInternal;
-    private ParserCfg cfg;
-
-    /**
-     * Static initializer for {@link Parse} transform
-     *
-     * @param options Pipeline options
-     */
-    public Parse(HTTPRequestOptions options) {
-      filterRequestPath = options.getFilterRequestPath();
-      cidrExclusionList = options.getCidrExclusionList();
-      includeUrlHostRegex = options.getIncludeUrlHostRegex();
-      ignoreCp = options.getIgnoreCloudProviderRequests();
-      ignoreInternal = options.getIgnoreInternalRequests();
-      cfg = ParserCfg.fromInputOptions(options);
-    }
-
-    @Override
-    public PCollection<Event> expand(PCollection<String> col) {
-      EventFilter filter = new EventFilter().passConfigurationTicks().setWantUTC(true);
-      EventFilterRule rule = new EventFilterRule().wantNormalizedType(Normalized.Type.HTTP_REQUEST);
-      if (filterRequestPath != null) {
-        for (String s : filterRequestPath) {
-          String[] parts = s.split(":");
-          if (parts.length != 2) {
-            throw new IllegalArgumentException(
-                "invalid format for filter path, must be <method>:<path>");
-          }
-          rule.except(
-              new EventFilterRule()
-                  .wantNormalizedType(Normalized.Type.HTTP_REQUEST)
-                  .addPayloadFilter(
-                      new EventFilterPayload()
-                          .withStringMatch(
-                              EventFilterPayload.StringProperty.NORMALIZED_REQUESTMETHOD, parts[0])
-                          .withStringMatch(
-                              EventFilterPayload.StringProperty.NORMALIZED_URLREQUESTPATH,
-                              parts[1]))
-                  .addPayloadFilter(
-                      new EventFilterPayloadOr()
-                          .addPayloadFilter(
-                              new EventFilterPayload()
-                                  .withIntegerRangeMatch(
-                                      EventFilterPayload.IntegerProperty.NORMALIZED_REQUESTSTATUS,
-                                      0,
-                                      399))
-                          .addPayloadFilter(
-                              new EventFilterPayload()
-                                  .withIntegerRangeMatch(
-                                      EventFilterPayload.IntegerProperty.NORMALIZED_REQUESTSTATUS,
-                                      500,
-                                      Integer.MAX_VALUE))));
-        }
-      }
-      if (includeUrlHostRegex != null) {
-        EventFilterPayloadOr orFilter = new EventFilterPayloadOr();
-        for (String s : includeUrlHostRegex) {
-          orFilter.addPayloadFilter(
-              new EventFilterPayload()
-                  .withStringRegexMatch(
-                      EventFilterPayload.StringProperty.NORMALIZED_URLREQUESTHOST, s));
-        }
-        rule.addPayloadFilter(orFilter);
-      }
-      filter.addRule(rule);
-      PCollection<Event> parsed =
-          col.apply(
-              ParDo.of(new ParserDoFn().withConfiguration(cfg).withInlineEventFilter(filter)));
-      int exclmask = 0;
-      if (cidrExclusionList != null) {
-        exclmask |= CidrUtil.CIDRUTIL_FILE;
-      }
-      if (ignoreCp) {
-        exclmask |= CidrUtil.CIDRUTIL_CLOUDPROVIDERS;
-      }
-      if (ignoreInternal) {
-        exclmask |= CidrUtil.CIDRUTIL_INTERNAL;
-      }
-      if (exclmask != 0) {
-        return parsed.apply(
-            "cidr exclusion",
-            ParDo.of(CidrUtil.excludeNormalizedSourceAddresses(exclmask, cidrExclusionList)));
-      }
-      return parsed;
-    }
+  public static void addToggleCacheEntry(String name, HTTPRequestToggles entry) {
+    toggleCache.put(name, entry);
   }
 
   /** Window events into fixed one minute windows */
@@ -187,8 +99,8 @@ public class HTTPRequest implements Serializable {
     private final Long gapDurationMinutes;
     private final Long paneFiringDelaySeconds = 10L;
 
-    public KeyAndWindowForSessionsFireEarly(HTTPRequestOptions options) {
-      gapDurationMinutes = options.getSessionGapDurationMinutes();
+    public KeyAndWindowForSessionsFireEarly(HTTPRequestToggles toggles) {
+      gapDurationMinutes = toggles.getSessionGapDurationMinutes();
     }
 
     @Override
@@ -263,9 +175,10 @@ public class HTTPRequest implements Serializable {
      * Static initializer for {@link ErrorRateAnalysis}
      *
      * @param options Pipeline options
+     * @param toggles Pipeline toggles
      */
-    public ErrorRateAnalysis(HTTPRequestOptions options) {
-      maxErrorRate = options.getMaxClientErrorRate();
+    public ErrorRateAnalysis(HTTPRequestOptions options, HTTPRequestToggles toggles) {
+      maxErrorRate = toggles.getMaxClientErrorRate();
       monitoredResource = options.getMonitoredResourceIndicator();
       enableIprepdDatastoreWhitelist = options.getOutputIprepdEnableDatastoreWhitelist();
       iprepdDatastoreWhitelistProject = options.getOutputIprepdDatastoreWhitelistProject();
@@ -363,9 +276,10 @@ public class HTTPRequest implements Serializable {
      * Static initializer for {@link HardLimitAnalysis}
      *
      * @param options Pipeline options
+     * @param toggles Pipeline toggles
      */
-    public HardLimitAnalysis(HTTPRequestOptions options) {
-      maxCount = options.getHardLimitRequestCount();
+    public HardLimitAnalysis(HTTPRequestOptions options, HTTPRequestToggles toggles) {
+      maxCount = toggles.getHardLimitRequestCount();
       monitoredResource = options.getMonitoredResourceIndicator();
       enableIprepdDatastoreWhitelist = options.getOutputIprepdEnableDatastoreWhitelist();
       iprepdDatastoreWhitelistProject = options.getOutputIprepdDatastoreWhitelistProject();
@@ -376,11 +290,14 @@ public class HTTPRequest implements Serializable {
      * Static initializer for {@link HardLimitAnalysis}
      *
      * @param options Pipeline options
+     * @param toggles Pipeline toggles
      * @param natView Use {@link DetectNat} view during hard limit analysis
      */
     public HardLimitAnalysis(
-        HTTPRequestOptions options, PCollectionView<Map<String, Boolean>> natView) {
-      this(options);
+        HTTPRequestOptions options,
+        HTTPRequestToggles toggles,
+        PCollectionView<Map<String, Boolean>> natView) {
+      this(options, toggles);
       this.natView = natView;
     }
 
@@ -485,12 +402,13 @@ public class HTTPRequest implements Serializable {
      * Initialize new {@link UserAgentBlacklistAnalysis}
      *
      * @param options Pipeline options
+     * @param toggles Pipeline toggles
      */
-    public UserAgentBlacklistAnalysis(HTTPRequestOptions options) {
+    public UserAgentBlacklistAnalysis(HTTPRequestOptions options, HTTPRequestToggles toggles) {
       monitoredResource = options.getMonitoredResourceIndicator();
       enableIprepdDatastoreWhitelist = options.getOutputIprepdEnableDatastoreWhitelist();
       iprepdDatastoreWhitelistProject = options.getOutputIprepdDatastoreWhitelistProject();
-      uaBlacklistPath = options.getUserAgentBlacklistPath();
+      uaBlacklistPath = toggles.getUserAgentBlacklistPath();
       log = LoggerFactory.getLogger(UserAgentBlacklistAnalysis.class);
     }
 
@@ -498,11 +416,14 @@ public class HTTPRequest implements Serializable {
      * Initialize new {@link UserAgentBlacklistAnalysis}
      *
      * @param options Pipeline options
+     * @param toggles Pipeline toggles
      * @param natView Use {@link DetectNat} view during analysis
      */
     public UserAgentBlacklistAnalysis(
-        HTTPRequestOptions options, PCollectionView<Map<String, Boolean>> natView) {
-      this(options);
+        HTTPRequestOptions options,
+        HTTPRequestToggles toggles,
+        PCollectionView<Map<String, Boolean>> natView) {
+      this(options, toggles);
       this.natView = natView;
     }
 
@@ -660,16 +581,16 @@ public class HTTPRequest implements Serializable {
      *
      * @param options Pipeline options
      */
-    public EndpointAbuseAnalysis(HTTPRequestOptions options) {
+    public EndpointAbuseAnalysis(HTTPRequestOptions options, HTTPRequestToggles toggles) {
       log = LoggerFactory.getLogger(EndpointAbuseAnalysis.class);
 
       monitoredResource = options.getMonitoredResourceIndicator();
       enableIprepdDatastoreWhitelist = options.getOutputIprepdEnableDatastoreWhitelist();
       iprepdDatastoreWhitelistProject = options.getOutputIprepdDatastoreWhitelistProject();
-      varianceSupportingOnly = options.getEndpointAbuseExtendedVariance();
-      suppressRecovery = options.getEndpointAbuseSuppressRecovery();
-      customVarianceSubstrings = options.getEndpointAbuseCustomVarianceSubstrings();
-      sessionGapDurationMinutes = options.getSessionGapDurationMinutes();
+      varianceSupportingOnly = toggles.getEndpointAbuseExtendedVariance();
+      suppressRecovery = toggles.getEndpointAbuseSuppressRecovery();
+      customVarianceSubstrings = toggles.getEndpointAbuseCustomVarianceSubstrings();
+      sessionGapDurationMinutes = toggles.getSessionGapDurationMinutes();
 
       String[] cfgEndpoints = options.getEndpointAbusePath();
       endpoints = new EndpointAbuseEndpointInfo[cfgEndpoints.length];
@@ -899,11 +820,11 @@ public class HTTPRequest implements Serializable {
      *
      * @param options {@link HTTPRequestOptions}
      */
-    public ThresholdAnalysis(HTTPRequestOptions options) {
-      this.thresholdModifier = options.getAnalysisThresholdModifier();
-      this.requiredMinimumAverage = options.getRequiredMinimumAverage();
-      this.requiredMinimumClients = options.getRequiredMinimumClients();
-      this.clampThresholdMaximum = options.getClampThresholdMaximum();
+    public ThresholdAnalysis(HTTPRequestOptions options, HTTPRequestToggles toggles) {
+      this.thresholdModifier = toggles.getAnalysisThresholdModifier();
+      this.requiredMinimumAverage = toggles.getRequiredMinimumAverage();
+      this.requiredMinimumClients = toggles.getRequiredMinimumClients();
+      this.clampThresholdMaximum = toggles.getClampThresholdMaximum();
       this.monitoredResource = options.getMonitoredResourceIndicator();
       this.enableIprepdDatastoreWhitelist = options.getOutputIprepdEnableDatastoreWhitelist();
       this.iprepdDatastoreWhitelistProject = options.getOutputIprepdDatastoreWhitelistProject();
@@ -917,8 +838,10 @@ public class HTTPRequest implements Serializable {
      * @param natView Use {@link DetectNat} view during threshold analysis
      */
     public ThresholdAnalysis(
-        HTTPRequestOptions options, PCollectionView<Map<String, Boolean>> natView) {
-      this(options);
+        HTTPRequestOptions options,
+        HTTPRequestToggles toggles,
+        PCollectionView<Map<String, Boolean>> natView) {
+      this(options, toggles);
       this.natView = natView;
     }
 
@@ -1187,121 +1110,240 @@ public class HTTPRequest implements Serializable {
     Boolean getIgnoreInternalRequests();
 
     void setIgnoreInternalRequests(Boolean value);
+
+    @Description("Load multimode configuration file; resource path, gcs path")
+    String getPipelineMultimodeConfiguration();
+
+    void setPipelineMultimodeConfiguration(String value);
+
+    @Description("Wired input stream; used only in testing")
+    Boolean getWiredInputStream();
+
+    void setWiredInputStream(Boolean value);
   }
 
   /**
-   * Build a configuration tick for HTTPRequest given pipeline options
+   * Build a configuration tick for HTTPRequest given pipeline options and configuration toggles
    *
    * @param options Pipeline options
+   * @param toggles Analysis toggles
    * @return String
    */
-  public static String buildConfigurationTick(HTTPRequestOptions options) throws IOException {
+  public static String buildConfigurationTick(
+      HTTPRequestOptions options, HTTPRequestToggles toggles) throws IOException {
     CfgTickBuilder b = new CfgTickBuilder().includePipelineOptions(options);
 
     if (options.getEnableThresholdAnalysis()) {
-      b.withTransformDoc(new ThresholdAnalysis(options, null));
+      b.withTransformDoc(new ThresholdAnalysis(options, toggles, null));
     }
     if (options.getEnableHardLimitAnalysis()) {
-      b.withTransformDoc(new HardLimitAnalysis(options, null));
+      b.withTransformDoc(new HardLimitAnalysis(options, toggles, null));
     }
     if (options.getEnableErrorRateAnalysis()) {
-      b.withTransformDoc(new ErrorRateAnalysis(options));
+      b.withTransformDoc(new ErrorRateAnalysis(options, toggles));
     }
     if (options.getEnableUserAgentBlacklistAnalysis()) {
-      b.withTransformDoc(new UserAgentBlacklistAnalysis(options, null));
+      b.withTransformDoc(new UserAgentBlacklistAnalysis(options, toggles, null));
     }
     if (options.getEnableEndpointAbuseAnalysis()) {
-      b.withTransformDoc(new EndpointAbuseAnalysis(options));
+      b.withTransformDoc(new EndpointAbuseAnalysis(options, toggles));
     }
 
     return b.build();
   }
 
-  private static void runHTTPRequest(HTTPRequestOptions options) {
-    Pipeline p = Pipeline.create(options);
+  /**
+   * Perform analysis on a given collection of events
+   *
+   * @param events Event PCollection
+   * @param options Pipeline options
+   * @param toggles Per-collection analysis toggles
+   * @return Collection of alerts
+   */
+  public static PCollection<Alert> analysis(
+      PCollection<Event> events, HTTPRequestOptions options, HTTPRequestToggles toggles) {
+    PCollectionList<Alert> resultsList = PCollectionList.empty(events.getPipeline());
 
-    PCollection<Event> events;
-    try {
-      events =
-          p.apply("input", Input.compositeInputAdapter(options, buildConfigurationTick(options)))
-              .apply("parse", new Parse(options));
-    } catch (IOException exc) {
-      throw new RuntimeException(exc.getMessage());
-    }
-
-    PCollectionList<Alert> resultsList = PCollectionList.empty(p);
-
-    if (options.getEnableThresholdAnalysis()
-        || options.getEnableErrorRateAnalysis()
-        || options.getEnableHardLimitAnalysis()) {
+    if (toggles.getEnableThresholdAnalysis()
+        || toggles.getEnableErrorRateAnalysis()
+        || toggles.getEnableHardLimitAnalysis()
+        || toggles.getEnableUserAgentBlacklistAnalysis()) {
       PCollection<Event> fwEvents = events.apply("window for fixed", new WindowForFixed());
 
       PCollectionView<Map<String, Boolean>> natView = null;
-      if (options.getNatDetection()) {
+      if (toggles.getEnableNatDetection()) {
         natView = DetectNat.getView(fwEvents);
       }
 
-      if (options.getEnableThresholdAnalysis()) {
+      if (toggles.getEnableThresholdAnalysis()) {
         resultsList =
             resultsList.and(
                 fwEvents
-                    .apply("threshold analysis", new ThresholdAnalysis(options, natView))
+                    .apply("threshold analysis", new ThresholdAnalysis(options, toggles, natView))
                     .apply("threshold analysis global", new GlobalTriggers<Alert>(5)));
       }
 
-      if (options.getEnableHardLimitAnalysis()) {
+      if (toggles.getEnableHardLimitAnalysis()) {
         resultsList =
             resultsList.and(
                 fwEvents
-                    .apply("hard limit analysis", new HardLimitAnalysis(options, natView))
+                    .apply("hard limit analysis", new HardLimitAnalysis(options, toggles, natView))
                     .apply("hard limit analysis global", new GlobalTriggers<Alert>(5)));
       }
 
-      if (options.getEnableErrorRateAnalysis()) {
+      if (toggles.getEnableErrorRateAnalysis()) {
         resultsList =
             resultsList.and(
                 fwEvents
-                    .apply("error rate analysis", new ErrorRateAnalysis(options))
+                    .apply("error rate analysis", new ErrorRateAnalysis(options, toggles))
                     .apply("error rate analysis global", new GlobalTriggers<Alert>(5)));
       }
 
-      if (options.getEnableUserAgentBlacklistAnalysis()) {
+      if (toggles.getEnableUserAgentBlacklistAnalysis()) {
         resultsList =
             resultsList.and(
                 fwEvents
                     .apply(
-                        "ua blacklist analysis", new UserAgentBlacklistAnalysis(options, natView))
+                        "ua blacklist analysis",
+                        new UserAgentBlacklistAnalysis(options, toggles, natView))
                     .apply("ua blacklist analysis global", new GlobalTriggers<Alert>(5)));
       }
     }
 
-    if (options.getEnableEndpointAbuseAnalysis()) {
+    if (toggles.getEnableEndpointAbuseAnalysis()) {
       resultsList =
           resultsList.and(
               events
                   .apply(
                       "key and window for sessions fire early",
-                      new KeyAndWindowForSessionsFireEarly(options))
+                      new KeyAndWindowForSessionsFireEarly(toggles))
                   // No requirement for follow up application of GlobalTriggers here since
                   // EndpointAbuseAnalysis will do this for us
-                  .apply("endpoint abuse analysis", new EndpointAbuseAnalysis(options)));
+                  .apply("endpoint abuse analysis", new EndpointAbuseAnalysis(options, toggles)));
     }
 
-    // If configuration ticks were enabled, enable the processor here too
-    if (options.getGenerateConfigurationTicksInterval() > 0) {
+    return resultsList.apply("flatten analysis output", Flatten.<Alert>pCollections());
+  }
+
+  /**
+   * Given HTTPRequest pipeline options, return a configured {@link Input} class
+   *
+   * <p>The returned input object will be configured based on the HTTPRequest pipeline options, and
+   * will have all applicable filters assigned.
+   *
+   * @param p Pipeline
+   * @param options Pipeline options
+   * @return Configured Input object
+   */
+  public static Input getInput(Pipeline p, HTTPRequestOptions options) throws IOException {
+    // Always use a multiplexed read here, even if we will only have one element associated
+    // with our input.
+    Input input = new Input(options.getProject()).multiplex();
+
+    if (options.getPipelineMultimodeConfiguration() != null) {
+      // XXX For now just throw an exception here.
+      throw new RuntimeException("multimode configuration not yet supported");
+    } else {
+      // We are using pipeline options based input configuration. Start with a new input element
+      // based on that configuration, we will essentially simulate a multimode configuration with
+      // a single element specified.
+      //
+      // We will simply use the monitored resource set in the pipeline options as the element name,
+      // which in turn will be reflected in alerts created.
+      //
+      // Since we are using pipeline options for all configuration here, we can also use them
+      // to build the configuration tick.
+      InputElement e =
+          InputElement.fromPipelineOptions(
+              options.getMonitoredResourceIndicator(),
+              options,
+              buildConfigurationTick(options, HTTPRequestToggles.fromPipelineOptions(options)));
+      e.setParserConfiguration(ParserCfg.fromInputOptions(options))
+          .setEventFilter(HTTPRequestToggles.fromPipelineOptions(options).toStandardFilter());
+      input.withInputElement(e);
+      toggleCache.put(
+          options.getMonitoredResourceIndicator(), HTTPRequestToggles.fromPipelineOptions(options));
+    }
+
+    return input;
+  }
+
+  /**
+   * Read from a configured {@link Input} object, returning a map of events
+   *
+   * <p>The map that is returned will have a string key that reflects the element name (which should
+   * correspond to the monitored resource), and the value will be a collection of events for that
+   * element.
+   *
+   * @param p Pipeline
+   * @param input Configured {@link Input} object
+   * @param options Pipeline options
+   * @return Map of element name/event collection
+   */
+  public static HashMap<String, PCollection<Event>> readInput(
+      Pipeline p, Input input, HTTPRequestOptions options) {
+    // Perform the multiplexed read operations
+    PCollection<KV<String, Event>> col = p.apply("input", input.multiplexRead());
+
+    HashMap<String, PCollection<Event>> ret = new HashMap<>();
+    // For each configured element, extract the resulting collection and associate it with
+    // a key in our input map.
+    for (InputElement e : input.getInputElements()) {
+      if (!toggleCache.containsKey(e.getName())) {
+        throw new RuntimeException(String.format("no toggle cache entry for %s", e.getName()));
+      }
+      PCollection<Event> t =
+          col.apply(
+              "per-element filter",
+              new HTTPRequestElementFilter(e.getName(), toggleCache.get(e.getName())));
+      ret.put(e.getName(), t);
+    }
+
+    return ret;
+  }
+
+  /**
+   * Expand the input map, executing analysis transforms for each element
+   *
+   * @param p Pipeline
+   * @param inputMap Map of service name to input collection
+   * @param options Pipeline options
+   * @return Flattened alerts in the global window
+   */
+  public static PCollection<Alert> expandInputMap(
+      Pipeline p, HashMap<String, PCollection<Event>> inputMap, HTTPRequestOptions options) {
+    PCollectionList<Alert> resultsList = PCollectionList.empty(p);
+
+    for (Map.Entry<String, PCollection<Event>> entry : inputMap.entrySet()) {
       resultsList =
-          resultsList.and(
-              events
-                  .apply(
-                      "cfgtick processor",
-                      ParDo.of(new CfgTickProcessor("httprequest-cfgtick", "category")))
-                  .apply(new GlobalTriggers<Alert>(5)));
+          resultsList
+              .and(
+                  analysis(entry.getValue(), options, toggleCache.get(entry.getKey()))
+                      .setCoder(SerializableCoder.of(Alert.class)))
+              .and(
+                  entry
+                      .getValue()
+                      .apply(
+                          "cfgtick processor",
+                          ParDo.of(new CfgTickProcessor("httprequest-cfgtick", "category")))
+                      .apply(new GlobalTriggers<Alert>(5)));
     }
 
-    resultsList
-        .apply("flatten output", Flatten.<Alert>pCollections())
+    return resultsList.apply("flatten all output", Flatten.<Alert>pCollections());
+  }
+
+  private static void standardOutput(PCollection<Alert> alerts, HTTPRequestOptions options) {
+    alerts
         .apply("output format", ParDo.of(new AlertFormatter(options)))
         .apply("output", OutputOptions.compositeOutput(options));
+  }
+
+  private static void runHTTPRequest(HTTPRequestOptions options) throws IOException {
+    Pipeline p = Pipeline.create(options);
+
+    Input input = getInput(p, options);
+    HashMap<String, PCollection<Event>> inputMap = readInput(p, input, options);
+    standardOutput(expandInputMap(p, inputMap, options), options);
 
     p.run();
   }
@@ -1311,7 +1353,7 @@ public class HTTPRequest implements Serializable {
    *
    * @param args Runtime arguments.
    */
-  public static void main(String[] args) {
+  public static void main(String[] args) throws Exception {
     PipelineOptionsFactory.register(HTTPRequestOptions.class);
     HTTPRequestOptions options =
         PipelineOptionsFactory.fromArgs(args).withValidation().as(HTTPRequestOptions.class);

--- a/src/main/java/com/mozilla/secops/httprequest/HTTPRequestElementFilter.java
+++ b/src/main/java/com/mozilla/secops/httprequest/HTTPRequestElementFilter.java
@@ -19,11 +19,11 @@ public class HTTPRequestElementFilter
     extends PTransform<PCollection<KV<String, Event>>, PCollection<Event>> {
   private static final long serialVersionUID = 1L;
 
-  private String name;
+  private final String name;
 
-  private Boolean ignoreCp;
-  private Boolean ignoreInternal;
-  private String cidrExclusionList;
+  private final Boolean ignoreCp;
+  private final Boolean ignoreInternal;
+  private final String cidrExclusionList;
 
   /**
    * Initialize new element filter

--- a/src/main/java/com/mozilla/secops/httprequest/HTTPRequestElementFilter.java
+++ b/src/main/java/com/mozilla/secops/httprequest/HTTPRequestElementFilter.java
@@ -1,0 +1,76 @@
+package com.mozilla.secops.httprequest;
+
+import com.mozilla.secops.CidrUtil;
+import com.mozilla.secops.parser.Event;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+
+/**
+ * Post-input filter for per-element analysis
+ *
+ * <p>The primary intent of this transform is filtering an event stream to ensure it contains only
+ * events for the desired element. Additional filtering such as network address/CIDR based filtering
+ * also occurs here.
+ */
+public class HTTPRequestElementFilter
+    extends PTransform<PCollection<KV<String, Event>>, PCollection<Event>> {
+  private static final long serialVersionUID = 1L;
+
+  private String name;
+
+  private Boolean ignoreCp;
+  private Boolean ignoreInternal;
+  private String cidrExclusionList;
+
+  /**
+   * Initialize new element filter
+   *
+   * @param name Resource name that we want, all others will be filtered
+   * @param toggles Per-element toggles
+   */
+  public HTTPRequestElementFilter(String name, HTTPRequestToggles toggles) {
+    this.name = name;
+
+    ignoreCp = toggles.getIgnoreCloudProviderRequests();
+    ignoreInternal = toggles.getIgnoreInternalRequests();
+    cidrExclusionList = toggles.getCidrExclusionList();
+  }
+
+  @Override
+  public PCollection<Event> expand(PCollection<KV<String, Event>> col) {
+    PCollection<Event> events =
+        col.apply(
+            "filter keys for element",
+            ParDo.of(
+                new DoFn<KV<String, Event>, Event>() {
+                  private static final long serialVersionUID = 1L;
+
+                  @ProcessElement
+                  public void processElement(ProcessContext c) {
+                    KV<String, Event> e = c.element();
+                    if (e.getKey().equals(name)) {
+                      c.output(e.getValue());
+                    }
+                  }
+                }));
+    int exclmask = 0;
+    if (cidrExclusionList != null) {
+      exclmask |= CidrUtil.CIDRUTIL_FILE;
+    }
+    if (ignoreCp) {
+      exclmask |= CidrUtil.CIDRUTIL_CLOUDPROVIDERS;
+    }
+    if (ignoreInternal) {
+      exclmask |= CidrUtil.CIDRUTIL_INTERNAL;
+    }
+    if (exclmask != 0) {
+      return events.apply(
+          "cidr exclusion",
+          ParDo.of(CidrUtil.excludeNormalizedSourceAddresses(exclmask, cidrExclusionList)));
+    }
+    return events;
+  }
+}

--- a/src/main/java/com/mozilla/secops/httprequest/HTTPRequestMultiMode.java
+++ b/src/main/java/com/mozilla/secops/httprequest/HTTPRequestMultiMode.java
@@ -1,0 +1,80 @@
+package com.mozilla.secops.httprequest;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mozilla.secops.GcsUtil;
+import com.mozilla.secops.input.Input;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+
+/** HTTPRequest multimode configuration */
+@JsonInclude(Include.NON_EMPTY)
+public class HTTPRequestMultiMode {
+  private Input input;
+  private HashMap<String, HTTPRequestToggles> serviceToggles;
+
+  /**
+   * Load multimode configuration from GCS or as a resource
+   *
+   * @param path Path to load JSON file from, resource path or GCS URL
+   * @return {@link HTTPRequestMultiMode}
+   */
+  public static HTTPRequestMultiMode load(String path) throws IOException {
+    InputStream in;
+    if (path == null) {
+      throw new IOException("attempt to load multimode configuration with null path");
+    }
+    if (GcsUtil.isGcsUrl(path)) {
+      in = GcsUtil.fetchInputStreamContent(path);
+    } else {
+      in = HTTPRequestMultiMode.class.getResourceAsStream(path);
+    }
+    if (in == null) {
+      throw new IOException("multimode configuration resource not found");
+    }
+    ObjectMapper mapper = new ObjectMapper();
+    return mapper.readValue(in, HTTPRequestMultiMode.class);
+  }
+
+  /**
+   * Set input configuration
+   *
+   * @param input Input
+   */
+  @JsonProperty("input")
+  public void setInput(Input input) {
+    this.input = input;
+  }
+
+  /**
+   * Get input configuration
+   *
+   * @return Input
+   */
+  public Input getInput() {
+    return input;
+  }
+
+  /**
+   * Set service toggles
+   *
+   * @param serviceToggles Map of service/HTTPRequestToggles
+   */
+  @JsonProperty("service_toggles")
+  public void setServiceToggles(HashMap<String, HTTPRequestToggles> serviceToggles) {
+    this.serviceToggles = serviceToggles;
+  }
+
+  /**
+   * Get service toggles
+   *
+   * @return Map of service/HTTPRequestToggles
+   */
+  public HashMap<String, HTTPRequestToggles> getServiceToggles() {
+    return serviceToggles;
+  }
+}

--- a/src/main/java/com/mozilla/secops/httprequest/HTTPRequestResourceTag.java
+++ b/src/main/java/com/mozilla/secops/httprequest/HTTPRequestResourceTag.java
@@ -1,0 +1,32 @@
+package com.mozilla.secops.httprequest;
+
+import com.mozilla.secops.alert.Alert;
+import org.apache.beam.sdk.transforms.DoFn;
+
+/**
+ * Add monitored resource indicator
+ *
+ * <p>Performs a similar function to AlertFormatter, however is intended for use with partitioned
+ * per-service pipelines
+ */
+public class HTTPRequestResourceTag extends DoFn<Alert, Alert> {
+  private static final long serialVersionUID = 1L;
+
+  private final String monitoredResourceIndicator;
+
+  /**
+   * Create new HTTPRequestResourceTag
+   *
+   * @param name Name to assign to monitored_resource
+   */
+  public HTTPRequestResourceTag(String name) {
+    monitoredResourceIndicator = name;
+  }
+
+  @ProcessElement
+  public void processElement(ProcessContext c) {
+    Alert a = c.element();
+    a.addMetadata("monitored_resource", monitoredResourceIndicator);
+    c.output(a);
+  }
+}

--- a/src/main/java/com/mozilla/secops/httprequest/HTTPRequestToggles.java
+++ b/src/main/java/com/mozilla/secops/httprequest/HTTPRequestToggles.java
@@ -1,0 +1,218 @@
+package com.mozilla.secops.httprequest;
+
+public class HTTPRequestToggles {
+  // Mode toggles
+  private Boolean enableThresholdAnalysis = false;
+  private Boolean enableErrorRateAnalysis = false;
+  private Boolean enableEndpointAbuseAnalysis = false;
+  private Boolean enableHardLimitAnalysis = false;
+  private Boolean enableUserAgentBlacklistAnalysis = false;
+  private Boolean enableNatDetection = false;
+
+  // Hard limit settings
+  private Long hardLimitRequestCount = 100L;
+
+  // Threshold analysis settings
+  private Double analysisThresholdModifier = 75.0;
+  private Double requiredMinimumAverage = 5.0;
+  private Long requiredMinimumClients = 5L;
+  private Double clampThresholdMaximum;
+
+  // Error rate settings
+  private Long maxClientErrorRate = 30L;
+
+  // User agent blacklist settings
+  private String userAgentBlacklistPath;
+
+  // Endpoint abuse settings
+  private String[] endpointAbusePath;
+  private Boolean endpointAbuseExtendedVariance = false;
+  private String[] endpointAbuseCustomVarianceSubstrings;
+  private Integer endpointAbuseSuppressRecovery;
+  private Long sessionGapDurationMinutes = 45L;
+
+  // Filtering settings
+  private String[] filterRequestPath;
+  private String[] includeUrlHostRegex;
+  private String cidrExclusionList;
+  private Boolean ignoreCloudProviderRequests = true;
+  private Boolean ignoreInternalRequests = true;
+
+  public void setEnableThresholdAnalysis(Boolean enableThresholdAnalysis) {
+    this.enableThresholdAnalysis = enableThresholdAnalysis;
+  }
+
+  public Boolean getEnableThresholdAnalysis() {
+    return enableThresholdAnalysis;
+  }
+
+  public void setAnalysisThresholdModifier(Double value) {
+    analysisThresholdModifier = value;
+  }
+
+  public Double getAnalysisThresholdModifier() {
+    return analysisThresholdModifier;
+  }
+
+  public void setRequiredMinimumAverage(Double value) {
+    requiredMinimumAverage = value;
+  }
+
+  public Double getRequiredMinimumAverage() {
+    return requiredMinimumAverage;
+  }
+
+  public void setRequiredMinimumClients(Long value) {
+    requiredMinimumClients = value;
+  }
+
+  public Long getRequiredMinimumClients() {
+    return requiredMinimumClients;
+  }
+
+  public void setClampThresholdMaximum(Double value) {
+    clampThresholdMaximum = value;
+  }
+
+  public Double getClampThresholdMaximum() {
+    return clampThresholdMaximum;
+  }
+
+  public void setEnableErrorRateAnalysis(Boolean enableErrorRateAnalysis) {
+    this.enableErrorRateAnalysis = enableErrorRateAnalysis;
+  }
+
+  public Boolean getEnableErrorRateAnalysis() {
+    return enableErrorRateAnalysis;
+  }
+
+  public void setMaxClientErrorRate(Long value) {
+    maxClientErrorRate = value;
+  }
+
+  public Long getMaxClientErrorRate() {
+    return maxClientErrorRate;
+  }
+
+  public void setEnableEndpointAbuseAnalysis(Boolean enableEndpointAbuseAnalysis) {
+    this.enableEndpointAbuseAnalysis = enableEndpointAbuseAnalysis;
+  }
+
+  public Boolean getEnableEndpointAbuseAnalysis() {
+    return enableEndpointAbuseAnalysis;
+  }
+
+  public void setEnableHardLimitAnalysis(Boolean enableHardLimitAnalysis) {
+    this.enableHardLimitAnalysis = enableHardLimitAnalysis;
+  }
+
+  public void setEndpointAbusePath(String[] value) {
+    endpointAbusePath = value;
+  }
+
+  public String[] getEndpointAbusePath() {
+    return endpointAbusePath;
+  }
+
+  public void setEndpointAbuseExtendedVariance(Boolean value) {
+    endpointAbuseExtendedVariance = value;
+  }
+
+  public Boolean getEndpointAbuseExtendedVariance() {
+    return endpointAbuseExtendedVariance;
+  }
+
+  public void setEndpointAbuseCustomVarianceSubstrings(String[] value) {
+    endpointAbuseCustomVarianceSubstrings = value;
+  }
+
+  public String[] getEndpointAbuseCustomVarianceSubstrings() {
+    return endpointAbuseCustomVarianceSubstrings;
+  }
+
+  public void setEndpointAbuseSuppressRecovery(Integer value) {
+    endpointAbuseSuppressRecovery = value;
+  }
+
+  public Integer getEndpointAbuseSuppressRecovery() {
+    return endpointAbuseSuppressRecovery;
+  }
+
+  public void setSessionGapDurationMinutes(Long value) {
+    sessionGapDurationMinutes = value;
+  }
+
+  public Long getSessionGapDurationMinutes() {
+    return sessionGapDurationMinutes;
+  }
+
+  public Boolean getEnableHardLimitAnalysis() {
+    return enableHardLimitAnalysis;
+  }
+
+  public void setHardLimitRequestCount(Long value) {
+    hardLimitRequestCount = value;
+  }
+
+  public Long getHardLimitRequestCount() {
+    return hardLimitRequestCount;
+  }
+
+  public void setEnableUserAgentBlacklistAnalysis(Boolean enableUserAgentBlacklistAnalysis) {
+    this.enableUserAgentBlacklistAnalysis = enableUserAgentBlacklistAnalysis;
+  }
+
+  public Boolean getEnableUserAgentBlacklistAnalysis() {
+    return enableUserAgentBlacklistAnalysis;
+  }
+
+  public void setUserAgentBlacklistPath(String value) {
+    userAgentBlacklistPath = value;
+  }
+
+  public String getUserAgentBlacklistPath() {
+    return userAgentBlacklistPath;
+  }
+
+  public void setFilterRequestPath(String[] value) {
+    filterRequestPath = value;
+  }
+
+  public String[] getFilterRequestPath() {
+    return filterRequestPath;
+  }
+
+  public void setIncludeUrlHostRegex(String[] value) {
+    includeUrlHostRegex = value;
+  }
+
+  public String[] getIncludeUrlHostRegex() {
+    return includeUrlHostRegex;
+  }
+
+  public void setCidrExclusionList(String value) {
+    cidrExclusionList = value;
+  }
+
+  public String getCidrExclusionList() {
+    return cidrExclusionList;
+  }
+
+  public void setIgnoreCloudProviderRequests(Boolean value) {
+    ignoreCloudProviderRequests = value;
+  }
+
+  public Boolean getIgnoreCloudProviderRequests() {
+    return ignoreCloudProviderRequests;
+  }
+
+  public void setIgnoreInternalRequests(Boolean value) {
+    ignoreInternalRequests = value;
+  }
+
+  public Boolean getIgnoreInternalRequests() {
+    return ignoreInternalRequests;
+  }
+
+  public HTTPRequestToggles() {}
+}

--- a/src/main/java/com/mozilla/secops/httprequest/HTTPRequestToggles.java
+++ b/src/main/java/com/mozilla/secops/httprequest/HTTPRequestToggles.java
@@ -2,6 +2,7 @@ package com.mozilla.secops.httprequest;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mozilla.secops.parser.EventFilter;
@@ -49,6 +50,9 @@ public class HTTPRequestToggles {
   private String cidrExclusionList;
   private Boolean ignoreCloudProviderRequests;
   private Boolean ignoreInternalRequests;
+
+  // Misc settings
+  private String monitoredResource;
 
   /**
    * Set enable NAT detection setting
@@ -355,7 +359,7 @@ public class HTTPRequestToggles {
   }
 
   /**
-   * Get user agent blacklist analysis setting
+   * Set user agent blacklist analysis setting
    *
    * @param enableUserAgentBlacklistAnalysis Boolean
    */
@@ -488,10 +492,30 @@ public class HTTPRequestToggles {
   }
 
   /**
+   * Set monitored resource
+   *
+   * @param value String
+   */
+  @JsonIgnore
+  public void setMonitoredResource(String value) {
+    monitoredResource = value;
+  }
+
+  /**
+   * Get monitored resource
+   *
+   * @return String
+   */
+  public String getMonitoredResource() {
+    return monitoredResource;
+  }
+
+  /**
    * Convert the toggles to a standard EventFilter for use in HTTPRequest
    *
    * <p>Note that this filter does not apply any form of address exclusion if indicated in the
-   * toggles. This must be handled outside of the event filter.
+   * toggles. This must be handled outside of the event filter, typically within {@link
+   * HTTPRequestElementFilter}.
    *
    * @return EventFilter
    */
@@ -556,6 +580,13 @@ public class HTTPRequestToggles {
    */
   public static HTTPRequestToggles fromPipelineOptions(HTTPRequest.HTTPRequestOptions o) {
     HTTPRequestToggles ret = new HTTPRequestToggles();
+
+    // Use the monitored resource indicator from pipeline options as the resource name
+    // here, since we'd only use this function in cases where a single service is being
+    // monitored and we are configuring with global pipeline options.
+    //
+    // This will ensure the correct service name is used in alert messages.
+    ret.setMonitoredResource(o.getMonitoredResourceIndicator());
 
     ret.setEnableThresholdAnalysis(o.getEnableThresholdAnalysis());
     ret.setEnableErrorRateAnalysis(o.getEnableErrorRateAnalysis());

--- a/src/main/java/com/mozilla/secops/httprequest/HTTPRequestToggles.java
+++ b/src/main/java/com/mozilla/secops/httprequest/HTTPRequestToggles.java
@@ -1,218 +1,489 @@
 package com.mozilla.secops.httprequest;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** Configuration toggles for HTTPRequest pipeline analysis */
+@JsonInclude(Include.NON_EMPTY)
 public class HTTPRequestToggles {
   // Mode toggles
-  private Boolean enableThresholdAnalysis = false;
-  private Boolean enableErrorRateAnalysis = false;
-  private Boolean enableEndpointAbuseAnalysis = false;
-  private Boolean enableHardLimitAnalysis = false;
-  private Boolean enableUserAgentBlacklistAnalysis = false;
-  private Boolean enableNatDetection = false;
+  private Boolean enableThresholdAnalysis;
+  private Boolean enableErrorRateAnalysis;
+  private Boolean enableEndpointAbuseAnalysis;
+  private Boolean enableHardLimitAnalysis;
+  private Boolean enableUserAgentBlacklistAnalysis;
+  private Boolean enableNatDetection;
 
   // Hard limit settings
-  private Long hardLimitRequestCount = 100L;
+  private Long hardLimitRequestCount;
 
   // Threshold analysis settings
-  private Double analysisThresholdModifier = 75.0;
-  private Double requiredMinimumAverage = 5.0;
-  private Long requiredMinimumClients = 5L;
+  private Double analysisThresholdModifier;
+  private Double requiredMinimumAverage;
+  private Long requiredMinimumClients;
   private Double clampThresholdMaximum;
 
   // Error rate settings
-  private Long maxClientErrorRate = 30L;
+  private Long maxClientErrorRate;
 
   // User agent blacklist settings
   private String userAgentBlacklistPath;
 
   // Endpoint abuse settings
   private String[] endpointAbusePath;
-  private Boolean endpointAbuseExtendedVariance = false;
+  private Boolean endpointAbuseExtendedVariance;
   private String[] endpointAbuseCustomVarianceSubstrings;
   private Integer endpointAbuseSuppressRecovery;
-  private Long sessionGapDurationMinutes = 45L;
+  private Long sessionGapDurationMinutes;
 
   // Filtering settings
   private String[] filterRequestPath;
   private String[] includeUrlHostRegex;
   private String cidrExclusionList;
-  private Boolean ignoreCloudProviderRequests = true;
-  private Boolean ignoreInternalRequests = true;
+  private Boolean ignoreCloudProviderRequests;
+  private Boolean ignoreInternalRequests;
 
+  /**
+   * Set threshold analysis setting
+   *
+   * @param enableThresholdAnalysis Boolean
+   */
+  @JsonProperty("enable_threshold_analysis")
   public void setEnableThresholdAnalysis(Boolean enableThresholdAnalysis) {
     this.enableThresholdAnalysis = enableThresholdAnalysis;
   }
 
+  /**
+   * Get threshold analysis setting
+   *
+   * @return Boolean
+   */
   public Boolean getEnableThresholdAnalysis() {
     return enableThresholdAnalysis;
   }
 
+  /**
+   * Set analysis threshold modifier
+   *
+   * @param value Value
+   */
+  @JsonProperty("analysis_threshold_modifier")
   public void setAnalysisThresholdModifier(Double value) {
     analysisThresholdModifier = value;
   }
 
+  /**
+   * Get analysis threshold modifier
+   *
+   * @return Double
+   */
   public Double getAnalysisThresholdModifier() {
     return analysisThresholdModifier;
   }
 
+  /**
+   * Set required minimum average
+   *
+   * @param value Double
+   */
+  @JsonProperty("required_minimum_average")
   public void setRequiredMinimumAverage(Double value) {
     requiredMinimumAverage = value;
   }
 
+  /**
+   * Get required minimum average
+   *
+   * @return Double
+   */
   public Double getRequiredMinimumAverage() {
     return requiredMinimumAverage;
   }
 
+  /**
+   * Set required minimum clients
+   *
+   * @param value Long
+   */
+  @JsonProperty("required_minimum_clients")
   public void setRequiredMinimumClients(Long value) {
     requiredMinimumClients = value;
   }
 
+  /**
+   * Get required minimum clients
+   *
+   * @return Long
+   */
   public Long getRequiredMinimumClients() {
     return requiredMinimumClients;
   }
 
+  /**
+   * Set clamp threshold maximum
+   *
+   * @param value Double
+   */
+  @JsonProperty("clamp_threshold_maximum")
   public void setClampThresholdMaximum(Double value) {
     clampThresholdMaximum = value;
   }
 
+  /**
+   * Get clamp threshold maximum
+   *
+   * @return Double
+   */
   public Double getClampThresholdMaximum() {
     return clampThresholdMaximum;
   }
 
+  /**
+   * Set error rate analysis setting
+   *
+   * @param enableErrorRateAnalysis Boolean
+   */
+  @JsonProperty("enable_error_rate_analysis")
   public void setEnableErrorRateAnalysis(Boolean enableErrorRateAnalysis) {
     this.enableErrorRateAnalysis = enableErrorRateAnalysis;
   }
 
+  /**
+   * Get error rate analysis setting
+   *
+   * @return Boolean
+   */
   public Boolean getEnableErrorRateAnalysis() {
     return enableErrorRateAnalysis;
   }
 
+  /**
+   * Set max client error rate
+   *
+   * @param value Long
+   */
+  @JsonProperty("max_client_error_rate")
   public void setMaxClientErrorRate(Long value) {
     maxClientErrorRate = value;
   }
 
+  /**
+   * Get max client error rate
+   *
+   * @return Long
+   */
   public Long getMaxClientErrorRate() {
     return maxClientErrorRate;
   }
 
+  /**
+   * Set endpoint abuse analysis setting
+   *
+   * @param enableEndpointAbuseAnalysis Boolean
+   */
+  @JsonProperty("enable_endpoint_abuse_analysis")
   public void setEnableEndpointAbuseAnalysis(Boolean enableEndpointAbuseAnalysis) {
     this.enableEndpointAbuseAnalysis = enableEndpointAbuseAnalysis;
   }
 
+  /**
+   * Get endpoint abuse analysis setting
+   *
+   * @return Boolean
+   */
   public Boolean getEnableEndpointAbuseAnalysis() {
     return enableEndpointAbuseAnalysis;
   }
 
-  public void setEnableHardLimitAnalysis(Boolean enableHardLimitAnalysis) {
-    this.enableHardLimitAnalysis = enableHardLimitAnalysis;
-  }
-
+  /**
+   * Set endpoint abuse path
+   *
+   * @param value String[]
+   */
+  @JsonProperty("endpoint_abuse_path")
   public void setEndpointAbusePath(String[] value) {
     endpointAbusePath = value;
   }
 
+  /**
+   * Get endpoint abuse path
+   *
+   * @return String[]
+   */
   public String[] getEndpointAbusePath() {
     return endpointAbusePath;
   }
 
+  /**
+   * Set endpoint abuse extended variance
+   *
+   * @param value Boolean
+   */
+  @JsonProperty("endpoint_abuse_extended_variance")
   public void setEndpointAbuseExtendedVariance(Boolean value) {
     endpointAbuseExtendedVariance = value;
   }
 
+  /**
+   * Get endpoint abuse extended variance
+   *
+   * @return Boolean
+   */
   public Boolean getEndpointAbuseExtendedVariance() {
     return endpointAbuseExtendedVariance;
   }
 
+  /**
+   * Set endpoint abuse custom variance substrings
+   *
+   * @param value String[]
+   */
+  @JsonProperty("endpoint_abuse_custom_variance_substrings")
   public void setEndpointAbuseCustomVarianceSubstrings(String[] value) {
     endpointAbuseCustomVarianceSubstrings = value;
   }
 
+  /**
+   * Get endpoint abuse custom variance substrings
+   *
+   * @return String[]
+   */
   public String[] getEndpointAbuseCustomVarianceSubstrings() {
     return endpointAbuseCustomVarianceSubstrings;
   }
 
+  /**
+   * Set endpoint abuse suppress recovery
+   *
+   * @param value Integer
+   */
+  @JsonProperty("endpoint_abuse_suppress_recovery")
   public void setEndpointAbuseSuppressRecovery(Integer value) {
     endpointAbuseSuppressRecovery = value;
   }
 
+  /**
+   * Get endpoint abuse suppress recovery
+   *
+   * @return Integer
+   */
   public Integer getEndpointAbuseSuppressRecovery() {
     return endpointAbuseSuppressRecovery;
   }
 
+  /**
+   * Set session gap duration minutes
+   *
+   * @param value Long
+   */
+  @JsonProperty("session_gap_duration_minutes")
   public void setSessionGapDurationMinutes(Long value) {
     sessionGapDurationMinutes = value;
   }
 
+  /**
+   * Get session gap duration minutes
+   *
+   * @return Long
+   */
   public Long getSessionGapDurationMinutes() {
     return sessionGapDurationMinutes;
   }
 
+  /**
+   * Set hard limit analysis setting
+   *
+   * @param enableHardLimitAnalysis Boolean
+   */
+  @JsonProperty("enable_hard_limit_analysis")
+  public void setEnableHardLimitAnalysis(Boolean enableHardLimitAnalysis) {
+    this.enableHardLimitAnalysis = enableHardLimitAnalysis;
+  }
+
+  /**
+   * Get hard limit analysis setting
+   *
+   * @return Boolean
+   */
   public Boolean getEnableHardLimitAnalysis() {
     return enableHardLimitAnalysis;
   }
 
+  /**
+   * Set hard limit request count
+   *
+   * @param value Long
+   */
+  @JsonProperty("hard_limit_request_count")
   public void setHardLimitRequestCount(Long value) {
     hardLimitRequestCount = value;
   }
 
+  /**
+   * Get hard limit request count
+   *
+   * @return Long
+   */
   public Long getHardLimitRequestCount() {
     return hardLimitRequestCount;
   }
 
+  /**
+   * Get user agent blacklist analysis setting
+   *
+   * @param enableUserAgentBlacklistAnalysis Boolean
+   */
+  @JsonProperty("enable_user_agent_blacklist_analysis")
   public void setEnableUserAgentBlacklistAnalysis(Boolean enableUserAgentBlacklistAnalysis) {
     this.enableUserAgentBlacklistAnalysis = enableUserAgentBlacklistAnalysis;
   }
 
+  /**
+   * Get user agent blacklist analysis setting
+   *
+   * @return Boolean
+   */
   public Boolean getEnableUserAgentBlacklistAnalysis() {
     return enableUserAgentBlacklistAnalysis;
   }
 
+  /**
+   * Set user agent blacklist path
+   *
+   * @param value String
+   */
+  @JsonProperty("user_agent_blacklist_path")
   public void setUserAgentBlacklistPath(String value) {
     userAgentBlacklistPath = value;
   }
 
+  /**
+   * Get user agent blacklist path
+   *
+   * @return String
+   */
   public String getUserAgentBlacklistPath() {
     return userAgentBlacklistPath;
   }
 
+  /**
+   * Set filter request path
+   *
+   * @param value String[]
+   */
+  @JsonProperty("filter_request_path")
   public void setFilterRequestPath(String[] value) {
     filterRequestPath = value;
   }
 
+  /**
+   * Get filter request path
+   *
+   * @return String[]
+   */
   public String[] getFilterRequestPath() {
     return filterRequestPath;
   }
 
+  /**
+   * Set include URL host regex
+   *
+   * @param value String[]
+   */
+  @JsonProperty("include_url_host_regex")
   public void setIncludeUrlHostRegex(String[] value) {
     includeUrlHostRegex = value;
   }
 
+  /**
+   * Get include URL host regex
+   *
+   * @return String[]
+   */
   public String[] getIncludeUrlHostRegex() {
     return includeUrlHostRegex;
   }
 
+  /**
+   * Set CIDR exclusion list path
+   *
+   * @param value String
+   */
+  @JsonProperty("cidr_exclusion_list")
   public void setCidrExclusionList(String value) {
     cidrExclusionList = value;
   }
 
+  /**
+   * Get CIDR exclusion list path
+   *
+   * @return String
+   */
   public String getCidrExclusionList() {
     return cidrExclusionList;
   }
 
+  /**
+   * Set ignore cloud provider requests
+   *
+   * @param value Boolean
+   */
+  @JsonProperty("ignore_cloud_provider_requests")
   public void setIgnoreCloudProviderRequests(Boolean value) {
     ignoreCloudProviderRequests = value;
   }
 
+  /**
+   * Get ignore cloud provider requests
+   *
+   * @return Boolean
+   */
   public Boolean getIgnoreCloudProviderRequests() {
     return ignoreCloudProviderRequests;
   }
 
+  /**
+   * Set ignore internal requests
+   *
+   * @param value Boolean
+   */
+  @JsonProperty("ignore_internal_requests")
   public void setIgnoreInternalRequests(Boolean value) {
     ignoreInternalRequests = value;
   }
 
+  /**
+   * Get ignore internal requests
+   *
+   * @return Boolean
+   */
   public Boolean getIgnoreInternalRequests() {
     return ignoreInternalRequests;
   }
 
-  public HTTPRequestToggles() {}
+  /** Initialize new {@link HTTPRequestToggles} with defaults */
+  public HTTPRequestToggles() {
+    enableThresholdAnalysis = false;
+    enableErrorRateAnalysis = false;
+    enableEndpointAbuseAnalysis = false;
+    enableHardLimitAnalysis = false;
+    enableUserAgentBlacklistAnalysis = false;
+    enableNatDetection = false;
+
+    hardLimitRequestCount = 100L;
+
+    analysisThresholdModifier = 75.0;
+    requiredMinimumAverage = 5.0;
+    requiredMinimumClients = 5L;
+
+    maxClientErrorRate = 30L;
+
+    endpointAbuseExtendedVariance = false;
+    sessionGapDurationMinutes = 45L;
+
+    ignoreCloudProviderRequests = true;
+    ignoreInternalRequests = true;
+  }
 }

--- a/src/main/java/com/mozilla/secops/input/Input.java
+++ b/src/main/java/com/mozilla/secops/input/Input.java
@@ -163,35 +163,8 @@ public class Input implements Serializable {
     if (!mode.equals(OperatingMode.SIMPLEX)) {
       throw new IOException("method only valid in simplex mode");
     }
-
-    InputElement element = new InputElement(SIMPLEX_DEFAULT_ELEMENT);
-
-    if (options.getGenerateConfigurationTicksInterval() > 0) {
-      element.setConfigurationTicks(
-          cfgTickMessage,
-          options.getGenerateConfigurationTicksInterval(),
-          options.getGenerateConfigurationTicksMaximum());
-    }
-
-    if (options.getInputFile() != null) {
-      for (String buf : options.getInputFile()) {
-        element.addFileInput(buf);
-      }
-    }
-
-    if (options.getInputPubsub() != null) {
-      for (String buf : options.getInputPubsub()) {
-        element.addPubsubInput(buf);
-      }
-    }
-
-    if (options.getInputKinesis() != null) {
-      for (String buf : options.getInputKinesis()) {
-        element.addKinesisInput(buf);
-      }
-    }
-
-    elements.add(element);
+    elements.add(
+        InputElement.fromPipelineOptions(SIMPLEX_DEFAULT_ELEMENT, options, cfgTickMessage));
     return this;
   }
 

--- a/src/main/java/com/mozilla/secops/input/Input.java
+++ b/src/main/java/com/mozilla/secops/input/Input.java
@@ -321,6 +321,7 @@ public class Input implements Serializable {
             list.and(
                 i.expandElementRaw(begin, input.getProject())
                     .apply(
+                        String.format("%s read multiplex raw", i.getName()),
                         ParDo.of(
                             new DoFn<String, KV<String, String>>() {
                               private static final long serialVersionUID = 1L;
@@ -371,6 +372,7 @@ public class Input implements Serializable {
             list.and(
                 i.expandElement(begin, input.getProject())
                     .apply(
+                        String.format("%s read multiplex", i.getName()),
                         ParDo.of(
                             new DoFn<Event, KV<String, Event>>() {
                               private static final long serialVersionUID = 1L;

--- a/src/main/java/com/mozilla/secops/input/Input.java
+++ b/src/main/java/com/mozilla/secops/input/Input.java
@@ -2,6 +2,7 @@ package com.mozilla.secops.input;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mozilla.secops.InputOptions;
@@ -138,6 +139,22 @@ public class Input implements Serializable {
    */
   public ArrayList<InputElement> getInputElements() {
     return elements;
+  }
+
+  /**
+   * Get an input element by name
+   *
+   * @param name Input element name
+   * @return Element or null if not found
+   */
+  @JsonIgnore
+  public InputElement getInputElementByName(String name) {
+    for (InputElement i : elements) {
+      if (i.getName().equals(name)) {
+        return i;
+      }
+    }
+    return null;
   }
 
   /**

--- a/src/main/java/com/mozilla/secops/input/InputElement.java
+++ b/src/main/java/com/mozilla/secops/input/InputElement.java
@@ -145,9 +145,6 @@ public class InputElement implements Serializable {
    */
   @JsonProperty("filter")
   public InputElement setEventFilter(EventFilter filter) {
-    if (parserCfg == null) {
-      throw new RuntimeException("parser must be configured to set an event filter");
-    }
     this.filter = filter;
     return this;
   }

--- a/src/main/java/com/mozilla/secops/input/InputElement.java
+++ b/src/main/java/com/mozilla/secops/input/InputElement.java
@@ -107,7 +107,10 @@ public class InputElement implements Serializable {
 
     if (cfgTickMessage != null) {
       list =
-          list.and(begin.apply(new CfgTickGenerator(cfgTickMessage, cfgTickInterval, cfgTickMax)));
+          list.and(
+              begin.apply(
+                  String.format("%s generate cfgtick", name),
+                  new CfgTickGenerator(cfgTickMessage, cfgTickInterval, cfgTickMax)));
     }
 
     if (wiredStream != null) {
@@ -115,10 +118,10 @@ public class InputElement implements Serializable {
     }
 
     for (String i : fileInputs) {
-      list = list.and(begin.apply(TextIO.read().from(i)));
+      list = list.and(begin.apply(i, TextIO.read().from(i)));
     }
     for (String i : pubsubInputs) {
-      list = list.and(begin.apply(PubsubIO.readStrings().fromTopic(i)));
+      list = list.and(begin.apply(i, PubsubIO.readStrings().fromTopic(i)));
     }
     for (String i : kinesisInputs) {
       KinesisInput k = KinesisInput.fromInputSpecifier(i, project);
@@ -138,7 +141,8 @@ public class InputElement implements Serializable {
       }
     }
 
-    return list.apply("flatten input components", Flatten.<String>pCollections());
+    return list.apply(
+        String.format("%s flatten input components", name), Flatten.<String>pCollections());
   }
 
   /**
@@ -157,7 +161,7 @@ public class InputElement implements Serializable {
     if (filter != null) {
       fn = fn.withInlineEventFilter(filter);
     }
-    return col.apply("parse", ParDo.of(fn));
+    return col.apply(String.format("%s parse", name), ParDo.of(fn));
   }
 
   /**

--- a/src/main/java/com/mozilla/secops/input/InputElement.java
+++ b/src/main/java/com/mozilla/secops/input/InputElement.java
@@ -1,5 +1,11 @@
 package com.mozilla.secops.input;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mozilla.secops.metrics.CfgTickGenerator;
 import com.mozilla.secops.parser.Event;
 import com.mozilla.secops.parser.EventFilter;
@@ -19,6 +25,7 @@ import org.apache.beam.sdk.values.PCollectionList;
  * InputElement represents a set of input sources that will always result in a single output
  * collection.
  */
+@JsonInclude(Include.NON_EMPTY)
 public class InputElement implements Serializable {
   private static final long serialVersionUID = 1L;
 
@@ -26,7 +33,7 @@ public class InputElement implements Serializable {
 
   private transient ArrayList<String> fileInputs;
   private transient ArrayList<String> pubsubInputs;
-  private transient ArrayList<KinesisInput> kinesisInputs;
+  private transient ArrayList<String> kinesisInputs;
 
   private transient ParserCfg parserCfg;
   private transient EventFilter filter;
@@ -48,8 +55,9 @@ public class InputElement implements Serializable {
    * Expand configured input types into a resulting collection of strings
    *
    * @param PBegin Pipeline begin
+   * @param project GCP project, set if using RuntimeSecrets
    */
-  public PCollection<String> expandElementRaw(PBegin begin) {
+  public PCollection<String> expandElementRaw(PBegin begin, String project) {
     PCollectionList<String> list = PCollectionList.<String>empty(begin.getPipeline());
 
     if (cfgTickMessage != null) {
@@ -63,8 +71,9 @@ public class InputElement implements Serializable {
     for (String i : pubsubInputs) {
       list = list.and(begin.apply(PubsubIO.readStrings().fromTopic(i)));
     }
-    for (KinesisInput i : kinesisInputs) {
-      list = list.and(i.toCollection(begin));
+    for (String i : kinesisInputs) {
+      KinesisInput k = KinesisInput.fromInputSpecifier(i, project);
+      list = list.and(k.toCollection(begin));
       try {
         // XXX Pause for a moment here for cases where we are configuring multiple Kinesis streams
         // that might exist in the same account; since setup calls DescribeStream it is possible
@@ -83,12 +92,18 @@ public class InputElement implements Serializable {
     return list.apply(Flatten.<String>pCollections());
   }
 
-  public PCollection<Event> expandElement(PBegin begin) {
+  /**
+   * Expand configured input types into a resulting collection of parsed events
+   *
+   * @param PBegin Pipeline begin
+   * @param project GCP project, set if using RuntimeSecrets
+   */
+  public PCollection<Event> expandElement(PBegin begin, String project) {
     if (parserCfg == null) {
       throw new RuntimeException("no parser configured for element");
     }
 
-    PCollection<String> col = expandElementRaw(begin);
+    PCollection<String> col = expandElementRaw(begin, project);
     ParserDoFn fn = new ParserDoFn().withConfiguration(parserCfg);
     if (filter != null) {
       fn = fn.withInlineEventFilter(filter);
@@ -105,9 +120,19 @@ public class InputElement implements Serializable {
    * @param parserCfg Parser configuration
    * @return this for chaining
    */
+  @JsonProperty("parser_configuration")
   public InputElement setParserConfiguration(ParserCfg parserCfg) {
     this.parserCfg = parserCfg;
     return this;
+  }
+
+  /**
+   * Get parser configuration
+   *
+   * @return Parser configuration or null if unset
+   */
+  public ParserCfg getParserConfiguration() {
+    return parserCfg;
   }
 
   /**
@@ -118,6 +143,7 @@ public class InputElement implements Serializable {
    * @param filter {@link EventFilter}
    * @return this for chaining
    */
+  @JsonProperty("filter")
   public InputElement setEventFilter(EventFilter filter) {
     if (parserCfg == null) {
       throw new RuntimeException("parser must be configured to set an event filter");
@@ -127,13 +153,27 @@ public class InputElement implements Serializable {
   }
 
   /**
+   * Get event filter
+   *
+   * @return Configured event filter or null
+   */
+  public EventFilter getEventFilter() {
+    return filter;
+  }
+
+  /**
    * Set configuration ticks for input element
+   *
+   * <p>Note that although {@link InputElement} is serializable to/from JSON, configuration ticks
+   * are specifically excluded from this. If an input element is initialized from JSON and
+   * configuration ticks are desired, these must be set manually.
    *
    * @param cfgTickMessage JSON message string to use
    * @param cfgTickInterval Tick interval in seconds
    * @param cfgTickMax Maximum number of ticks to generate before exiting
    * @return this for chaining
    */
+  @JsonIgnore
   public InputElement setConfigurationTicks(
       String cfgTickMessage, Integer cfgTickInterval, long cfgTickMax) {
     if (cfgTickMessage == null) {
@@ -157,6 +197,25 @@ public class InputElement implements Serializable {
   }
 
   /**
+   * Set file inputs
+   *
+   * @param fileInputs File inputs
+   */
+  @JsonProperty("file_inputs")
+  public void setFileInputs(ArrayList<String> fileInputs) {
+    this.fileInputs = fileInputs;
+  }
+
+  /**
+   * Get file inputs
+   *
+   * @return File inputs
+   */
+  public ArrayList<String> getFileInputs() {
+    return fileInputs;
+  }
+
+  /**
    * Add new Pubsub input
    *
    * @param input Pubsub topic
@@ -168,14 +227,52 @@ public class InputElement implements Serializable {
   }
 
   /**
+   * Set Pubsub inputs
+   *
+   * @param pubsubInputs Pubsub inputs
+   */
+  @JsonProperty("pubsub_inputs")
+  public void setPubsubInputs(ArrayList<String> pubsubInputs) {
+    this.pubsubInputs = pubsubInputs;
+  }
+
+  /**
+   * Get Pubsub inputs
+   *
+   * @return Pubsub inputs
+   */
+  public ArrayList<String> getPubsubInputs() {
+    return pubsubInputs;
+  }
+
+  /**
    * Add new Kinesis input
    *
    * @param input Kinesis input specification
    * @return this for chaining
    */
-  public InputElement addKinesisInput(KinesisInput input) {
+  public InputElement addKinesisInput(String input) {
     kinesisInputs.add(input);
     return this;
+  }
+
+  /**
+   * Set Kinesis inputs
+   *
+   * @param kinesisInputs Kinesis inputs
+   */
+  @JsonProperty("kinesis_inputs")
+  public void setKinesisInputs(ArrayList<String> kinesisInputs) {
+    this.kinesisInputs = kinesisInputs;
+  }
+
+  /**
+   * Get Kinesis inputs
+   *
+   * @return Kinesis inputs
+   */
+  public ArrayList<String> getKinesisInputs() {
+    return kinesisInputs;
   }
 
   /**
@@ -183,11 +280,12 @@ public class InputElement implements Serializable {
    *
    * @param name Name to associate with element
    */
-  public InputElement(String name) {
+  @JsonCreator
+  public InputElement(@JsonProperty("name") String name) {
     this.name = name;
 
     fileInputs = new ArrayList<String>();
     pubsubInputs = new ArrayList<String>();
-    kinesisInputs = new ArrayList<KinesisInput>();
+    kinesisInputs = new ArrayList<String>();
   }
 }

--- a/src/main/java/com/mozilla/secops/input/KinesisInput.java
+++ b/src/main/java/com/mozilla/secops/input/KinesisInput.java
@@ -46,6 +46,7 @@ public class KinesisInput {
   public PCollection<String> toCollection(PBegin begin) {
     return begin
         .apply(
+            String.format("%s %s", streamName, region),
             KinesisIO.read()
                 .withStreamName(streamName)
                 .withInitialPositionInStream(InitialPositionInStream.LATEST)

--- a/src/main/java/com/mozilla/secops/parser/ParserCfg.java
+++ b/src/main/java/com/mozilla/secops/parser/ParserCfg.java
@@ -1,5 +1,10 @@
 package com.mozilla.secops.parser;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mozilla.secops.CidrUtil;
 import com.mozilla.secops.InputOptions;
 import java.io.Serializable;
@@ -7,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 
 /** Represents configuration data used to configure an instance of a {@link Parser} */
+@JsonInclude(Include.NON_EMPTY)
 public class ParserCfg implements Serializable {
   private static final long serialVersionUID = 1L;
 
@@ -60,6 +66,7 @@ public class ParserCfg implements Serializable {
    * <p>This option is intended to behave in a similar manner to the nginx realip module,
    * https://nginx.org/en/docs/http/ngx_http_realip_module.html.
    */
+  @JsonProperty("xff_address_selector")
   public void setXffAddressSelector(ArrayList<String> subnets) {
     xffAddressSelectorSubnets = subnets;
   }
@@ -78,6 +85,7 @@ public class ParserCfg implements Serializable {
    *
    * @return CidrUtil or null if not set
    */
+  @JsonIgnore
   public CidrUtil getXffAddressSelectorAsCidrUtil() {
     if (xffAddressSelectorSubnets == null) {
       return null;
@@ -103,6 +111,7 @@ public class ParserCfg implements Serializable {
    *
    * @param path Path
    */
+  @JsonProperty("maxmind_city_db_path")
   public void setMaxmindCityDbPath(String path) {
     maxmindCityDbPath = path;
   }
@@ -121,6 +130,7 @@ public class ParserCfg implements Serializable {
    *
    * @param path Path
    */
+  @JsonProperty("maxmind_isp_db_path")
   public void setMaxmindIspDbPath(String path) {
     maxmindIspDbPath = path;
   }
@@ -139,6 +149,7 @@ public class ParserCfg implements Serializable {
    *
    * @param path Path
    */
+  @JsonProperty("identity_manager_path")
   public void setIdentityManagerPath(String path) {
     idmanagerPath = path;
   }
@@ -165,6 +176,7 @@ public class ParserCfg implements Serializable {
    *
    * @param fastMatcher Matcher substring
    */
+  @JsonProperty("parser_fast_matcher")
   public void setParserFastMatcher(String fastMatcher) {
     this.fastMatcher = fastMatcher;
   }
@@ -188,6 +200,7 @@ public class ParserCfg implements Serializable {
    *
    * @param useEventTimestamp Boolean
    */
+  @JsonProperty("use_event_timestamp")
   public void setUseEventTimestamp(Boolean useEventTimestamp) {
     this.useEventTimestamp = useEventTimestamp;
   }
@@ -210,6 +223,7 @@ public class ParserCfg implements Serializable {
    *
    * @param stackdriverLabelFilters Array of key:value labels that must match
    */
+  @JsonProperty("stackdriver_label_filters")
   public void setStackdriverLabelFilters(String[] stackdriverLabelFilters) {
     this.stackdriverLabelFilters = stackdriverLabelFilters;
   }
@@ -232,6 +246,7 @@ public class ParserCfg implements Serializable {
    *
    * @param stackdriverProjectFilter Project value
    */
+  @JsonProperty("stackdriver_project_filter")
   public void setStackdriverProjectFilter(String stackdriverProjectFilter) {
     this.stackdriverProjectFilter = stackdriverProjectFilter;
   }

--- a/src/test/java/com/mozilla/secops/TestIprepdIO.java
+++ b/src/test/java/com/mozilla/secops/TestIprepdIO.java
@@ -88,6 +88,7 @@ public class TestIprepdIO implements Serializable {
   @Test
   public void iprepdIOTestWrite() throws Exception {
     IOOptions options = PipelineOptionsFactory.as(IOOptions.class);
+    options.setMonitoredResourceIndicator("test");
     options.setOutputIprepd("http://127.0.0.1:8080");
     options.setOutputIprepdApikey("test");
 
@@ -131,6 +132,7 @@ public class TestIprepdIO implements Serializable {
     options.setOutputIprepd("http://127.0.0.1:8080");
     options.setOutputIprepdApikey("test");
     options.setOutputIprepdLegacyMode(true);
+    options.setMonitoredResourceIndicator("test");
 
     deleteReputation("ip", "127.0.0.1");
     deleteReputation("ip", "99.99.99.1");
@@ -173,6 +175,7 @@ public class TestIprepdIO implements Serializable {
     IOOptions options = PipelineOptionsFactory.as(IOOptions.class);
     options.setOutputIprepd("http://127.0.0.1:8080");
     options.setOutputIprepdApikey("test");
+    options.setMonitoredResourceIndicator("test");
 
     IprepdIO.Reader r = IprepdIO.getReader("http://127.0.0.1:8080", "test", null);
 

--- a/src/test/java/com/mozilla/secops/alert/TestAlertFormatter.java
+++ b/src/test/java/com/mozilla/secops/alert/TestAlertFormatter.java
@@ -31,6 +31,7 @@ public class TestAlertFormatter {
   @Test
   public void runFormatter() {
     IOOptions options = PipelineOptionsFactory.as(IOOptions.class);
+    options.setMonitoredResourceIndicator("test");
     PCollection<String> res = getTestInput(p).apply(ParDo.of(new AlertFormatter(options)));
 
     PAssert.that(res)

--- a/src/test/java/com/mozilla/secops/httprequest/HTTPRequestUtil.java
+++ b/src/test/java/com/mozilla/secops/httprequest/HTTPRequestUtil.java
@@ -1,0 +1,37 @@
+package com.mozilla.secops.httprequest;
+
+import com.mozilla.secops.input.Input;
+import com.mozilla.secops.input.InputElement;
+import com.mozilla.secops.parser.ParserCfg;
+import org.apache.beam.sdk.testing.TestStream;
+
+/** Various test utilities for HTTPRequest */
+public class HTTPRequestUtil {
+  /**
+   * Return an input stream wired with {@link TestStream}
+   *
+   * <p>This function currently makes an assumption reads will only be from a single TestStream
+   * element, and that all configuration is done via pipeline options. It is essentially a version
+   * of HTTPRequest.getInput and can be used with TestStream.
+   *
+   * @param options Pipeline options
+   * @param testStream TestStream
+   * @return Input
+   */
+  public static Input wiredInputStream(
+      HTTPRequest.HTTPRequestOptions options, TestStream<String> testStream) throws Exception {
+    Input input = new Input().multiplex();
+    InputElement e =
+        new InputElement(options.getMonitoredResourceIndicator()).addWiredStream(testStream);
+    e.setParserConfiguration(ParserCfg.fromInputOptions(options))
+        .setEventFilter(HTTPRequestToggles.fromPipelineOptions(options).toStandardFilter());
+    input.withInputElement(e);
+
+    // If we are using this we will not be calling getInput in HTTPRequest. Therefore push
+    // configuration data into the toggle cache externally, since we will need it later.
+    HTTPRequest.addToggleCacheEntry(
+        options.getMonitoredResourceIndicator(), HTTPRequestToggles.fromPipelineOptions(options));
+
+    return input;
+  }
+}

--- a/src/test/java/com/mozilla/secops/httprequest/TestEndpointAbuse1.java
+++ b/src/test/java/com/mozilla/secops/httprequest/TestEndpointAbuse1.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertThat;
 
 import com.mozilla.secops.TestUtil;
 import com.mozilla.secops.alert.Alert;
+import com.mozilla.secops.input.Input;
 import java.util.Arrays;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
@@ -30,6 +31,7 @@ public class TestEndpointAbuse1 {
         PipelineOptionsFactory.as(HTTPRequest.HTTPRequestOptions.class);
     ret.setUseEventTimestamp(true); // Use timestamp from events for our testing
     ret.setMonitoredResourceIndicator("test");
+    ret.setEnableEndpointAbuseAnalysis(true);
     ret.setSessionGapDurationMinutes(20L);
     ret.setIgnoreInternalRequests(false); // Tests use internal subnets
     return ret;
@@ -62,11 +64,10 @@ public class TestEndpointAbuse1 {
             .addElements(eb3[0], Arrays.copyOfRange(eb3, 1, eb3.length))
             .advanceWatermarkToInfinity();
 
+    Input input = HTTPRequestUtil.wiredInputStream(options, s);
+
     PCollection<Alert> results =
-        p.apply(s)
-            .apply(new HTTPRequest.Parse(options))
-            .apply(new HTTPRequest.KeyAndWindowForSessionsFireEarly(options))
-            .apply(new HTTPRequest.EndpointAbuseAnalysis(options));
+        HTTPRequest.expandInputMap(p, HTTPRequest.readInput(p, input, options), options);
 
     PCollection<Long> count = results.apply(Count.globally());
 
@@ -121,11 +122,10 @@ public class TestEndpointAbuse1 {
             .advanceProcessingTime(Duration.standardSeconds(60))
             .advanceWatermarkToInfinity();
 
+    Input input = HTTPRequestUtil.wiredInputStream(options, s);
+
     PCollection<Alert> results =
-        p.apply(s)
-            .apply(new HTTPRequest.Parse(options))
-            .apply(new HTTPRequest.KeyAndWindowForSessionsFireEarly(options))
-            .apply(new HTTPRequest.EndpointAbuseAnalysis(options));
+        HTTPRequest.expandInputMap(p, HTTPRequest.readInput(p, input, options), options);
 
     PCollection<Long> count = results.apply(Count.globally());
 
@@ -179,11 +179,10 @@ public class TestEndpointAbuse1 {
             .advanceProcessingTime(Duration.standardSeconds(60))
             .advanceWatermarkToInfinity();
 
+    Input input = HTTPRequestUtil.wiredInputStream(options, s);
+
     PCollection<Alert> results =
-        p.apply(s)
-            .apply(new HTTPRequest.Parse(options))
-            .apply(new HTTPRequest.KeyAndWindowForSessionsFireEarly(options))
-            .apply(new HTTPRequest.EndpointAbuseAnalysis(options));
+        HTTPRequest.expandInputMap(p, HTTPRequest.readInput(p, input, options), options);
 
     PCollection<Long> count = results.apply(Count.globally());
 
@@ -235,11 +234,10 @@ public class TestEndpointAbuse1 {
             .addElements(eb3[0], Arrays.copyOfRange(eb3, 1, eb3.length))
             .advanceWatermarkToInfinity();
 
+    Input input = HTTPRequestUtil.wiredInputStream(options, s);
+
     PCollection<Alert> results =
-        p.apply(s)
-            .apply(new HTTPRequest.Parse(options))
-            .apply(new HTTPRequest.KeyAndWindowForSessionsFireEarly(options))
-            .apply(new HTTPRequest.EndpointAbuseAnalysis(options));
+        HTTPRequest.expandInputMap(p, HTTPRequest.readInput(p, input, options), options);
 
     PCollection<Long> count = results.apply(Count.globally());
 
@@ -293,11 +291,10 @@ public class TestEndpointAbuse1 {
             .addElements(eb1[0], Arrays.copyOfRange(eb1, 1, eb1.length))
             .advanceWatermarkToInfinity();
 
+    Input input = HTTPRequestUtil.wiredInputStream(options, s);
+
     PCollection<Alert> results =
-        p.apply(s)
-            .apply(new HTTPRequest.Parse(options))
-            .apply(new HTTPRequest.KeyAndWindowForSessionsFireEarly(options))
-            .apply(new HTTPRequest.EndpointAbuseAnalysis(options));
+        HTTPRequest.expandInputMap(p, HTTPRequest.readInput(p, input, options), options);
 
     PCollection<Long> count = results.apply(Count.globally());
     PAssert.that(count).containsInAnyOrder(1L);

--- a/src/test/java/com/mozilla/secops/httprequest/TestEndpointAbuse1.java
+++ b/src/test/java/com/mozilla/secops/httprequest/TestEndpointAbuse1.java
@@ -81,7 +81,7 @@ public class TestEndpointAbuse1 {
                 assertEquals("192.168.1.2", a.getMetadataValue("sourceaddress"));
                 assertEquals(
                     "test httprequest endpoint_abuse 192.168.1.2 GET /test 10", a.getSummary());
-                assertEquals("endpoint_abuse", a.getNotifyMergeKey());
+                assertEquals("test endpoint_abuse", a.getNotifyMergeKey());
                 assertEquals("endpoint_abuse", a.getMetadataValue("category"));
                 assertEquals("60", a.getMetadataValue("iprepd_suppress_recovery"));
                 assertEquals("Mozilla", a.getMetadataValue("useragent"));
@@ -138,7 +138,7 @@ public class TestEndpointAbuse1 {
                 assertEquals("192.168.1.2", a.getMetadataValue("sourceaddress"));
                 assertEquals(
                     "test httprequest endpoint_abuse 192.168.1.2 GET /test 10", a.getSummary());
-                assertEquals("endpoint_abuse", a.getNotifyMergeKey());
+                assertEquals("test endpoint_abuse", a.getNotifyMergeKey());
                 assertEquals("endpoint_abuse", a.getMetadataValue("category"));
                 assertEquals("Mozilla", a.getMetadataValue("useragent"));
                 assertEquals(10L, Long.parseLong(a.getMetadataValue("count"), 10));
@@ -195,7 +195,7 @@ public class TestEndpointAbuse1 {
                 assertEquals("192.168.1.2", a.getMetadataValue("sourceaddress"));
                 assertEquals(
                     "test httprequest endpoint_abuse 192.168.1.2 GET /test 10", a.getSummary());
-                assertEquals("endpoint_abuse", a.getNotifyMergeKey());
+                assertEquals("test endpoint_abuse", a.getNotifyMergeKey());
                 assertEquals("endpoint_abuse", a.getMetadataValue("category"));
                 assertEquals("Mozilla", a.getMetadataValue("useragent"));
                 assertEquals(10L, Long.parseLong(a.getMetadataValue("count"), 10));
@@ -254,7 +254,7 @@ public class TestEndpointAbuse1 {
                 assertEquals("192.168.1.2", a.getMetadataValue("sourceaddress"));
                 assertEquals(
                     "test httprequest endpoint_abuse 192.168.1.2 GET /test 10", a.getSummary());
-                assertEquals("endpoint_abuse", a.getNotifyMergeKey());
+                assertEquals("test endpoint_abuse", a.getNotifyMergeKey());
                 assertEquals("endpoint_abuse", a.getMetadataValue("category"));
                 assertEquals("60", a.getMetadataValue("iprepd_suppress_recovery"));
                 assertEquals("Mozilla", a.getMetadataValue("useragent"));

--- a/src/test/java/com/mozilla/secops/httprequest/TestFilter.java
+++ b/src/test/java/com/mozilla/secops/httprequest/TestFilter.java
@@ -1,6 +1,5 @@
 package com.mozilla.secops.httprequest;
 
-import com.mozilla.secops.TestUtil;
 import com.mozilla.secops.parser.Event;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.testing.PAssert;
@@ -23,17 +22,20 @@ public class TestFilter {
         PipelineOptionsFactory.as(HTTPRequest.HTTPRequestOptions.class);
     ret.setUseEventTimestamp(true); // Use timestamp from events for our testing
     ret.setIgnoreInternalRequests(false); // Tests use internal subnets
+    ret.setMonitoredResourceIndicator("test");
     return ret;
   }
 
   @Test
   public void noProjectFilterTest() throws Exception {
-    PCollection<String> input = TestUtil.getTestInput("/testdata/httpreq_filter.txt", p);
+    HTTPRequest.HTTPRequestOptions options = getTestOptions();
+    options.setInputFile(new String[] {"./target/test-classes/testdata/httpreq_filter.txt"});
 
     PCollection<Event> events =
-        input
-            .apply(new HTTPRequest.Parse(getTestOptions()))
+        HTTPRequest.readInput(p, HTTPRequest.getInput(p, options), options)
+            .get("test")
             .apply(new HTTPRequest.WindowForFixed());
+
     PCollection<Long> count =
         events.apply(Combine.globally(Count.<Event>combineFn()).withoutDefaults());
 
@@ -46,12 +48,15 @@ public class TestFilter {
 
   @Test
   public void withProjectFilterTest() throws Exception {
-    PCollection<String> input = TestUtil.getTestInput("/testdata/httpreq_filter.txt", p);
-
     HTTPRequest.HTTPRequestOptions options = getTestOptions();
     options.setStackdriverProjectFilter("test");
+    options.setInputFile(new String[] {"./target/test-classes/testdata/httpreq_filter.txt"});
+
     PCollection<Event> events =
-        input.apply(new HTTPRequest.Parse(options)).apply(new HTTPRequest.WindowForFixed());
+        HTTPRequest.readInput(p, HTTPRequest.getInput(p, options), options)
+            .get("test")
+            .apply(new HTTPRequest.WindowForFixed());
+
     PCollection<Long> count =
         events.apply(Combine.globally(Count.<Event>combineFn()).withoutDefaults());
 
@@ -64,12 +69,15 @@ public class TestFilter {
 
   @Test
   public void withLabelFilterTest() throws Exception {
-    PCollection<String> input = TestUtil.getTestInput("/testdata/httpreq_filter.txt", p);
-
     HTTPRequest.HTTPRequestOptions options = getTestOptions();
     options.setStackdriverLabelFilters(new String[] {"env:holodeck"});
+    options.setInputFile(new String[] {"./target/test-classes/testdata/httpreq_filter.txt"});
+
     PCollection<Event> events =
-        input.apply(new HTTPRequest.Parse(options)).apply(new HTTPRequest.WindowForFixed());
+        HTTPRequest.readInput(p, HTTPRequest.getInput(p, options), options)
+            .get("test")
+            .apply(new HTTPRequest.WindowForFixed());
+
     PCollection<Long> count =
         events.apply(Combine.globally(Count.<Event>combineFn()).withoutDefaults());
 
@@ -82,12 +90,15 @@ public class TestFilter {
 
   @Test
   public void withCidrFilterTest() throws Exception {
-    PCollection<String> input = TestUtil.getTestInput("/testdata/httpreq_filter.txt", p);
-
     HTTPRequest.HTTPRequestOptions options = getTestOptions();
+    options.setInputFile(new String[] {"./target/test-classes/testdata/httpreq_filter.txt"});
     options.setCidrExclusionList("/testdata/cidrutil2.txt");
+
     PCollection<Event> events =
-        input.apply(new HTTPRequest.Parse(options)).apply(new HTTPRequest.WindowForFixed());
+        HTTPRequest.readInput(p, HTTPRequest.getInput(p, options), options)
+            .get("test")
+            .apply(new HTTPRequest.WindowForFixed());
+
     PCollection<Long> count =
         events.apply(Combine.globally(Count.<Event>combineFn()).withoutDefaults());
 
@@ -100,12 +111,15 @@ public class TestFilter {
 
   @Test
   public void withNoMatchLabelFilterTest() throws Exception {
-    PCollection<String> input = TestUtil.getTestInput("/testdata/httpreq_filter.txt", p);
-
     HTTPRequest.HTTPRequestOptions options = getTestOptions();
+    options.setInputFile(new String[] {"./target/test-classes/testdata/httpreq_filter.txt"});
     options.setStackdriverLabelFilters(new String[] {"env:hydroponicsbay"});
+
     PCollection<Event> events =
-        input.apply(new HTTPRequest.Parse(options)).apply(new HTTPRequest.WindowForFixed());
+        HTTPRequest.readInput(p, HTTPRequest.getInput(p, options), options)
+            .get("test")
+            .apply(new HTTPRequest.WindowForFixed());
+
     PCollection<Long> count =
         events.apply(Combine.globally(Count.<Event>combineFn()).withoutDefaults());
 
@@ -116,11 +130,14 @@ public class TestFilter {
 
   @Test
   public void hostNoFilterTest() throws Exception {
-    PCollection<String> input = TestUtil.getTestInput("/testdata/httpreq_urlhostfilter.txt", p);
-
     HTTPRequest.HTTPRequestOptions options = getTestOptions();
+    options.setInputFile(new String[] {"./target/test-classes/testdata/httpreq_urlhostfilter.txt"});
+
     PCollection<Event> events =
-        input.apply(new HTTPRequest.Parse(options)).apply(new HTTPRequest.WindowForFixed());
+        HTTPRequest.readInput(p, HTTPRequest.getInput(p, options), options)
+            .get("test")
+            .apply(new HTTPRequest.WindowForFixed());
+
     PCollection<Long> count =
         events.apply(Combine.globally(Count.<Event>combineFn()).withoutDefaults());
 
@@ -133,12 +150,15 @@ public class TestFilter {
 
   @Test
   public void hostFilterTest() throws Exception {
-    PCollection<String> input = TestUtil.getTestInput("/testdata/httpreq_urlhostfilter.txt", p);
-
     HTTPRequest.HTTPRequestOptions options = getTestOptions();
+    options.setInputFile(new String[] {"./target/test-classes/testdata/httpreq_urlhostfilter.txt"});
     options.setIncludeUrlHostRegex(new String[] {"wontmatch", "^send\\..*"});
+
     PCollection<Event> events =
-        input.apply(new HTTPRequest.Parse(options)).apply(new HTTPRequest.WindowForFixed());
+        HTTPRequest.readInput(p, HTTPRequest.getInput(p, options), options)
+            .get("test")
+            .apply(new HTTPRequest.WindowForFixed());
+
     PCollection<Long> count =
         events.apply(Combine.globally(Count.<Event>combineFn()).withoutDefaults());
 
@@ -151,12 +171,15 @@ public class TestFilter {
 
   @Test
   public void hostFilterNoMatchTest() throws Exception {
-    PCollection<String> input = TestUtil.getTestInput("/testdata/httpreq_urlhostfilter.txt", p);
-
     HTTPRequest.HTTPRequestOptions options = getTestOptions();
+    options.setInputFile(new String[] {"./target/test-classes/testdata/httpreq_urlhostfilter.txt"});
     options.setIncludeUrlHostRegex(new String[] {"wontmatch", "wontmatch2"});
+
     PCollection<Event> events =
-        input.apply(new HTTPRequest.Parse(options)).apply(new HTTPRequest.WindowForFixed());
+        HTTPRequest.readInput(p, HTTPRequest.getInput(p, options), options)
+            .get("test")
+            .apply(new HTTPRequest.WindowForFixed());
+
     PCollection<Long> count =
         events.apply(Combine.globally(Count.<Event>combineFn()).withoutDefaults());
 

--- a/src/test/java/com/mozilla/secops/httprequest/TestMulti1.java
+++ b/src/test/java/com/mozilla/secops/httprequest/TestMulti1.java
@@ -69,6 +69,7 @@ public class TestMulti1 implements Serializable {
                   assertEquals(10L, Long.parseLong(a.getMetadataValue("request_threshold")));
                   assertEquals("1970-01-01T00:00:59.999Z", a.getMetadataValue("window_timestamp"));
                   assertEquals("hard_limit", a.getMetadataValue("monitored_resource"));
+                  assertEquals("hard_limit hard_limit_count", a.getMetadataValue("notify_merge"));
                 } else if (a.getMetadataValue("category").equals("error_rate")) {
                   assertEquals("10.0.0.1", a.getMetadataValue("sourceaddress"));
                   assertEquals("error_rate httprequest error_rate 10.0.0.1 35", a.getSummary());
@@ -77,6 +78,7 @@ public class TestMulti1 implements Serializable {
                   assertEquals(30L, Long.parseLong(a.getMetadataValue("error_threshold"), 10));
                   assertEquals("1970-01-01T00:00:59.999Z", a.getMetadataValue("window_timestamp"));
                   assertEquals("error_rate", a.getMetadataValue("monitored_resource"));
+                  assertEquals("error_rate error_count", a.getMetadataValue("notify_merge"));
                 }
               }
               return null;

--- a/src/test/java/com/mozilla/secops/httprequest/TestMulti1.java
+++ b/src/test/java/com/mozilla/secops/httprequest/TestMulti1.java
@@ -1,0 +1,87 @@
+package com.mozilla.secops.httprequest;
+
+import static org.junit.Assert.assertEquals;
+
+import com.mozilla.secops.alert.Alert;
+import com.mozilla.secops.alert.AlertFormatter;
+import java.io.Serializable;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Combine;
+import org.apache.beam.sdk.transforms.Count;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.PCollection;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class TestMulti1 implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  public TestMulti1() {}
+
+  @Rule public final transient TestPipeline p = TestPipeline.create();
+
+  private HTTPRequest.HTTPRequestOptions getTestOptions() {
+    HTTPRequest.HTTPRequestOptions ret =
+        PipelineOptionsFactory.as(HTTPRequest.HTTPRequestOptions.class);
+    ret.setGenerateConfigurationTicksInterval(1);
+    ret.setGenerateConfigurationTicksMaximum(5L);
+    return ret;
+  }
+
+  @Test
+  public void testMulti1() throws Exception {
+    HTTPRequest.HTTPRequestOptions options = getTestOptions();
+    options.setPipelineMultimodeConfiguration("/testdata/httpreq_multi1.json");
+
+    // Run the analysis; at the end plug the alert formatter in so we can validate the monitored
+    // resource metadata is set correct for the common output transforms
+    PCollection<Alert> results =
+        HTTPRequest.expandInputMap(
+                p, HTTPRequest.readInput(p, HTTPRequest.getInput(p, options), options), options)
+            .apply(ParDo.of(new AlertFormatter(options)))
+            .apply(
+                ParDo.of(
+                    new DoFn<String, Alert>() {
+                      private static final long serialVersionUID = 1L;
+
+                      @ProcessElement
+                      public void processElement(ProcessContext c) {
+                        c.output(Alert.fromJSON(c.element()));
+                      }
+                    }));
+
+    PCollection<Long> resultCount =
+        results.apply(Combine.globally(Count.<Alert>combineFn()).withoutDefaults());
+    PAssert.thatSingleton(resultCount)
+        .isEqualTo(12L); // Should have two alerts and 10 configuration events
+
+    PAssert.that(results)
+        .satisfies(
+            i -> {
+              for (Alert a : i) {
+                if (a.getMetadataValue("category").equals("hard_limit")) {
+                  assertEquals("192.168.1.2", a.getMetadataValue("sourceaddress"));
+                  assertEquals("hard_limit httprequest hard_limit 192.168.1.2 11", a.getSummary());
+                  assertEquals(11L, Long.parseLong(a.getMetadataValue("count")));
+                  assertEquals(10L, Long.parseLong(a.getMetadataValue("request_threshold")));
+                  assertEquals("1970-01-01T00:00:59.999Z", a.getMetadataValue("window_timestamp"));
+                  assertEquals("hard_limit", a.getMetadataValue("monitored_resource"));
+                } else if (a.getMetadataValue("category").equals("error_rate")) {
+                  assertEquals("10.0.0.1", a.getMetadataValue("sourceaddress"));
+                  assertEquals("error_rate httprequest error_rate 10.0.0.1 35", a.getSummary());
+                  assertEquals("error_rate", a.getMetadataValue("category"));
+                  assertEquals(35L, Long.parseLong(a.getMetadataValue("error_count"), 10));
+                  assertEquals(30L, Long.parseLong(a.getMetadataValue("error_threshold"), 10));
+                  assertEquals("1970-01-01T00:00:59.999Z", a.getMetadataValue("window_timestamp"));
+                  assertEquals("error_rate", a.getMetadataValue("monitored_resource"));
+                }
+              }
+              return null;
+            });
+
+    p.run().waitUntilFinish();
+  }
+}

--- a/src/test/java/com/mozilla/secops/input/TestInputJson.java
+++ b/src/test/java/com/mozilla/secops/input/TestInputJson.java
@@ -124,4 +124,46 @@ public class TestInputJson {
 
     pipeline.run().waitUntilFinish();
   }
+
+  @Test
+  public void testJsonSerializeInputSimplexProjectFilterInclude() throws Exception {
+    ParserCfg cfg = new ParserCfg();
+    cfg.setStackdriverProjectFilter("test");
+    Input input =
+        new Input("project")
+            .simplex()
+            .withInputElement(
+                new InputElement(Input.SIMPLEX_DEFAULT_ELEMENT)
+                    .addFileInput("./target/test-classes/testdata/httpreq_errorrate1.txt")
+                    .setParserConfiguration(cfg));
+
+    input = mapper.readValue(mapper.writeValueAsString(input), Input.class);
+
+    PCollection<Event> results = pipeline.apply(input.simplexRead());
+    PCollection<Long> count = results.apply(Count.globally());
+
+    PAssert.thatSingleton(count).isEqualTo(55L);
+
+    pipeline.run().waitUntilFinish();
+  }
+
+  @Test
+  public void testJsonSerializeInputSimplexProjectFilterExclude() throws Exception {
+    ParserCfg cfg = new ParserCfg();
+    cfg.setStackdriverProjectFilter("notmatched");
+    Input input =
+        new Input("project")
+            .simplex()
+            .withInputElement(
+                new InputElement(Input.SIMPLEX_DEFAULT_ELEMENT)
+                    .addFileInput("./target/test-classes/testdata/httpreq_errorrate1.txt")
+                    .setParserConfiguration(cfg));
+
+    input = mapper.readValue(mapper.writeValueAsString(input), Input.class);
+
+    PCollection<Event> results = pipeline.apply(input.simplexRead());
+    PAssert.that(results).empty();
+
+    pipeline.run().waitUntilFinish();
+  }
 }

--- a/src/test/java/com/mozilla/secops/input/TestInputJson.java
+++ b/src/test/java/com/mozilla/secops/input/TestInputJson.java
@@ -1,0 +1,44 @@
+package com.mozilla.secops.input;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mozilla.secops.parser.EventFilter;
+import com.mozilla.secops.parser.EventFilterPayload;
+import com.mozilla.secops.parser.EventFilterRule;
+import com.mozilla.secops.parser.ParserCfg;
+import com.mozilla.secops.parser.Payload;
+import com.mozilla.secops.parser.Raw;
+import org.junit.Test;
+
+public class TestInputJson {
+  public TestInputJson() {}
+
+  private static ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  public void testJsonSerializeInput() throws Exception {
+    EventFilter filter = new EventFilter();
+    filter.addRule(
+        new EventFilterRule()
+            .wantSubtype(Payload.PayloadType.RAW)
+            .addPayloadFilter(
+                new EventFilterPayload(Raw.class)
+                    .withStringMatch(EventFilterPayload.StringProperty.RAW_RAW, "test")));
+
+    Input input =
+        new Input("project")
+            .multiplex()
+            .withInputElement(
+                new InputElement("a")
+                    .addFileInput("./target/test-classes/testdata/inputtype_buffer3.txt")
+                    .setParserConfiguration(new ParserCfg())
+                    .setEventFilter(filter))
+            .withInputElement(
+                new InputElement("b")
+                    .addFileInput("./target/test-classes/testdata/inputtype_buffer3.txt")
+                    .setParserConfiguration(new ParserCfg())
+                    .setEventFilter(filter));
+
+    // XXX Expand to test read
+    mapper.writeValueAsString(input);
+  }
+}

--- a/src/test/java/com/mozilla/secops/input/TestInputJson.java
+++ b/src/test/java/com/mozilla/secops/input/TestInputJson.java
@@ -1,18 +1,34 @@
 package com.mozilla.secops.input;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mozilla.secops.InputOptions;
+import com.mozilla.secops.parser.Event;
 import com.mozilla.secops.parser.EventFilter;
 import com.mozilla.secops.parser.EventFilterPayload;
 import com.mozilla.secops.parser.EventFilterRule;
 import com.mozilla.secops.parser.ParserCfg;
 import com.mozilla.secops.parser.Payload;
 import com.mozilla.secops.parser.Raw;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Count;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.junit.Rule;
 import org.junit.Test;
 
 public class TestInputJson {
   public TestInputJson() {}
 
   private static ObjectMapper mapper = new ObjectMapper();
+
+  @Rule public final transient TestPipeline pipeline = TestPipeline.fromOptions(getInputOptions());
+
+  private static InputOptions getInputOptions() {
+    InputOptions o = PipelineOptionsFactory.as(InputOptions.class);
+    return o;
+  }
 
   @Test
   public void testJsonSerializeInput() throws Exception {
@@ -38,7 +54,74 @@ public class TestInputJson {
                     .setParserConfiguration(new ParserCfg())
                     .setEventFilter(filter));
 
-    // XXX Expand to test read
-    mapper.writeValueAsString(input);
+    input = mapper.readValue(mapper.writeValueAsString(input), Input.class);
+
+    PCollection<KV<String, Event>> results = pipeline.apply(input.multiplexRead());
+    PCollection<Long> count = results.apply(Count.globally());
+
+    PAssert.thatSingleton(count).isEqualTo(20L);
+
+    pipeline.run().waitUntilFinish();
+  }
+
+  @Test
+  public void testJsonSerializeInputRaw() throws Exception {
+    Input input =
+        new Input("project")
+            .multiplex()
+            .withInputElement(
+                new InputElement("a")
+                    .addFileInput("./target/test-classes/testdata/inputtype_buffer3.txt"))
+            .withInputElement(
+                new InputElement("b")
+                    .addFileInput("./target/test-classes/testdata/inputtype_buffer3.txt"));
+
+    input = mapper.readValue(mapper.writeValueAsString(input), Input.class);
+
+    PCollection<KV<String, String>> results = pipeline.apply(input.multiplexReadRaw());
+    PCollection<Long> count = results.apply(Count.globally());
+
+    PAssert.thatSingleton(count).isEqualTo(40L);
+
+    pipeline.run().waitUntilFinish();
+  }
+
+  @Test
+  public void testJsonSerializeInputSimplexRaw() throws Exception {
+    Input input =
+        new Input("project")
+            .simplex()
+            .withInputElement(
+                new InputElement(Input.SIMPLEX_DEFAULT_ELEMENT)
+                    .addFileInput("./target/test-classes/testdata/inputtype_buffer3.txt"));
+
+    input = mapper.readValue(mapper.writeValueAsString(input), Input.class);
+
+    PCollection<String> results = pipeline.apply(input.simplexReadRaw());
+    PCollection<Long> count = results.apply(Count.globally());
+
+    PAssert.thatSingleton(count).isEqualTo(20L);
+
+    pipeline.run().waitUntilFinish();
+  }
+
+  @Test
+  public void testJsonSerializeInputSimplex() throws Exception {
+    Input input =
+        new Input("project")
+            .simplex()
+            .withInputElement(
+                new InputElement(Input.SIMPLEX_DEFAULT_ELEMENT)
+                    .addFileInput("./target/test-classes/testdata/inputtype_buffer3.txt")
+                    .setParserConfiguration(new ParserCfg()));
+
+    input = mapper.readValue(mapper.writeValueAsString(input), Input.class);
+
+    PCollection<Event> results = pipeline.apply(input.simplexRead());
+    PCollection<Long> count = results.apply(Count.globally());
+
+    PAssert.thatSingleton(count).isEqualTo(20L);
+
+    pipeline.run().waitUntilFinish();
   }
 }

--- a/src/test/java/com/mozilla/secops/input/TestInputTypeFile.java
+++ b/src/test/java/com/mozilla/secops/input/TestInputTypeFile.java
@@ -1,7 +1,6 @@
-package com.mozilla.secops;
+package com.mozilla.secops.input;
 
-import com.mozilla.secops.input.Input;
-import com.mozilla.secops.input.InputElement;
+import com.mozilla.secops.InputOptions;
 import com.mozilla.secops.parser.Event;
 import com.mozilla.secops.parser.ParserCfg;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;

--- a/src/test/java/com/mozilla/secops/input/TestInputTypeFileMulti.java
+++ b/src/test/java/com/mozilla/secops/input/TestInputTypeFileMulti.java
@@ -1,10 +1,9 @@
-package com.mozilla.secops;
+package com.mozilla.secops.input;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-import com.mozilla.secops.input.Input;
-import com.mozilla.secops.input.InputElement;
+import com.mozilla.secops.InputOptions;
 import com.mozilla.secops.parser.Event;
 import com.mozilla.secops.parser.EventFilter;
 import com.mozilla.secops.parser.EventFilterPayload;

--- a/src/test/resources/testdata/httpreq_errorrate1_single.json
+++ b/src/test/resources/testdata/httpreq_errorrate1_single.json
@@ -1,0 +1,36 @@
+{
+  "input": {
+    "mode": "MULTIPLEX",
+    "elements": [
+      {
+        "name": "test",
+        "file_inputs": [
+          "./target/test-classes/testdata/httpreq_errorrate1.txt"
+        ],
+        "parser_configuration": {
+          "parser_fast_matcher": "prod-send",
+          "stackdriver_project_filter": "test",
+          "use_event_timestamp": true
+        },
+        "filter": {
+          "rules": [
+            {
+              "subtype": "CFGTICK"
+            },
+            {
+              "normalized_type": "HTTP_REQUEST"
+            }
+          ],
+          "want_utc": true,
+          "match_any": false
+        }
+      }
+    ]
+  },
+  "service_toggles": {
+    "test": {
+      "enable_error_rate_analysis": true,
+      "ignore_internal_requests": false
+    }
+  }
+}

--- a/src/test/resources/testdata/httpreq_multi1.json
+++ b/src/test/resources/testdata/httpreq_multi1.json
@@ -1,0 +1,66 @@
+{
+  "input": {
+    "mode": "MULTIPLEX",
+    "elements": [
+      {
+        "name": "error_rate",
+        "file_inputs": [
+          "./target/test-classes/testdata/httpreq_errorrate1.txt"
+        ],
+        "parser_configuration": {
+          "parser_fast_matcher": "prod-send",
+          "stackdriver_project_filter": "test",
+          "use_event_timestamp": true
+        },
+        "filter": {
+          "rules": [
+            {
+              "subtype": "CFGTICK"
+            },
+            {
+              "normalized_type": "HTTP_REQUEST"
+            }
+          ],
+          "want_utc": true,
+          "match_any": false
+        }
+      },
+      {
+        "name": "hard_limit",
+        "file_inputs": [
+          "./target/test-classes/testdata/httpreq_hardlimit1.txt"
+        ],
+        "parser_configuration": {
+          "use_event_timestamp": true
+        },
+        "filter": {
+          "rules": [
+            {
+              "subtype": "CFGTICK"
+            },
+            {
+              "normalized_type": "HTTP_REQUEST"
+            }
+          ],
+          "want_utc": true,
+          "match_any": false
+        }
+      }
+    ]
+  },
+  "service_toggles": {
+    "error_rate": {
+      "enable_error_rate_analysis": true,
+      "enable_threshold_analysis": true,
+      "enable_nat_detection": true,
+      "ignore_internal_requests": false
+    },
+    "hard_limit": {
+      "enable_hard_limit_analysis": true,
+      "hard_limit_request_count": 10,
+      "enable_threshold_analysis": true,
+      "enable_nat_detection": true,
+      "ignore_internal_requests": false
+    }
+  }
+}


### PR DESCRIPTION
This adds the ability to process streams associated with multiple services to HTTPRequest. An input configuration is used to partition configuration options, so different options can be associated with different services.

As a follow up, created #239 which we also need as part of this, since all partitions will share the same output path.