### PR TITLE
Reusable AuthStateModel, move geo-velocity analysis into model

### DIFF
--- a/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
+++ b/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
@@ -620,9 +620,6 @@ public class AuthProfile implements Serializable {
             a.addMetadata("entry_key", entryKey);
           }
 
-          // used for geo velocity analysis
-          AuthStateModel.ModelEntry lastLocation = sm.getLatestEntry();
-
           if (sm.updateEntry(
               entryKey,
               e.getNormalized().getSourceAddressLatitude(),

--- a/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
+++ b/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
@@ -646,16 +646,18 @@ public class AuthProfile implements Serializable {
                   userIdentity,
                   geoResp.getKmDistance(),
                   geoResp.getTimeDifference());
-              log.info("{}: creating geo velocity alert", userIdentity);
-              Alert ga = AuthProfile.createBaseAlert(e);
-              ga.addMetadata("identity_key", userIdentity);
-              ga.addMetadata("category", "geo_velocity");
-              // TODO: Once this has run for a while, should switch to CRITICAL and add escalation
-              // metadata
-              ga.setSeverity(Alert.AlertSeverity.INFORMATIONAL);
-              buildGeoVelocityAlertSummary(e, ga);
-              buildGeoVelocityAlertPayload(e, ga);
-              c.output(ga);
+              if (geoResp.getMaxKmPerSecondExceeded()) {
+                log.info("{}: creating geo velocity alert", userIdentity);
+                Alert ga = AuthProfile.createBaseAlert(e);
+                ga.addMetadata("identity_key", userIdentity);
+                ga.addMetadata("category", "geo_velocity");
+                // TODO: Once this has run for a while, should switch to CRITICAL and add escalation
+                // metadata
+                ga.setSeverity(Alert.AlertSeverity.INFORMATIONAL);
+                buildGeoVelocityAlertSummary(e, ga);
+                buildGeoVelocityAlertPayload(e, ga);
+                c.output(ga);
+              }
             }
 
           } else {

--- a/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
+++ b/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
@@ -8,6 +8,7 @@ import com.mozilla.secops.OutputOptions;
 import com.mozilla.secops.alert.Alert;
 import com.mozilla.secops.alert.AlertFormatter;
 import com.mozilla.secops.alert.AlertIO;
+import com.mozilla.secops.authstate.AuthStateModel;
 import com.mozilla.secops.identity.Identity;
 import com.mozilla.secops.identity.IdentityManager;
 import com.mozilla.secops.input.Input;
@@ -611,9 +612,9 @@ public class AuthProfile implements Serializable {
 
           a.addMetadata("identity_key", userIdentity);
           // The event was for a tracked identity, initialize the state model
-          StateModel sm = StateModel.get(userIdentity, cur);
+          AuthStateModel sm = AuthStateModel.get(userIdentity, cur);
           if (sm == null) {
-            sm = new StateModel(userIdentity);
+            sm = new AuthStateModel(userIdentity);
           }
 
           String entryKey = getEntryKey(e.getNormalized().getSourceAddress());
@@ -622,7 +623,7 @@ public class AuthProfile implements Serializable {
           }
 
           // used for geo velocity analysis
-          StateModel.ModelEntry lastLocation = sm.getLatestEntry();
+          AuthStateModel.ModelEntry lastLocation = sm.getLatestEntry();
 
           if (sm.updateEntry(
               entryKey,

--- a/src/main/java/com/mozilla/secops/authstate/AuthStateModel.java
+++ b/src/main/java/com/mozilla/secops/authstate/AuthStateModel.java
@@ -4,8 +4,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.mozilla.secops.GeoUtil;
 import com.mozilla.secops.state.StateCursor;
 import com.mozilla.secops.state.StateException;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -28,6 +33,41 @@ public class AuthStateModel {
 
   private String subject;
   private Map<String, ModelEntry> entries;
+
+  /** Response to {@link AuthStateModel} GeoVelocity analysis request */
+  public static class GeoVelocityResponse {
+    private Long timeDifference;
+    private Double kmDistance;
+
+    /**
+     * Get difference in time in seconds
+     *
+     * @return Long
+     */
+    public Long getTimeDifference() {
+      return timeDifference;
+    }
+
+    /**
+     * Get distance between points in KM
+     *
+     * @return Double
+     */
+    public Double getKmDistance() {
+      return kmDistance;
+    }
+
+    /**
+     * Create new GeoVelocityResponse
+     *
+     * @param timeDifference Time difference in seconds
+     * @param kmDistance Distance between points in KM
+     */
+    public GeoVelocityResponse(Long timeDifference, Double kmDistance) {
+      this.timeDifference = timeDifference;
+      this.kmDistance = kmDistance;
+    }
+  }
 
   /** Represents a single known source for authentication for a given user */
   @JsonIgnoreProperties(ignoreUnknown = true)
@@ -258,6 +298,87 @@ public class AuthStateModel {
   public void set(StateCursor s) throws StateException {
     s.set(subject, this);
     s.commit();
+  }
+
+  /**
+   * Perform geo-velocity analysis using the latest entries in the model
+   *
+   * <p>The latest entry in the model (e.g., last known authentication event) is compared against
+   * the entry that precedes it. If long/lat information is available, this information is used to
+   * calculate the distance between the events and the amount of time that passed between the
+   * events.
+   *
+   * <p>If the KM/s exceeds maxKmPerSecond, a response is returned. If analysis was not possible or
+   * maxKmPerSecond was not violated, null is returned.
+   *
+   * @param maxKmPerSecond The maximum KM per second to use for the analysis
+   * @return GeoVelocityResponse or null
+   */
+  public GeoVelocityResponse geoVelocityAnalyzeLatest(Double maxKmPerSecond) {
+    ArrayList<AbstractMap.SimpleEntry<String, ModelEntry>> ent = timeSortedEntries();
+
+    int s = ent.size();
+    if (s <= 1) {
+      return null;
+    }
+
+    AbstractMap.SimpleEntry<String, ModelEntry> prev = ent.get(s - 2);
+    AbstractMap.SimpleEntry<String, ModelEntry> cur = ent.get(s - 1);
+
+    // Make sure we have long/lat for both entries
+    if ((prev.getValue().getLatitude() == null)
+        || (prev.getValue().getLongitude() == null)
+        || (cur.getValue().getLatitude() == null)
+        || (cur.getValue().getLongitude() == null)) {
+      return null;
+    }
+
+    Double kmdist =
+        GeoUtil.kmBetweenTwoPoints(
+            prev.getValue().getLatitude(),
+            prev.getValue().getLongitude(),
+            cur.getValue().getLatitude(),
+            cur.getValue().getLongitude());
+
+    long td =
+        (cur.getValue().getTimestamp().getMillis() / 1000)
+            - (prev.getValue().getTimestamp().getMillis() / 1000);
+
+    if ((kmdist / td) > maxKmPerSecond) {
+      return new GeoVelocityResponse(td, kmdist);
+    }
+
+    return null;
+  }
+
+  /**
+   * Return all entries in AuthStateModel as an array list, sorted by timestamp
+   *
+   * @return ArrayList
+   */
+  public ArrayList<AbstractMap.SimpleEntry<String, ModelEntry>> timeSortedEntries() {
+    ArrayList<AbstractMap.SimpleEntry<String, ModelEntry>> ret = new ArrayList<>();
+    for (Map.Entry<String, ModelEntry> entry : entries.entrySet()) {
+      ret.add(new AbstractMap.SimpleEntry<String, ModelEntry>(entry.getKey(), entry.getValue()));
+    }
+    Collections.sort(
+        ret,
+        new Comparator<AbstractMap.SimpleEntry<String, ModelEntry>>() {
+          @Override
+          public int compare(
+              AbstractMap.SimpleEntry<String, ModelEntry> lhs,
+              AbstractMap.SimpleEntry<String, ModelEntry> rhs) {
+            DateTime lhsd = lhs.getValue().getTimestamp();
+            DateTime rhsd = rhs.getValue().getTimestamp();
+            if (lhsd.isAfter(rhsd)) {
+              return 1;
+            } else if (lhsd.isBefore(rhsd)) {
+              return -1;
+            }
+            return 0;
+          }
+        });
+    return ret;
   }
 
   /**

--- a/src/main/java/com/mozilla/secops/authstate/AuthStateModel.java
+++ b/src/main/java/com/mozilla/secops/authstate/AuthStateModel.java
@@ -36,8 +36,9 @@ public class AuthStateModel {
 
   /** Response to {@link AuthStateModel} GeoVelocity analysis request */
   public static class GeoVelocityResponse {
-    private Long timeDifference;
-    private Double kmDistance;
+    private final Long timeDifference;
+    private final Double kmDistance;
+    private final Boolean maxKmPerSExceeded;
 
     /**
      * Get difference in time in seconds
@@ -46,6 +47,15 @@ public class AuthStateModel {
      */
     public Long getTimeDifference() {
       return timeDifference;
+    }
+
+    /**
+     * Return true if max KM/s was exceeded
+     *
+     * @return Boolean
+     */
+    public Boolean getMaxKmPerSecondExceeded() {
+      return maxKmPerSExceeded;
     }
 
     /**
@@ -63,9 +73,10 @@ public class AuthStateModel {
      * @param timeDifference Time difference in seconds
      * @param kmDistance Distance between points in KM
      */
-    public GeoVelocityResponse(Long timeDifference, Double kmDistance) {
+    public GeoVelocityResponse(Long timeDifference, Double kmDistance, Boolean maxKmPerSExceeded) {
       this.timeDifference = timeDifference;
       this.kmDistance = kmDistance;
+      this.maxKmPerSExceeded = maxKmPerSExceeded;
     }
   }
 
@@ -308,8 +319,7 @@ public class AuthStateModel {
    * calculate the distance between the events and the amount of time that passed between the
    * events.
    *
-   * <p>If the KM/s exceeds maxKmPerSecond, a response is returned. If analysis was not possible or
-   * maxKmPerSecond was not violated, null is returned.
+   * <p>If geo-velocity analysis was possible, a GeoVelocityResponse is returned, null if not.
    *
    * @param maxKmPerSecond The maximum KM per second to use for the analysis
    * @return GeoVelocityResponse or null
@@ -345,10 +355,9 @@ public class AuthStateModel {
             - (prev.getValue().getTimestamp().getMillis() / 1000);
 
     if ((kmdist / td) > maxKmPerSecond) {
-      return new GeoVelocityResponse(td, kmdist);
+      return new GeoVelocityResponse(td, kmdist, true);
     }
-
-    return null;
+    return new GeoVelocityResponse(td, kmdist, false);
   }
 
   /**

--- a/src/main/java/com/mozilla/secops/authstate/AuthStateModel.java
+++ b/src/main/java/com/mozilla/secops/authstate/AuthStateModel.java
@@ -135,6 +135,9 @@ public class AuthStateModel {
    * <p>Note this function does not write the new state, set must be called to make changes
    * permanent.
    *
+   * <p>This variant of the method will use the current time as the timestamp for the authentication
+   * event, instead of accepting a parameter incidating the timestamp to associated with the event.
+   *
    * @param ipaddr IP address to update state with
    * @param latitude IP address's latitude
    * @param longitude IP address's longitude

--- a/src/main/java/com/mozilla/secops/authstate/package-info.java
+++ b/src/main/java/com/mozilla/secops/authstate/package-info.java
@@ -1,0 +1,2 @@
+/** Authentication state storage and utility classes */
+package com.mozilla.secops.authstate;

--- a/src/test/java/com/mozilla/secops/authprofile/TestAuthProfile.java
+++ b/src/test/java/com/mozilla/secops/authprofile/TestAuthProfile.java
@@ -13,6 +13,7 @@ import com.mozilla.secops.alert.Alert;
 import com.mozilla.secops.alert.AlertConfiguration;
 import com.mozilla.secops.alert.AlertIO;
 import com.mozilla.secops.alert.TemplateManager;
+import com.mozilla.secops.authstate.AuthStateModel;
 import com.mozilla.secops.input.Input;
 import com.mozilla.secops.parser.Event;
 import com.mozilla.secops.parser.Normalized;
@@ -490,7 +491,7 @@ public class TestAuthProfile {
                 options.getDatastoreKind(), options.getDatastoreNamespace()));
     state.initialize();
     StateCursor c = state.newCursor();
-    StateModel sm = new StateModel("wriker@mozilla.com");
+    AuthStateModel sm = new AuthStateModel("wriker@mozilla.com");
     DateTime n = new DateTime();
     // Set it to be a day ago so that we can test that moving a new entry far away
     // geographically in a long period of time does not create an alert.
@@ -546,7 +547,7 @@ public class TestAuthProfile {
                 options.getDatastoreKind(), options.getDatastoreNamespace()));
     state.initialize();
     StateCursor c = state.newCursor();
-    StateModel sm = new StateModel("wriker@mozilla.com");
+    AuthStateModel sm = new AuthStateModel("wriker@mozilla.com");
     sm.updateEntry("216.160.83.56", null, null);
     sm.set(c);
     state.done();

--- a/src/test/java/com/mozilla/secops/authstate/TestAuthStateModel.java
+++ b/src/test/java/com/mozilla/secops/authstate/TestAuthStateModel.java
@@ -9,6 +9,8 @@ import static org.junit.Assert.assertTrue;
 import com.mozilla.secops.state.DatastoreStateInterface;
 import com.mozilla.secops.state.State;
 import com.mozilla.secops.state.StateCursor;
+import java.util.AbstractMap;
+import java.util.ArrayList;
 import org.joda.time.DateTime;
 import org.junit.Rule;
 import org.junit.Test;
@@ -27,7 +29,27 @@ public class TestAuthStateModel {
   public TestAuthStateModel() {}
 
   @Test
-  public void AuthStateModelTest() throws Exception {
+  public void authStateModelTimeSortedTest() throws Exception {
+    AuthStateModel sm = new AuthStateModel("riker");
+    sm.updateEntry("127.0.0.4", new DateTime(4L), 4.0, 4.0);
+    sm.updateEntry("127.0.0.3", new DateTime(3L), 3.0, 3.0);
+    sm.updateEntry("127.0.0.1", new DateTime(1L), 1.0, 1.0);
+    sm.updateEntry("127.0.0.2", new DateTime(2L), 2.0, 2.0);
+    ArrayList<AbstractMap.SimpleEntry<String, AuthStateModel.ModelEntry>> ret =
+        sm.timeSortedEntries();
+    assertEquals(4, ret.size());
+    assertEquals("127.0.0.1", ret.get(0).getKey());
+    assertEquals(1L, ret.get(0).getValue().getTimestamp().getMillis());
+    assertEquals("127.0.0.2", ret.get(1).getKey());
+    assertEquals(2L, ret.get(1).getValue().getTimestamp().getMillis());
+    assertEquals("127.0.0.3", ret.get(2).getKey());
+    assertEquals(3L, ret.get(2).getValue().getTimestamp().getMillis());
+    assertEquals("127.0.0.4", ret.get(3).getKey());
+    assertEquals(4L, ret.get(3).getValue().getTimestamp().getMillis());
+  }
+
+  @Test
+  public void authStateModelTest() throws Exception {
     testEnv();
     State s = new State(new DatastoreStateInterface("authprofile", "teststatemodel"));
     StateCursor c;

--- a/src/test/java/com/mozilla/secops/authstate/TestAuthStateModel.java
+++ b/src/test/java/com/mozilla/secops/authstate/TestAuthStateModel.java
@@ -1,4 +1,4 @@
-package com.mozilla.secops.authprofile;
+package com.mozilla.secops.authstate;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -14,7 +14,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
 
-public class TestStateModel {
+public class TestAuthStateModel {
   @Rule public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
   private void testEnv() {
@@ -24,26 +24,26 @@ public class TestStateModel {
     environmentVariables.set("DATASTORE_PROJECT_ID", "foxsec-pipeline");
   }
 
-  public TestStateModel() {}
+  public TestAuthStateModel() {}
 
   @Test
-  public void StateModelTest() throws Exception {
+  public void AuthStateModelTest() throws Exception {
     testEnv();
     State s = new State(new DatastoreStateInterface("authprofile", "teststatemodel"));
     StateCursor c;
     s.initialize();
 
     c = s.newCursor();
-    assertNull(StateModel.get("nonexist", c));
+    assertNull(AuthStateModel.get("nonexist", c));
     c.commit();
 
-    StateModel sm = new StateModel("riker");
+    AuthStateModel sm = new AuthStateModel("riker");
     assertNotNull(sm);
     c = s.newCursor();
     sm.set(c);
 
     c = s.newCursor();
-    sm = StateModel.get("riker", c);
+    sm = AuthStateModel.get("riker", c);
     assertNotNull(sm);
     assertEquals(sm.getEntries().size(), 0);
 
@@ -53,7 +53,7 @@ public class TestStateModel {
     sm.set(c);
 
     c = s.newCursor();
-    sm = StateModel.get("riker", c);
+    sm = AuthStateModel.get("riker", c);
     assertEquals(sm.getEntries().size(), 1);
     assertFalse(sm.updateEntry("127.0.0.1", 1.0, 1.0)); // Assert false for update existing
     sm.set(c);
@@ -63,11 +63,11 @@ public class TestStateModel {
     assertEquals(sm.getEntries().size(), 2);
     sm.set(c);
     c = s.newCursor();
-    sm = StateModel.get("riker", c);
+    sm = AuthStateModel.get("riker", c);
     assertEquals(sm.getEntries().size(), 2);
     c.commit();
 
-    sm = new StateModel("picard");
+    sm = new AuthStateModel("picard");
     assertNotNull(sm);
     assertTrue(sm.updateEntry("127.0.0.1", 1.0, 1.0));
     assertEquals(sm.getEntries().size(), 1);
@@ -75,17 +75,17 @@ public class TestStateModel {
     sm.set(c);
 
     c = s.newCursor();
-    sm = StateModel.get("picard", c);
+    sm = AuthStateModel.get("picard", c);
     assertTrue(sm.updateEntry("10.0.0.1", new DateTime().minusDays(1), 44.0, 44.0));
     sm.set(c);
 
     c = s.newCursor();
-    sm = StateModel.get("picard", c);
+    sm = AuthStateModel.get("picard", c);
     assertEquals(sm.getEntries().size(), 2);
     sm.pruneState(43200L);
     sm.set(c);
     c = s.newCursor();
-    sm = StateModel.get("picard", c);
+    sm = AuthStateModel.get("picard", c);
     assertEquals(sm.getEntries().size(), 1);
     c.commit();
 


### PR DESCRIPTION
Move `StateModel` out of the `authprofile` package into a new `authstate` package, with the intent of making this class reusable with other pipelines.

This also moves the geo-velocity analysis that was originally part of `AuthProfile` into the state model.