### PR TITLE
improve handling of datastore errors

### DIFF
--- a/src/main/java/com/mozilla/secops/IprepdIO.java
+++ b/src/main/java/com/mozilla/secops/IprepdIO.java
@@ -622,6 +622,8 @@ public class IprepdIO {
    * <p>This variant allows specification of a project ID, for cases where the datastore instance
    * lives in another GCP project.
    *
+   * <p>If for some reason the whitelist state lookup fails, an {@link IOException} will be thrown.
+   *
    * @param obj Object to check (usually an IP or email)
    * @param type Type of object (usually "ip" or "email")
    * @param a Alert to add metadata to

--- a/src/main/java/com/mozilla/secops/customs/CustomsVelocity.java
+++ b/src/main/java/com/mozilla/secops/customs/CustomsVelocity.java
@@ -165,7 +165,15 @@ public class CustomsVelocity extends PTransform<PCollection<Event>, PCollection<
                       }
                       seenAddr.add(remoteAddress);
 
-                      StateCursor cur = state.newCursor();
+                      StateCursor cur;
+                      try {
+                        cur = state.newCursor();
+                      } catch (StateException exc) {
+                        // Experimental, so log this as info for now. This could be expanded to
+                        // error in the future.
+                        log.info("error initializing state cursor: {}", exc.getMessage());
+                        return;
+                      }
 
                       AuthStateModel sm = null;
                       try {
@@ -174,7 +182,9 @@ public class CustomsVelocity extends PTransform<PCollection<Event>, PCollection<
                           sm = new AuthStateModel(uid);
                         }
                       } catch (StateException exc) {
-                        log.error("error reading from state: {}", exc.getMessage());
+                        // Experimental, so log this as info for now. This could be expanded to
+                        // error in the future.
+                        log.info("error reading from state: {}", exc.getMessage());
                         return;
                       }
 
@@ -191,7 +201,7 @@ public class CustomsVelocity extends PTransform<PCollection<Event>, PCollection<
                         try {
                           sm.set(cur, new PruningStrategyLatest());
                         } catch (StateException exc) {
-                          log.error("error updating state: {}", exc.getMessage());
+                          log.info("error updating state: {}", exc.getMessage());
                           return;
                         }
                         continue;
@@ -253,7 +263,7 @@ public class CustomsVelocity extends PTransform<PCollection<Event>, PCollection<
                       try {
                         sm.set(cur, new PruningStrategyLatest());
                       } catch (StateException exc) {
-                        log.error("error updating state: {}", exc.getMessage());
+                        log.info("error updating state: {}", exc.getMessage());
                       }
                     }
                   }

