### PR TITLE
Recommended fixes from lgtm.com

### DIFF
--- a/src/main/java/com/mozilla/secops/GeoUtil.java
+++ b/src/main/java/com/mozilla/secops/GeoUtil.java
@@ -37,12 +37,12 @@ public class GeoUtil {
     int r = 6378;
 
     // convert to radians
-    Double lat1Radian = lat1 * Math.PI / 180;
-    Double lon1Radian = lon1 * Math.PI / 180;
-    Double lat2Radian = lat2 * Math.PI / 180;
-    Double lon2Radian = lon2 * Math.PI / 180;
+    double lat1Radian = lat1 * Math.PI / 180;
+    double lon1Radian = lon1 * Math.PI / 180;
+    double lat2Radian = lat2 * Math.PI / 180;
+    double lon2Radian = lon2 * Math.PI / 180;
 
-    Double h =
+    double h =
         haversin(lat2Radian - lat1Radian)
             + Math.cos(lat1Radian) * Math.cos(lat2Radian) * haversin(lon2Radian - lon1Radian);
 

--- a/src/main/java/com/mozilla/secops/Stats.java
+++ b/src/main/java/com/mozilla/secops/Stats.java
@@ -31,6 +31,9 @@ public class Stats extends PTransform<PCollection<Long>, PCollection<Stats.Stats
 
     @Override
     public boolean equals(Object o) {
+      if (!(o instanceof StatsOutput)) {
+        return false;
+      }
       StatsOutput s = (StatsOutput) o;
       return getOutputId().equals(s.getOutputId());
     }
@@ -137,6 +140,9 @@ public class Stats extends PTransform<PCollection<Long>, PCollection<Stats.Stats
 
       @Override
       public boolean equals(Object o) {
+        if (!(o instanceof State)) {
+          return false;
+        }
         State s = (State) o;
         return getId().equals(s.getId());
       }

--- a/src/main/java/com/mozilla/secops/alert/Alert.java
+++ b/src/main/java/com/mozilla/secops/alert/Alert.java
@@ -362,6 +362,9 @@ public class Alert implements Serializable {
 
   @Override
   public boolean equals(Object o) {
+    if (!(o instanceof Alert)) {
+      return false;
+    }
     Alert t = (Alert) o;
     return getAlertId().equals(t.getAlertId());
   }

--- a/src/main/java/com/mozilla/secops/amo/AddonMultiIpLogin.java
+++ b/src/main/java/com/mozilla/secops/amo/AddonMultiIpLogin.java
@@ -212,7 +212,7 @@ public class AddonMultiIpLogin extends PTransform<PCollection<Event>, PCollectio
                       return;
                     }
 
-                    Boolean aggMatch = false;
+                    boolean aggMatch = false;
                     for (Pattern i : aggRe) {
                       Matcher m = i.matcher(c.element().getKey());
                       if (m.matches()) {

--- a/src/main/java/com/mozilla/secops/amo/FxaAccountAbuseNewVersion.java
+++ b/src/main/java/com/mozilla/secops/amo/FxaAccountAbuseNewVersion.java
@@ -127,7 +127,7 @@ public class FxaAccountAbuseNewVersion extends PTransform<PCollection<Event>, PC
                         }
 
                         // Compare profile against configured ban patterns
-                        Boolean configuredBan = false;
+                        boolean configuredBan = false;
                         for (Pattern p : banAccountsPat) {
                           if (p.matcher(d.getFxaEmail()).matches()) {
                             configuredBan = true;

--- a/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
+++ b/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
@@ -575,7 +575,7 @@ public class AuthProfile implements Serializable {
 
         // If the address is already in the known address list, we have already processed it
         // as known so just skip the state logic
-        Boolean isSeen = false;
+        boolean isSeen = false;
         for (String s : seenKnownAddresses) {
           if (s.equals(e.getNormalized().getSourceAddress())) {
             isSeen = true;
@@ -651,7 +651,7 @@ public class AuthProfile implements Serializable {
                       e.getNormalized().getSourceAddressLatitude(),
                       e.getNormalized().getSourceAddressLongitude());
 
-              Long timeDifference =
+              long timeDifference =
                   (DateTimeUtils.currentTimeMillis() / 1000)
                       - (lastLocation.getTimestamp().getMillis() / 1000);
 

--- a/src/main/java/com/mozilla/secops/authprofile/StateModel.java
+++ b/src/main/java/com/mozilla/secops/authprofile/StateModel.java
@@ -18,8 +18,8 @@ import org.joda.time.DateTimeUtils;
  * <p>Used by {@link AuthProfile}.
  */
 public class StateModel {
-  private static final Long DEFAULTPRUNEAGE = 864000L * 3; // 30 days
-  private static final Long DEFAULTEXPIREAGE = 864000L; // 10 days
+  private static final long DEFAULTPRUNEAGE = 864000L * 3; // 30 days
+  private static final long DEFAULTEXPIREAGE = 864000L; // 10 days
 
   private String subject;
   private Map<String, ModelEntry> entries;
@@ -94,7 +94,7 @@ public class StateModel {
      * @return Boolean
      */
     public boolean isExpired() {
-      Long mts = timestamp.getMillis() / 1000;
+      long mts = timestamp.getMillis() / 1000;
       if ((DateTimeUtils.currentTimeMillis() / 1000) - mts > DEFAULTEXPIREAGE) {
         return true;
       }
@@ -119,7 +119,7 @@ public class StateModel {
     while (it.hasNext()) {
       Map.Entry<?, ?> p = (Map.Entry) it.next();
       ModelEntry me = (ModelEntry) p.getValue();
-      Long mts = me.getTimestamp().getMillis() / 1000;
+      long mts = me.getTimestamp().getMillis() / 1000;
       if ((DateTimeUtils.currentTimeMillis() / 1000) - mts > age) {
         it.remove();
       }

--- a/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
+++ b/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
@@ -568,7 +568,9 @@ public class HTTPRequest implements Serializable {
     /**
      * Static initializer for {@link EndpointAbuseAnalysis}
      *
-     * @param options Pipeline options
+     * @param toggles {@link HTTPRequestToggles}
+     * @param enableIprepdDatastoreWhitelist True to enable datastore whitelist
+     * @param iprepdDatastoreWhitelistProject Project to look for datastore entities in
      */
     public EndpointAbuseAnalysis(
         HTTPRequestToggles toggles,
@@ -637,8 +639,8 @@ public class HTTPRequest implements Serializable {
                       Iterable<ArrayList<String>> paths = c.element().getValue();
                       int[] endCounter = new int[endpoints.length];
                       String userAgent = null;
-                      Boolean basicVariance = false;
-                      Boolean extendedVariance = false;
+                      boolean basicVariance = false;
+                      boolean extendedVariance = false;
 
                       // Used to track the latest applicable EPA request, so we can use it as the
                       // alert timestamp if we need to generate an alert.

--- a/src/main/java/com/mozilla/secops/input/InputElement.java
+++ b/src/main/java/com/mozilla/secops/input/InputElement.java
@@ -99,7 +99,7 @@ public class InputElement implements Serializable {
   /**
    * Expand configured input types into a resulting collection of strings
    *
-   * @param PBegin Pipeline begin
+   * @param begin Pipeline begin using {@link PBegin}
    * @param project GCP project, set if using RuntimeSecrets
    */
   public PCollection<String> expandElementRaw(PBegin begin, String project) {
@@ -146,7 +146,7 @@ public class InputElement implements Serializable {
   /**
    * Expand configured input types into a resulting collection of parsed events
    *
-   * @param PBegin Pipeline begin
+   * @param begin Pipeline begin using {@link PBegin}
    * @param project GCP project, set if using RuntimeSecrets
    */
   public PCollection<Event> expandElement(PBegin begin, String project) {

--- a/src/main/java/com/mozilla/secops/parser/Event.java
+++ b/src/main/java/com/mozilla/secops/parser/Event.java
@@ -49,6 +49,9 @@ public class Event implements Serializable {
 
   @Override
   public boolean equals(Object o) {
+    if (!(o instanceof Event)) {
+      return false;
+    }
     Event t = (Event) o;
     return getEventId().equals(t.getEventId());
   }

--- a/src/main/java/com/mozilla/secops/slack/SlackManager.java
+++ b/src/main/java/com/mozilla/secops/slack/SlackManager.java
@@ -185,7 +185,7 @@ public class SlackManager {
     } catch (SlackApiException exc) {
       Optional<String> retryAfter = Optional.ofNullable(exc.getResponse().header("Retry-After"));
       if (retryAfter.isPresent()) {
-        Integer wait = Integer.parseInt(retryAfter.get());
+        int wait = Integer.parseInt(retryAfter.get());
         log.info("waiting {} seconds for slack rate limit to expire.", wait);
         try {
           Thread.sleep(wait * 1000);


### PR DESCRIPTION
Went through a number of alerts from lgtm.com, fixed most ones in these
categories:

  * Equals method does not inspect argument type - https://lgtm.com/rules/7850079/
    * Make sure to check object type in `equals()` funcs
  * Boxed variable is never null - https://lgtm.com/rules/1813633265/
    * Basically, use a primitive if your variable can't be null.
    Improves readability and performance.
  * Spurious Javadoc `@param` tags - https://lgtm.com/rules/2049510531/
    * `@param` tags where the param doesn't match the param