### PR TITLE
Support fan out for iprepd output

### DIFF
--- a/src/main/java/com/mozilla/secops/CompositeOutput.java
+++ b/src/main/java/com/mozilla/secops/CompositeOutput.java
@@ -37,9 +37,7 @@ public abstract class CompositeOutput {
     final String outputBigQuery = options.getOutputBigQuery();
     final String[] outputPubsub = options.getOutputPubsub();
     final String outputSqs = options.getOutputSqs();
-    final String outputIprepd = options.getOutputIprepd();
-    final String outputIprepdApikey = options.getOutputIprepdApikey();
-    final Boolean outputIprepdLegacyMode = options.getOutputIprepdLegacyMode();
+    final String[] outputIprepd = options.getOutputIprepd();
     final String project = options.getProject();
     Logger log = LoggerFactory.getLogger(CompositeOutput.class);
 
@@ -111,9 +109,7 @@ public abstract class CompositeOutput {
           }
         }
         if (outputIprepd != null) {
-          input.apply(
-              IprepdIO.write(outputIprepd, outputIprepdApikey, project)
-                  .setUseLegacySubmission(outputIprepdLegacyMode));
+          input.apply(IprepdIO.writeSpecs(outputIprepd, project));
         }
         if (outputSqs != null) {
           input.apply(SqsIO.write(outputSqs, project));

--- a/src/main/java/com/mozilla/secops/InputOptions.java
+++ b/src/main/java/com/mozilla/secops/InputOptions.java
@@ -78,4 +78,9 @@ public interface InputOptions extends PipelineOptions, PubsubOptions, GcpOptions
   Long getGenerateConfigurationTicksMaximum();
 
   void setGenerateConfigurationTicksMaximum(Long value);
+
+  @Description("Read reputation from iprepd; specify URL and API Key (supports RuntimeSecrets).")
+  String getInputIprepd();
+
+  void setInputIprepd(String value);
 }

--- a/src/main/java/com/mozilla/secops/OutputOptions.java
+++ b/src/main/java/com/mozilla/secops/OutputOptions.java
@@ -36,21 +36,10 @@ public interface OutputOptions extends PipelineOptions, GcpOptions {
   void setOutputSqs(String value);
 
   @Description(
-      "Write violation notices to iprepd; specify URL, only applicable for HTTPRequest results")
-  String getOutputIprepd();
+      "Write violation notices to iprepd; specify URL and API Key (supports RuntimeSecrets). Only applicable for HTTPRequest results")
+  String[] getOutputIprepd();
 
-  void setOutputIprepd(String value);
-
-  @Description("With iprepd output; use API key for authentication (supports RuntimeSecrets)")
-  String getOutputIprepdApikey();
-
-  void setOutputIprepdApikey(String value);
-
-  @Description("Use legacy IP submission endpoints with iprepd")
-  @Default.Boolean(false)
-  Boolean getOutputIprepdLegacyMode();
-
-  void setOutputIprepdLegacyMode(Boolean value);
+  void setOutputIprepd(String[] value);
 
   @Description("Enable use of whitelisted ips saved in datastore; requires deployment in GCP")
   @Default.Boolean(false)

