### PR TITLE
include local tz in authprofile alerts

### DIFF
--- a/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
+++ b/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
@@ -47,6 +47,7 @@ import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionList;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -780,6 +781,12 @@ public class AuthProfile implements Serializable {
     } else {
       a.addMetadata("sourceaddress_country", "unknown");
     }
+    String tz = n.getSourceAddressTimeZone();
+    if (tz != null) {
+      a.addMetadata("sourceaddress_timezone", tz);
+    } else {
+      a.addMetadata("sourceaddress_timezone", "unknown");
+    }
 
     if (e.getNormalized().isOfType(Normalized.Type.AUTH)) {
       a.addMetadata("auth_alert_type", "auth");
@@ -790,6 +797,13 @@ public class AuthProfile implements Serializable {
     DateTime eventTimestamp = e.getTimestamp();
     if (eventTimestamp != null) {
       a.addMetadata("event_timestamp", eventTimestamp.toString());
+
+      if (tz != null) {
+        DateTimeZone dtz = DateTimeZone.forID(tz);
+        if (dtz != null) {
+          a.addMetadata("event_timestamp_source_local", eventTimestamp.withZone(dtz).toString());
+        }
+      }
     }
 
     return a;

--- a/src/main/java/com/mozilla/secops/parser/Normalized.java
+++ b/src/main/java/com/mozilla/secops/parser/Normalized.java
@@ -25,6 +25,7 @@ public class Normalized implements Serializable {
   private String sourceAddressCountry;
   private Double sourceAddressLatitude;
   private Double sourceAddressLongitude;
+  private String sourceAddressTimeZone;
   private String object;
   private String requestMethod;
   private String requestUrl;
@@ -213,6 +214,24 @@ public class Normalized implements Serializable {
    */
   public void setSourceAddressCountry(String sourceAddressCountry) {
     this.sourceAddressCountry = sourceAddressCountry;
+  }
+
+  /**
+   * Get source address time zone field
+   *
+   * @return Source address time zone, or null if not present
+   */
+  public String getSourceAddressTimeZone() {
+    return sourceAddressTimeZone;
+  }
+
+  /**
+   * Set source address time zone field
+   *
+   * @param sourceAddressTimeZone IANA time zone string, e.g., Europe/London
+   */
+  public void setSourceAddressTimeZone(String sourceAddressTimeZone) {
+    this.sourceAddressTimeZone = sourceAddressTimeZone;
   }
 
   /**

--- a/src/main/java/com/mozilla/secops/parser/SourcePayloadBase.java
+++ b/src/main/java/com/mozilla/secops/parser/SourcePayloadBase.java
@@ -17,6 +17,7 @@ public abstract class SourcePayloadBase extends PayloadBase implements Serializa
   private String sourceAddressCountry;
   private Double sourceAddressLatitude;
   private Double sourceAddressLongitude;
+  private String sourceTimeZone;
 
   /**
    * Set source address field
@@ -48,6 +49,10 @@ public abstract class SourcePayloadBase extends PayloadBase implements Serializa
             && (cr.getLocation().getLongitude() != null)) {
           sourceAddressLatitude = cr.getLocation().getLatitude();
           sourceAddressLongitude = cr.getLocation().getLongitude();
+
+          if (cr.getLocation().getTimeZone() != null) {
+            sourceTimeZone = cr.getLocation().getTimeZone();
+          }
         }
       }
     }
@@ -59,6 +64,7 @@ public abstract class SourcePayloadBase extends PayloadBase implements Serializa
       n.setSourceAddressCountry(sourceAddressCountry);
       n.setSourceAddressLatitude(sourceAddressLatitude);
       n.setSourceAddressLongitude(sourceAddressLongitude);
+      n.setSourceAddressTimeZone(sourceTimeZone);
     }
   }
 

--- a/src/main/resources/alert/templates/email/authprofile.ftlh
+++ b/src/main/resources/alert/templates/email/authprofile.ftlh
@@ -109,7 +109,7 @@
                       <td style="font-family: sans-serif; font-size: 14px; vertical-align: top;">
 
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
-                        We noticed a login for ${username} to ${object} at ${alert.timestamp?datetime.iso_m_nz}.
+                        We noticed a login for ${username} to ${object} at ${event_timestamp}.
                         </p>
 
                         <#if category == "state_analyze">
@@ -123,8 +123,14 @@
                         </#if>
 
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
-                        ${alert.timestamp?datetime.iso_m_nz} - ${sourceaddress} - ${sourceaddress_city}, ${sourceaddress_country}
+                        ${event_timestamp} - ${sourceaddress} - ${sourceaddress_city}, ${sourceaddress_country}
                         </p>
+
+                        <#if event_timestamp_source_local??>
+                        <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
+                        Timestamp for login based on source address time zone was ${event_timestamp_source_local}.
+                        </p>
+                        </#if>
 
                         <#if category == "state_analyze">
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">

--- a/src/test/java/com/mozilla/secops/authprofile/TestAuthProfile.java
+++ b/src/test/java/com/mozilla/secops/authprofile/TestAuthProfile.java
@@ -34,8 +34,6 @@ import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.joda.time.DateTime;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
@@ -54,8 +52,12 @@ public class TestAuthProfile {
       return null;
     }
 
-    DateTimeFormatter fmt = DateTimeFormat.forPattern("MMM d, yyyy h:mm:ss aa");
-    in = in.replaceAll("DATESTAMP", fmt.print(a.getTimestamp()));
+    in = in.replaceAll("DATESTAMP", a.getMetadataValue("event_timestamp"));
+
+    if (a.getMetadataValue("event_timestamp_source_local") != null) {
+      in = in.replaceAll("DATELOCALSTAMP", a.getMetadataValue("event_timestamp_source_local"));
+    }
+
     return in.replaceAll("ALERTID", a.getAlertId().toString());
   }
 
@@ -209,6 +211,9 @@ public class TestAuthProfile {
                   assertEquals("Milton", a.getMetadataValue("sourceaddress_city"));
                   assertEquals("US", a.getMetadataValue("sourceaddress_country"));
                   assertEquals("2018-09-18T22:15:38.000Z", a.getMetadataValue("event_timestamp"));
+                  assertEquals(
+                      "2018-09-18T15:15:38.000-07:00",
+                      a.getMetadataValue("event_timestamp_source_local"));
                 } else if (a.getMetadataValue("category").equals("cfgtick")) {
                   cfgTickCnt++;
                   assertEquals("authprofile-cfgtick", a.getCategory());

--- a/src/test/resources/testdata/templateoutput/authprof_critobj.html
+++ b/src/test/resources/testdata/templateoutput/authprof_critobj.html
@@ -119,6 +119,10 @@
                         </p>
 
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
+                        Timestamp for login based on source address time zone was DATELOCALSTAMP.
+                        </p>
+
+                        <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
                         These alerts are always generated when authentication activity is seen for objects configured as critical.
                         </p>
 

--- a/src/test/resources/testdata/templateoutput/authprof_state_known.html
+++ b/src/test/resources/testdata/templateoutput/authprof_state_known.html
@@ -119,6 +119,10 @@
                         </p>
 
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
+                        Timestamp for login based on source address time zone was DATELOCALSTAMP.
+                        </p>
+
+                        <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
                         <strong>If this was not you</strong>, please respond to this email and let the Firefox Operations Security team know this access should be investigated.
                         </p>
 

--- a/src/test/resources/testdata/templateoutput/authprof_state_new.html
+++ b/src/test/resources/testdata/templateoutput/authprof_state_new.html
@@ -119,6 +119,10 @@
                         </p>
 
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
+                        Timestamp for login based on source address time zone was DATELOCALSTAMP.
+                        </p>
+
+                        <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
                         <strong>If this was not you</strong>, please respond to this email and let the Firefox Operations Security team know this access should be investigated.
                         </p>
 


### PR DESCRIPTION
If possible, also include the timestamp associated with the
authentication event in local time (based on the time zone associated
with the source address), in addition to the UTC timestamp.

Closes #262 