### PR TITLE
improve discarded event handling

### DIFF
--- a/src/main/java/com/mozilla/secops/InputOptions.java
+++ b/src/main/java/com/mozilla/secops/InputOptions.java
@@ -67,6 +67,13 @@ public interface InputOptions extends PipelineOptions, PubsubOptions, GcpOptions
 
   void setParserFastMatcher(String value);
 
+  @Description(
+      "Maximum allowable timestamp difference, events with timestamp difference older than value "
+          + "in seconds will be flagged; integer")
+  Integer getMaximumAllowableTimestampDifference();
+
+  void setMaximumAllowableTimestampDifference(Integer value);
+
   @Description("Configuration tick interval, 0 to disable; seconds")
   @Default.Integer(0)
   Integer getGenerateConfigurationTicksInterval();

--- a/src/main/java/com/mozilla/secops/input/InputDiscardSummary.java
+++ b/src/main/java/com/mozilla/secops/input/InputDiscardSummary.java
@@ -1,0 +1,93 @@
+package com.mozilla.secops.input;
+
+import com.mozilla.secops.parser.Event;
+import org.apache.beam.sdk.transforms.Count;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.windowing.FixedWindows;
+import org.apache.beam.sdk.transforms.windowing.Window;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PDone;
+import org.joda.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Summarize input discard events */
+public class InputDiscardSummary extends PTransform<PCollection<Event>, PDone> {
+  private static final long serialVersionUID = 1L;
+
+  private static final String UNKNOWN_DISCARD = "unknown_discard";
+  private static final String INLINE_FILTER_MISMATCH = "inline_filter_mismatch";
+  private static final String FASTMATCH_MISMATCH = "fastmatch_mismatch";
+  private static final String COMMON_INPUT_FILTER_MISMATCH = "common_input_filter_mismatch";
+  private static final String TIMESTAMP_TOO_OLD = "timestamp_too_old";
+
+  private String name;
+  private Logger log;
+
+  /**
+   * Create new InputDiscardSummary
+   *
+   * @param name Element name
+   */
+  public InputDiscardSummary(String name) {
+    this.name = name;
+    log = LoggerFactory.getLogger(InputDiscardSummary.class);
+  }
+
+  @Override
+  public PDone expand(PCollection<Event> input) {
+    input
+        .apply(
+            "discard extract type",
+            ParDo.of(
+                new DoFn<Event, String>() {
+                  private static final long serialVersionUID = 1L;
+
+                  @ProcessElement
+                  public void processElement(ProcessContext c) {
+                    Event e = c.element();
+                    switch (e.getEventFlag()) {
+                      case FLAG_OK:
+                        // This should never happen
+                        throw new RuntimeException("FLAG_OK in InputDiscardSummary");
+                      case FLAG_INLINE_FILTER_MISMATCH:
+                        c.output(INLINE_FILTER_MISMATCH);
+                        break;
+                      case FLAG_FASTMATCH_MISMATCH:
+                        c.output(FASTMATCH_MISMATCH);
+                        break;
+                      case FLAG_COMMON_INPUT_FILTER_MISMATCH:
+                        c.output(COMMON_INPUT_FILTER_MISMATCH);
+                        break;
+                      case FLAG_TIMESTAMP_TOO_OLD:
+                        c.output(TIMESTAMP_TOO_OLD);
+                        break;
+                      default:
+                        c.output(UNKNOWN_DISCARD);
+                        break;
+                    }
+                  }
+                }))
+        .apply(Window.<String>into(FixedWindows.of(Duration.standardMinutes(5))))
+        .apply(Count.perElement())
+        .apply(
+            "discard summary",
+            ParDo.of(
+                new DoFn<KV<String, Long>, Void>() {
+                  private static final long serialVersionUID = 1L;
+
+                  @ProcessElement
+                  public void processElement(ProcessContext c) {
+                    log.info(
+                        "input discard summary: {}: {} {}",
+                        name,
+                        c.element().getKey(),
+                        c.element().getValue());
+                  }
+                }));
+    return PDone.in(input.getPipeline());
+  }
+}

