### PR TITLE
Optimizations for multimode HTTPRequest

### DIFF
--- a/src/main/java/com/mozilla/secops/input/Input.java
+++ b/src/main/java/com/mozilla/secops/input/Input.java
@@ -407,7 +407,21 @@ public class Input implements Serializable {
 
                               @ProcessElement
                               public void processElement(ProcessContext c) {
-                                c.output(KV.of(i.getName(), c.element()));
+                                String el = c.element();
+                                // As an optimization, if a parser fast match element is set we can
+                                // apply it right here, and avoid passing elements in the collection
+                                // which will be dropped later.
+                                String fm = null;
+                                if (i.getParserConfiguration() != null) {
+                                  fm = i.getParserConfiguration().getParserFastMatcher();
+                                }
+                                if (fm != null) {
+                                  if (!el.contains(fm) && !el.contains("configuration_tick")) {
+                                    return;
+                                  }
+                                }
+
+                                c.output(KV.of(i.getName(), el));
                               }
                             })));
       }

--- a/src/main/java/com/mozilla/secops/input/InputElement.java
+++ b/src/main/java/com/mozilla/secops/input/InputElement.java
@@ -31,7 +31,7 @@ public class InputElement implements Serializable {
 
   private String name;
 
-  private transient Input parent;
+  private Input parent;
 
   private transient PTransform<PBegin, PCollection<String>> wiredStream;
 
@@ -39,8 +39,8 @@ public class InputElement implements Serializable {
   private transient ArrayList<String> pubsubInputs;
   private transient ArrayList<String> kinesisInputs;
 
-  private transient ParserCfg parserCfg;
-  private transient EventFilter filter;
+  private ParserCfg parserCfg;
+  private EventFilter filter;
 
   private String cfgTickMessage;
   private Integer cfgTickInterval;

--- a/src/main/java/com/mozilla/secops/parser/GLB.java
+++ b/src/main/java/com/mozilla/secops/parser/GLB.java
@@ -15,7 +15,7 @@ import org.joda.time.DateTime;
 public class GLB extends PayloadBase implements Serializable {
   private static final long serialVersionUID = 1L;
 
-  private final JacksonFactory jfmatcher;
+  private static final JacksonFactory jfmatcher = new JacksonFactory();
 
   private String requestMethod;
   private String userAgent;
@@ -59,9 +59,7 @@ public class GLB extends PayloadBase implements Serializable {
   }
 
   /** Construct matcher object. */
-  public GLB() {
-    jfmatcher = new JacksonFactory();
-  }
+  public GLB() {}
 
   /**
    * Construct parser object.
@@ -71,7 +69,6 @@ public class GLB extends PayloadBase implements Serializable {
    * @param state State
    */
   public GLB(String input, Event e, ParserState state) {
-    jfmatcher = null;
     LogEntry entry = state.getLogEntryHint();
     if (entry == null) {
       // Reuse JacksonFactory from parser state

--- a/src/main/java/com/mozilla/secops/parser/Nginx.java
+++ b/src/main/java/com/mozilla/secops/parser/Nginx.java
@@ -19,7 +19,7 @@ import org.joda.time.DateTime;
 public class Nginx extends PayloadBase implements Serializable {
   private static final long serialVersionUID = 1L;
 
-  private final transient JacksonFactory jfmatcher;
+  private static final JacksonFactory jfmatcher = new JacksonFactory();
 
   private String xForwardedProto;
   private String remoteAddr;
@@ -91,9 +91,7 @@ public class Nginx extends PayloadBase implements Serializable {
   }
 
   /** Construct matcher object. */
-  public Nginx() {
-    jfmatcher = new JacksonFactory();
-  }
+  public Nginx() {}
 
   /**
    * Construct parser object.
@@ -103,7 +101,6 @@ public class Nginx extends PayloadBase implements Serializable {
    * @param state State
    */
   public Nginx(String input, Event e, ParserState state) {
-    jfmatcher = null;
     LogEntry entry = state.getLogEntryHint();
     if (entry == null) {
       // Use method local JacksonFactory as the object is not serializable, and this event

--- a/src/main/java/com/mozilla/secops/parser/ParserMultiDoFn.java
+++ b/src/main/java/com/mozilla/secops/parser/ParserMultiDoFn.java
@@ -1,0 +1,123 @@
+package com.mozilla.secops.parser;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.values.KV;
+
+/**
+ * Process an incoming raw event feed using multiple parser configurations
+ *
+ * <p>Similar to {@link ParserDoFn}, but can be used to process an incoming raw event feed that is
+ * keyed using an identifier. An arbitrary number of parser configurations and filters can be
+ * installed in the class associated with an identifier.
+ *
+ * <p>When the DoFn processes an incoming raw string, it will utilize the configuration and filters
+ * associated with the identifier corresponding to the key of the input string.
+ *
+ * <p>The output will be the parsed event, keyed with the same identifier as the raw string.
+ */
+public class ParserMultiDoFn extends DoFn<KV<String, String>, KV<String, Event>> {
+  private static final long serialVersionUID = 1L;
+
+  private HashMap<String, ParserCfg> configurations;
+  private HashMap<String, EventFilter> inlineFilters;
+  private HashMap<String, EventFilter> commonInputFilters;
+
+  private transient HashMap<String, Parser> parsers;
+
+  /** Create new {@link ParserMultiDoFn} */
+  public ParserMultiDoFn() {
+    configurations = new HashMap<String, ParserCfg>();
+    inlineFilters = new HashMap<String, EventFilter>();
+    commonInputFilters = new HashMap<String, EventFilter>();
+  }
+
+  /**
+   * Add a new parser configuration and filter for the specified key name
+   *
+   * @param name Identifier name
+   * @param cfg Parser configuration
+   * @param inlineFilter Inline event filter, null for none
+   */
+  public void addParser(String name, ParserCfg cfg, EventFilter inlineFilter) {
+    if (cfg == null) {
+      throw new IllegalArgumentException("new parser must have configuration");
+    }
+    configurations.put(name, cfg);
+    if (inlineFilter != null) {
+      inlineFilters.put(name, inlineFilter);
+    }
+  }
+
+  @Setup
+  public void setup() {
+    parsers = new HashMap<String, Parser>();
+    // Create an instance of the parser for each configuration we have
+    for (Map.Entry<String, ParserCfg> entry : configurations.entrySet()) {
+      ParserCfg c = entry.getValue();
+      parsers.put(entry.getKey(), new Parser(c));
+
+      // Install a common input filter for this parser instance if needed; see the comments in
+      // ParserDoFn for more details on this
+      if ((c.getStackdriverLabelFilters() != null) || (c.getStackdriverProjectFilter() != null)) {
+        EventFilter commonInputFilter = new EventFilter().passConfigurationTicks();
+        EventFilterRule rule = new EventFilterRule();
+
+        if (c.getStackdriverLabelFilters() != null) {
+          for (String labelFilter : c.getStackdriverLabelFilters()) {
+            String parts[] = labelFilter.split(":");
+            if (parts.length != 2) {
+              throw new IllegalArgumentException(
+                  "invalid format for Stackdriver label filter, must be <key>:<value>");
+            }
+            rule.wantStackdriverLabel(parts[0], parts[1]);
+          }
+        }
+
+        if (c.getStackdriverProjectFilter() != null) {
+          rule.wantStackdriverProject(c.getStackdriverProjectFilter());
+        }
+
+        commonInputFilter.addRule(rule);
+        commonInputFilters.put(entry.getKey(), commonInputFilter);
+      }
+    }
+  }
+
+  @ProcessElement
+  public void processElement(ProcessContext c) {
+    KV<String, String> raw = c.element();
+
+    Parser p = parsers.get(raw.getKey());
+    if (p == null) {
+      throw new RuntimeException(String.format("input for unknown element %s", raw.getKey()));
+    }
+    EventFilter common = commonInputFilters.get(raw.getKey());
+    EventFilter inline = inlineFilters.get(raw.getKey());
+    ParserCfg cfg = configurations.get(raw.getKey());
+
+    Event e = p.parse(raw.getValue());
+    if (e == null) {
+      return;
+    }
+
+    if (common != null) {
+      if (!(common.matches(e))) {
+        return;
+      }
+    }
+
+    if (inline != null) {
+      if (!(inline.matches(e))) {
+        return;
+      }
+    }
+
+    if (cfg.getUseEventTimestamp()) {
+      c.outputWithTimestamp(KV.of(raw.getKey(), e), e.getTimestamp().toInstant());
+    } else {
+      c.output(KV.of(raw.getKey(), e));
+    }
+  }
+}


### PR DESCRIPTION
* Instead of using a separate `DoFn` for each input leg, apply a single function
* Reuse `JacksonFactory` where possible
* Apply parser fast match early in `Input` if we can; this significantly reduces the number of raw events we will need to throw away in the filtering stage