--- a/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
+++ b/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
@@ -170,6 +170,8 @@ public class HTTPRequest implements Serializable {
     private final Boolean enableIprepdDatastoreWhitelist;
     private final String iprepdDatastoreWhitelistProject;
 
+    private Logger log;
+
     /**
      * Static initializer for {@link ErrorRateAnalysis}
      *
@@ -185,6 +187,7 @@ public class HTTPRequest implements Serializable {
       monitoredResource = toggles.getMonitoredResource();
       this.enableIprepdDatastoreWhitelist = enableIprepdDatastoreWhitelist;
       this.iprepdDatastoreWhitelistProject = iprepdDatastoreWhitelistProject;
+      log = LoggerFactory.getLogger(ErrorRateAnalysis.class);
     }
 
     public String getTransformDoc() {
@@ -244,6 +247,7 @@ public class HTTPRequest implements Serializable {
                           IprepdIO.addMetadataIfIpWhitelisted(
                               c.element().getKey(), a, iprepdDatastoreWhitelistProject);
                         } catch (IOException exc) {
+                          log.error("error checking whitelist: {}", exc.getMessage());
                           return;
                         }
                       }
@@ -360,6 +364,7 @@ public class HTTPRequest implements Serializable {
                                   c.element().getKey(), a, iprepdDatastoreWhitelistProject);
                             }
                           } catch (IOException exc) {
+                            log.error("error checking whitelist: {}", exc.getMessage());
                             return;
                           }
 
@@ -499,6 +504,7 @@ public class HTTPRequest implements Serializable {
                                   saddr, a, iprepdDatastoreWhitelistProject);
                             }
                           } catch (IOException exc) {
+                            log.error("error checking whitelist: {}", exc.getMessage());
                             return;
                           }
 
@@ -738,6 +744,7 @@ public class HTTPRequest implements Serializable {
                               remoteAddress, a, iprepdDatastoreWhitelistProject);
                         }
                       } catch (IOException exc) {
+                        log.error("error checking whitelist: {}", exc.getMessage());
                         return;
                       }
 
@@ -940,6 +947,7 @@ public class HTTPRequest implements Serializable {
                                     c.element().getKey(), a, iprepdDatastoreWhitelistProject);
                               }
                             } catch (IOException exc) {
+                              log.error("error checking whitelist: {}", exc.getMessage());
                               return;
                             }
 

--- a/src/main/java/com/mozilla/secops/state/DatastoreStateCursor.java
+++ b/src/main/java/com/mozilla/secops/state/DatastoreStateCursor.java
@@ -23,13 +23,17 @@ public class DatastoreStateCursor extends StateCursor {
     }
   }
 
-  public String getObject(String s) {
-    Key nk = keyFactory.newKey(s);
-    Entity e = tx.get(nk);
-    if (e == null) {
-      return null;
+  public String getObject(String s) throws StateException {
+    try {
+      Key nk = keyFactory.newKey(s);
+      Entity e = tx.get(nk);
+      if (e == null) {
+        return null;
+      }
+      return e.getString("state");
+    } catch (DatastoreException exc) {
+      throw new StateException(exc.getMessage());
     }
-    return e.getString("state");
   }
 
   public void saveObject(String s, String v) throws StateException {

--- a/src/main/java/com/mozilla/secops/state/DatastoreStateInterface.java
+++ b/src/main/java/com/mozilla/secops/state/DatastoreStateInterface.java
@@ -2,6 +2,7 @@ package com.mozilla.secops.state;
 
 import com.google.cloud.NoCredentials;
 import com.google.cloud.datastore.Datastore;
+import com.google.cloud.datastore.DatastoreException;
 import com.google.cloud.datastore.DatastoreOptions;
 import com.google.cloud.datastore.Entity;
 import com.google.cloud.datastore.KeyFactory;
@@ -17,8 +18,12 @@ public class DatastoreStateInterface implements StateInterface {
   private KeyFactory keyFactory;
   private String project;
 
-  public StateCursor newCursor() {
-    return new DatastoreStateCursor(datastore, namespace, kind);
+  public StateCursor newCursor() throws StateException {
+    try {
+      return new DatastoreStateCursor(datastore, namespace, kind);
+    } catch (DatastoreException exc) {
+      throw new StateException(exc.getMessage());
+    }
   }
 
   public void done() {}

--- a/src/main/java/com/mozilla/secops/state/MemcachedStateInterface.java
+++ b/src/main/java/com/mozilla/secops/state/MemcachedStateInterface.java
@@ -11,7 +11,7 @@ public class MemcachedStateInterface implements StateInterface {
   private final int memcachedPort;
   private MemcachedClient memclient;
 
-  public StateCursor newCursor() {
+  public StateCursor newCursor() throws StateException {
     return new MemcachedStateCursor(memclient);
   }
 

--- a/src/main/java/com/mozilla/secops/state/State.java
+++ b/src/main/java/com/mozilla/secops/state/State.java
@@ -56,7 +56,7 @@ public class State {
    *
    * @return {@link StateCursor}
    */
-  public StateCursor newCursor() {
+  public StateCursor newCursor() throws StateException {
     return si.newCursor();
   }
 

--- a/src/main/java/com/mozilla/secops/state/StateInterface.java
+++ b/src/main/java/com/mozilla/secops/state/StateInterface.java
@@ -12,5 +12,5 @@ public interface StateInterface {
   public void initialize() throws StateException;
 
   /** Allocate new state cursor */
-  public StateCursor newCursor();
+  public StateCursor newCursor() throws StateException;
 }


### PR DESCRIPTION
Some updates to improve how errors occurring due to an outage in
Datastore are handled.

In customs velocity analysis, instead of raising this exception and
causing the pipeline to halt, log this as an error condition and give up
on this particular analysis step.

In HTTPRequest, if a whitelist check fails log this as an error
condition and continue processing (but give up on this particular
analysis step).