--- a/src/main/java/com/mozilla/secops/input/InputIsolator.java
+++ b/src/main/java/com/mozilla/secops/input/InputIsolator.java
@@ -1,0 +1,44 @@
+package com.mozilla.secops.input;
+
+import com.mozilla.secops.parser.Event;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.values.TupleTag;
+
+/**
+ * Input tuple isolation
+ *
+ * <p>DoFn which takes a collection of events as input, and returns an output tuple with two tuple
+ * tags, one for events with FLAG_OK, and the other for any events which have a different event flag
+ * set.
+ */
+public class InputIsolator extends DoFn<Event, Event> {
+  private static final long serialVersionUID = 1L;
+
+  private final TupleTag<Event> okEvents;
+  private final TupleTag<Event> discardEvents;
+
+  /**
+   * Initialize new input isolator
+   *
+   * @param okEvents OK events tuple tag
+   * @param discardEvents Discard events tuple tag
+   */
+  public InputIsolator(TupleTag<Event> okEvents, TupleTag<Event> discardEvents) {
+    this.okEvents = okEvents;
+    this.discardEvents = discardEvents;
+  }
+
+  @ProcessElement
+  public void processElement(ProcessContext c, MultiOutputReceiver out) {
+    Event e = c.element();
+
+    switch (e.getEventFlag()) {
+      case FLAG_OK:
+        out.get(okEvents).output(e);
+        break;
+      default:
+        out.get(discardEvents).output(e);
+        break;
+    }
+  }
+}

--- a/src/main/java/com/mozilla/secops/input/MultiInputIsolator.java
+++ b/src/main/java/com/mozilla/secops/input/MultiInputIsolator.java
@@ -1,0 +1,46 @@
+package com.mozilla.secops.input;
+
+import com.mozilla.secops.parser.Event;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.TupleTag;
+
+/**
+ * Input tuple isolation for multiplexed input
+ *
+ * <p>DoFn which takes a collection of events as input, and returns an output tuple with two tuple
+ * tags, one for events with FLAG_OK, and the other for any events which have a different event flag
+ * set.
+ */
+public class MultiInputIsolator extends DoFn<KV<String, Event>, KV<String, Event>> {
+  private static final long serialVersionUID = 1L;
+
+  private final TupleTag<KV<String, Event>> okEvents;
+  private final TupleTag<KV<String, Event>> discardEvents;
+
+  /**
+   * Initialize new multi input isolator
+   *
+   * @param okEvents OK events tuple tag
+   * @param discardEvents Discard events tuple tag
+   */
+  public MultiInputIsolator(
+      TupleTag<KV<String, Event>> okEvents, TupleTag<KV<String, Event>> discardEvents) {
+    this.okEvents = okEvents;
+    this.discardEvents = discardEvents;
+  }
+
+  @ProcessElement
+  public void processElement(ProcessContext c, MultiOutputReceiver out) {
+    KV<String, Event> e = c.element();
+
+    switch (e.getValue().getEventFlag()) {
+      case FLAG_OK:
+        out.get(okEvents).output(e);
+        break;
+      default:
+        out.get(discardEvents).output(e);
+        break;
+    }
+  }
+}