--- a/src/main/java/com/mozilla/secops/amo/Amo.java
+++ b/src/main/java/com/mozilla/secops/amo/Amo.java
@@ -39,7 +39,7 @@ public class Amo implements Serializable {
       Pipeline p, PCollection<String> input, AmoOptions options) throws IOException {
     // A valid iprepd configuration is required here, as values are pulled from iprepd in some of
     // the pipeline transforms
-    if ((options.getOutputIprepd() == null) || (options.getOutputIprepdApikey() == null)) {
+    if ((options.getInputIprepd() == null)) {
       throw new RuntimeException("iprepd pipeline configuration options are required");
     }
 
@@ -60,8 +60,7 @@ public class Amo implements Serializable {
                     options.getMonitoredResourceIndicator(),
                     options.getAccountMatchBanOnLogin(),
                     options.getBanPatternSuppressRecovery(),
-                    options.getOutputIprepd(),
-                    options.getOutputIprepdApikey(),
+                    options.getInputIprepd(),
                     options.getProject())));
     resultsList =
         resultsList.and(

--- a/src/main/java/com/mozilla/secops/amo/FxaAccountAbuseNewVersion.java
+++ b/src/main/java/com/mozilla/secops/amo/FxaAccountAbuseNewVersion.java
@@ -24,8 +24,7 @@ public class FxaAccountAbuseNewVersion extends PTransform<PCollection<Event>, PC
   private static final long serialVersionUID = 1L;
 
   private final String monitoredResource;
-  private final String iprepdUrl;
-  private final String iprepdKey;
+  private final String iprepdSpec;
   private final String project;
   private final String[] banAccounts;
   private final Integer banAccountsSuppress;
@@ -36,24 +35,21 @@ public class FxaAccountAbuseNewVersion extends PTransform<PCollection<Event>, PC
    * @param monitoredResource Monitored resource indicator
    * @param banAccounts Blacklisted accounts regex
    * @param banAccountsSuppress Optional recovery suppression for ban pattern alerts
-   * @param iprepdUrl iprepd URL for reputation lookups
-   * @param iprepdKey iprepd API key (supports RuntimeSecrets)
+   * @param iprepdSpec iprepd spec for reputation lookups
    * @param project Project for KMS secrets decryption of API key if required
    */
   public FxaAccountAbuseNewVersion(
       String monitoredResource,
       String[] banAccounts,
       Integer banAccountsSuppress,
-      String iprepdUrl,
-      String iprepdKey,
+      String iprepdSpec,
       String project) {
     this.monitoredResource = monitoredResource;
 
     this.banAccounts = banAccounts;
     this.banAccountsSuppress = banAccountsSuppress;
 
-    this.iprepdUrl = iprepdUrl;
-    this.iprepdKey = iprepdKey;
+    this.iprepdSpec = iprepdSpec;
     this.project = project;
   }
 
@@ -160,7 +156,7 @@ public class FxaAccountAbuseNewVersion extends PTransform<PCollection<Event>, PC
 
                       @Setup
                       public void setup() {
-                        iprepdReader = IprepdIO.getReader(iprepdUrl, iprepdKey, project);
+                        iprepdReader = IprepdIO.getReader(iprepdSpec, project);
                       }
 
                       @ProcessElement

--- a/src/test/java/com/mozilla/secops/amo/TestAmo.java
+++ b/src/test/java/com/mozilla/secops/amo/TestAmo.java
@@ -35,8 +35,8 @@ public class TestAmo {
     ret.setUseEventTimestamp(true);
     ret.setMonitoredResourceIndicator("test");
     ret.setMaxmindCityDbPath(ParserTest.TEST_GEOIP_DBPATH);
-    ret.setOutputIprepd("http://127.0.0.1:8080");
-    ret.setOutputIprepdApikey("test");
+    ret.setInputIprepd("http://127.0.0.1:8080|test");
+    ret.setOutputIprepd(new String[] {"http://127.0.0.1:8080|test"});
     ret.setAccountMatchBanOnLogin(new String[] {"locutus.*"});
     ret.setAddonMatchCriteria(new String[] {".*test_submission.*:7500:7500"});
     // Reduce the required country match count for the IP login tests here

--- a/src/test/java/com/mozilla/secops/httprequest/TestHardLimit1.java
+++ b/src/test/java/com/mozilla/secops/httprequest/TestHardLimit1.java
@@ -64,11 +64,10 @@ public class TestHardLimit1 {
     TestIprepdIO.deleteReputation("ip", "192.168.1.4");
     TestIprepdIO.deleteReputation("ip", "192.168.1.5");
 
-    IprepdIO.Reader r = IprepdIO.getReader("http://127.0.0.1:8080", "test", null);
+    IprepdIO.Reader r = IprepdIO.getReader("http://127.0.0.1:8080|test", null);
 
     HTTPRequest.HTTPRequestOptions options = getTestOptions();
-    options.setOutputIprepd("http://127.0.0.1:8080");
-    options.setOutputIprepdApikey("test");
+    options.setOutputIprepd(new String[] {"http://127.0.0.1:8080|test"});
 
     PCollection<Alert> results =
         HTTPRequest.expandInputMap(
@@ -127,7 +126,7 @@ public class TestHardLimit1 {
     TestIprepdIO.deleteReputation("ip", "192.168.1.4");
     TestIprepdIO.deleteReputation("ip", "192.168.1.5");
 
-    IprepdIO.Reader r = IprepdIO.getReader("http://127.0.0.1:8080", "test", null);
+    IprepdIO.Reader r = IprepdIO.getReader("http://127.0.0.1:8080|test", null);
 
     // Create whitelisted ip in datastore
     State state =
@@ -162,8 +161,7 @@ public class TestHardLimit1 {
 
     HTTPRequest.HTTPRequestOptions options = getTestOptions();
     options.setOutputIprepdEnableDatastoreWhitelist(true);
-    options.setOutputIprepd("http://127.0.0.1:8080");
-    options.setOutputIprepdApikey("test");
+    options.setOutputIprepd(new String[] {"http://127.0.0.1:8080|test"});
 
     PCollection<Alert> results =
         HTTPRequest.expandInputMap(


### PR DESCRIPTION
* Creates a new spec similar to kinesis for iprepd `url:key` combos
* Moves "input iprepd" to input options (used by AMO)
* Remove legacy iprepd support

Fixes #239