--- a/src/main/java/com/mozilla/secops/parser/Event.java
+++ b/src/main/java/com/mozilla/secops/parser/Event.java
@@ -26,6 +26,25 @@ import org.joda.time.DateTimeZone;
 public class Event implements Serializable {
   private static final long serialVersionUID = 1L;
 
+  /**
+   * Event flags control how downstream transforms may handle an event, and are set during the
+   * parsing process.
+   *
+   * <p>All events default to FLAG_OK, and will be set otherwise under certain circumstances.
+   */
+  public enum EventFlag {
+    /** A normal event, can be considered to have no specific flag set */
+    FLAG_OK,
+    /** The event did not match the specified inline event filter */
+    FLAG_INLINE_FILTER_MISMATCH,
+    /** Parser fast matcher mismatch */
+    FLAG_FASTMATCH_MISMATCH,
+    /** Common input filter mismatch */
+    FLAG_COMMON_INPUT_FILTER_MISMATCH,
+    /** The event timestamp was older than is permitted by the parser configuration */
+    FLAG_TIMESTAMP_TOO_OLD
+  }
+
   private Payload<? extends PayloadBase> payload;
   private final UUID eventId;
   private DateTime timestamp;
@@ -33,6 +52,8 @@ public class Event implements Serializable {
   private Mozlog mozlog;
   private String stackdriverProject;
   private Map<String, String> stackdriverLabels;
+
+  private EventFlag eventFlag;
 
   /**
    * Create a new {@link Event} object.
@@ -45,6 +66,8 @@ public class Event implements Serializable {
 
     // Default the event timestamp to creation time
     timestamp = new DateTime(DateTimeZone.UTC);
+
+    eventFlag = EventFlag.FLAG_OK;
   }
 
   @Override
@@ -93,6 +116,24 @@ public class Event implements Serializable {
 
   private void setPayloadType(Payload.PayloadType value) {
     // Noop setter, required for event deserialization
+  }
+
+  /**
+   * Get event flag
+   *
+   * @return EventFlag
+   */
+  public EventFlag getEventFlag() {
+    return eventFlag;
+  }
+
+  /**
+   * Set event flag
+   *
+   * @param eventFlag EventFlag
+   */
+  public void setEventFlag(EventFlag eventFlag) {
+    this.eventFlag = eventFlag;
   }
 
   /**

--- a/src/main/java/com/mozilla/secops/parser/ParserCfg.java
+++ b/src/main/java/com/mozilla/secops/parser/ParserCfg.java
@@ -22,6 +22,7 @@ public class ParserCfg implements Serializable {
   private ArrayList<String> xffAddressSelectorSubnets;
   private String idmanagerPath;
   private Boolean useEventTimestamp;
+  private Integer maxTimestampDifference;
 
   private String stackdriverProjectFilter;
   private String[] stackdriverLabelFilters;
@@ -39,6 +40,7 @@ public class ParserCfg implements Serializable {
     cfg.setMaxmindIspDbPath(options.getMaxmindIspDbPath());
     cfg.setIdentityManagerPath(options.getIdentityManagerPath());
     cfg.setParserFastMatcher(options.getParserFastMatcher());
+    cfg.setMaximumAllowableTimestampDifference(options.getMaximumAllowableTimestampDifference());
     if (options.getXffAddressSelector() != null) {
       String parts[] = options.getXffAddressSelector().split(",");
       if (parts.length > 0) {
@@ -249,6 +251,30 @@ public class ParserCfg implements Serializable {
   @JsonProperty("stackdriver_project_filter")
   public void setStackdriverProjectFilter(String stackdriverProjectFilter) {
     this.stackdriverProjectFilter = stackdriverProjectFilter;
+  }
+
+  /**
+   * Get maximum allowable timestamp difference in seconds
+   *
+   * @return Integer or null if unset
+   */
+  public Integer getMaximumAllowableTimestampDifference() {
+    return maxTimestampDifference;
+  }
+
+  /**
+   * Set maximum allowable timestamp difference in seconds
+   *
+   * <p>By default, the event timestamp is not inspected by the parser. If this option is set, the
+   * parsed event timestamp will be compared to the current time. If the difference in seconds
+   * exceeds the specified value, the FLAG_TIMESTAMP_TOO_OLD event flag will be set on the parsed
+   * event.
+   *
+   * @param maxTimestampDifference Seconds
+   */
+  @JsonProperty("max_timestamp_difference")
+  void setMaximumAllowableTimestampDifference(Integer maxTimestampDifference) {
+    this.maxTimestampDifference = maxTimestampDifference;
   }
 
   /** Construct default parser configuration */

--- a/src/main/java/com/mozilla/secops/parser/ParserDoFn.java
+++ b/src/main/java/com/mozilla/secops/parser/ParserDoFn.java
@@ -79,15 +79,17 @@ public class ParserDoFn extends DoFn<String, Event> {
     Event e = ep.parse(c.element());
     if (e != null) {
       // If a common input filter has been configured, apply that first
-      if (commonInputFilter != null) {
+      if ((e.getEventFlag().equals(Event.EventFlag.FLAG_OK)) && (commonInputFilter != null)) {
         if (!(commonInputFilter.matches(e))) {
-          return;
+          e.setEventFlag(Event.EventFlag.FLAG_COMMON_INPUT_FILTER_MISMATCH);
         }
       }
 
-      if (inlineFilter != null) {
+      // If the event is still marked OK (the common input filter if set passed) and
+      // we have an inline filter, apply it
+      if ((e.getEventFlag().equals(Event.EventFlag.FLAG_OK)) && (inlineFilter != null)) {
         if (!(inlineFilter.matches(e))) {
-          return;
+          e.setEventFlag(Event.EventFlag.FLAG_INLINE_FILTER_MISMATCH);
         }
       }
       if ((cfg != null) && cfg.getUseEventTimestamp()) {

--- a/src/main/java/com/mozilla/secops/parser/ParserMultiDoFn.java
+++ b/src/main/java/com/mozilla/secops/parser/ParserMultiDoFn.java
@@ -102,15 +102,15 @@ public class ParserMultiDoFn extends DoFn<KV<String, String>, KV<String, Event>>
       return;
     }
 
-    if (common != null) {
+    if ((e.getEventFlag().equals(Event.EventFlag.FLAG_OK)) && (common != null)) {
       if (!(common.matches(e))) {
-        return;
+        e.setEventFlag(Event.EventFlag.FLAG_COMMON_INPUT_FILTER_MISMATCH);
       }
     }
 
-    if (inline != null) {
+    if ((e.getEventFlag().equals(Event.EventFlag.FLAG_OK)) && (inline != null)) {
       if (!(inline.matches(e))) {
-        return;
+        e.setEventFlag(Event.EventFlag.FLAG_INLINE_FILTER_MISMATCH);
       }
     }
 


### PR DESCRIPTION
Rather than silently dropping events that do not match filters, use a
tuple tag to group these events in a separate collection. In the current
implementation, the count of events that were not OK is simply logged in
the pipeline. This could be expanded to potentially write certain types
of failures out to GCS as an example.

This also adds a new flag to drop events that have a timestamp older
than the specified period in seconds.