### PR TITLE
Customs enhancements

### DIFF
--- a/src/main/java/com/mozilla/secops/customs/Customs.java
+++ b/src/main/java/com/mozilla/secops/customs/Customs.java
@@ -447,9 +447,11 @@ public class Customs implements Serializable {
   public static PCollection<Alert> executePipeline(
       Pipeline p, PCollection<String> input, CustomsOptions options) throws IOException {
     PCollection<Event> events =
-        input.apply(
-            "parse",
-            ParDo.of(new ParserDoFn().withConfiguration(ParserCfg.fromInputOptions(options))));
+        input
+            .apply(
+                "parse",
+                ParDo.of(new ParserDoFn().withConfiguration(ParserCfg.fromInputOptions(options))))
+            .apply("prefilter", new CustomsPreFilter());
 
     PCollectionList<Alert> resultsList = PCollectionList.empty(p);
     CollectionInfo ci = new CollectionInfo();

--- a/src/main/java/com/mozilla/secops/customs/Customs.java
+++ b/src/main/java/com/mozilla/secops/customs/Customs.java
@@ -15,6 +15,7 @@ import com.mozilla.secops.parser.ParserDoFn;
 import com.mozilla.secops.window.GlobalTriggers;
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.ArrayList;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.Description;
@@ -56,6 +57,26 @@ public class Customs implements Serializable {
     public PCollection<KV<String, Event>> sourceKey;
     public PCollection<KV<String, Event>> emailKey;
     public PCollection<KV<String, Event>> domainKey;
+  }
+
+  /**
+   * Return an array of EventSummary values that indicate which events should be stored during
+   * feature extraction
+   *
+   * <p>Any EventSummary values returned here will indicate that an event of that type should be
+   * stored during feature extraction. This is required if the underlying analysis transform needs
+   * to operate on the events themselves.
+   *
+   * @return ArrayList
+   */
+  public static ArrayList<FxaAuth.EventSummary> featureSummaryRegistration() {
+    ArrayList<FxaAuth.EventSummary> ret = new ArrayList<>();
+    ret.add(FxaAuth.EventSummary.ACCOUNT_CREATE_SUCCESS);
+    ret.add(FxaAuth.EventSummary.PASSWORD_FORGOT_SEND_CODE_SUCCESS);
+    ret.add(FxaAuth.EventSummary.PASSWORD_FORGOT_SEND_CODE_FAILURE);
+    ret.add(FxaAuth.EventSummary.LOGIN_FAILURE);
+    ret.add(FxaAuth.EventSummary.LOGIN_SUCCESS);
+    return ret;
   }
 
   /**

--- a/src/main/java/com/mozilla/secops/customs/Customs.java
+++ b/src/main/java/com/mozilla/secops/customs/Customs.java
@@ -26,6 +26,8 @@ import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.Flatten;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.windowing.AfterProcessingTime;
+import org.apache.beam.sdk.transforms.windowing.AfterWatermark;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
 import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.values.KV;
@@ -393,7 +395,14 @@ public class Customs implements Serializable {
           ci.sourceKey
               .apply(
                   "fixed ten source address",
-                  Window.<KV<String, Event>>into(FixedWindows.of(Duration.standardMinutes(10))))
+                  Window.<KV<String, Event>>into(FixedWindows.of(Duration.standardMinutes(10)))
+                      .triggering(
+                          AfterWatermark.pastEndOfWindow()
+                              .withEarlyFirings(
+                                  AfterProcessingTime.pastFirstElementInPane()
+                                      .plusDelayOf(Duration.standardSeconds(30))))
+                      .withAllowedLateness(Duration.ZERO)
+                      .accumulatingFiredPanes())
               .apply("fixed ten source address features", new CustomsFeaturesCombiner());
     }
     if (options.getEnableSourceLoginFailureDetector()) {
@@ -401,7 +410,14 @@ public class Customs implements Serializable {
           ci.emailKey
               .apply(
                   "fixed ten email",
-                  Window.<KV<String, Event>>into(FixedWindows.of(Duration.standardMinutes(10))))
+                  Window.<KV<String, Event>>into(FixedWindows.of(Duration.standardMinutes(10)))
+                      .triggering(
+                          AfterWatermark.pastEndOfWindow()
+                              .withEarlyFirings(
+                                  AfterProcessingTime.pastFirstElementInPane()
+                                      .plusDelayOf(Duration.standardSeconds(30))))
+                      .withAllowedLateness(Duration.ZERO)
+                      .accumulatingFiredPanes())
               .apply("fixed ten email features", new CustomsFeaturesCombiner());
     }
     if (options.getEnableAccountCreationAbuseDetector()) {
@@ -409,7 +425,14 @@ public class Customs implements Serializable {
           ci.domainKey
               .apply(
                   "fixed ten domain",
-                  Window.<KV<String, Event>>into(FixedWindows.of(Duration.standardMinutes(10))))
+                  Window.<KV<String, Event>>into(FixedWindows.of(Duration.standardMinutes(10)))
+                      .triggering(
+                          AfterWatermark.pastEndOfWindow()
+                              .withEarlyFirings(
+                                  AfterProcessingTime.pastFirstElementInPane()
+                                      .plusDelayOf(Duration.standardSeconds(30))))
+                      .withAllowedLateness(Duration.ZERO)
+                      .accumulatingFiredPanes())
               .apply("fixed ten domain features", new CustomsFeaturesCombiner());
     }
 

--- a/src/main/java/com/mozilla/secops/customs/CustomsAccountCreation.java
+++ b/src/main/java/com/mozilla/secops/customs/CustomsAccountCreation.java
@@ -13,6 +13,8 @@ import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Abusive account creation from a single source address
@@ -28,6 +30,8 @@ public class CustomsAccountCreation
   private final String monitoredResource;
   private final Integer accountAbuseSuppressRecovery;
   private final boolean escalate;
+
+  private final Logger log = LoggerFactory.getLogger(CustomsAccountCreation.class);
 
   /**
    * Create new CustomsAccountCreation
@@ -84,6 +88,10 @@ public class CustomsAccountCreation
                     }
 
                     if (cf.nominalVariance()) {
+                      log.info(
+                          "{}: skipping notification, variance index {}",
+                          remoteAddress,
+                          cf.getVarianceIndex());
                       return;
                     }
 

--- a/src/main/java/com/mozilla/secops/customs/CustomsFeatures.java
+++ b/src/main/java/com/mozilla/secops/customs/CustomsFeatures.java
@@ -130,8 +130,6 @@ public class CustomsFeatures implements Serializable {
       summarizedEventCounters.put(entry.getKey(), cur + entry.getValue());
     }
     unknownEventCounter += cf.getUnknownEventCounter();
-
-    recalculate();
   }
 
   /**

--- a/src/main/java/com/mozilla/secops/customs/CustomsFeatures.java
+++ b/src/main/java/com/mozilla/secops/customs/CustomsFeatures.java
@@ -15,11 +15,13 @@ public class CustomsFeatures implements Serializable {
   public static final int NOMINAL_VARIANCE_INDEX = 33;
 
   private ArrayList<Event> events;
+  private ArrayList<FxaAuth.EventSummary> collectEvents;
 
   private HashMap<String, Integer> sourceAddressEventCount;
   private HashMap<String, Integer> uniquePathRequestCount;
   private HashMap<String, Integer> uniquePathSuccessfulRequestCount;
 
+  private int totalEvents;
   private int totalLoginFailureCount;
   private int totalLoginSuccessCount;
   private int totalAccountCreateSuccess;
@@ -88,6 +90,7 @@ public class CustomsFeatures implements Serializable {
   public void merge(CustomsFeatures cf) {
     events.addAll(cf.getEvents());
 
+    totalEvents += cf.getTotalEvents();
     totalLoginFailureCount += cf.getTotalLoginFailureCount();
     totalLoginSuccessCount += cf.getTotalLoginSuccessCount();
     totalAccountCreateSuccess += cf.getTotalAccountCreateSuccess();
@@ -129,6 +132,18 @@ public class CustomsFeatures implements Serializable {
     unknownEventCounter += cf.getUnknownEventCounter();
 
     recalculate();
+  }
+
+  /**
+   * Get total event count
+   *
+   * <p>Return the total of all events in the collection, including those that could not be
+   * summarized or were not explicitly registered for raw event storage.
+   *
+   * @return int
+   */
+  public int getTotalEvents() {
+    return totalEvents;
   }
 
   /**
@@ -236,7 +251,7 @@ public class CustomsFeatures implements Serializable {
    * @param e Event
    */
   public void addEvent(Event e) {
-    events.add(e);
+    totalEvents++;
 
     FxaAuth.EventSummary s = CustomsUtil.authGetEventSummary(e);
     if (s != null) {
@@ -256,6 +271,11 @@ public class CustomsFeatures implements Serializable {
         case PASSWORD_FORGOT_SEND_CODE_FAILURE:
           totalPasswordForgotSendCodeFailure++;
           break;
+      }
+      // This is something we have a summary for, if it's registered for storage add it
+      // to the event collection.
+      if (collectEvents.contains(s)) {
+        events.add(e);
       }
 
       Integer cnt = summarizedEventCounters.containsKey(s) ? summarizedEventCounters.get(s) : 0;
@@ -324,6 +344,7 @@ public class CustomsFeatures implements Serializable {
 
   CustomsFeatures() {
     events = new ArrayList<Event>();
+    collectEvents = Customs.featureSummaryRegistration();
 
     // Default to 100 if not calculated
     varianceIndex = 100;
@@ -332,6 +353,7 @@ public class CustomsFeatures implements Serializable {
     uniquePathRequestCount = new HashMap<String, Integer>();
     uniquePathSuccessfulRequestCount = new HashMap<String, Integer>();
 
+    totalEvents = 0;
     totalLoginFailureCount = 0;
     totalLoginSuccessCount = 0;
     totalAccountCreateSuccess = 0;

--- a/src/main/java/com/mozilla/secops/customs/CustomsPasswordResetAbuse.java
+++ b/src/main/java/com/mozilla/secops/customs/CustomsPasswordResetAbuse.java
@@ -11,6 +11,8 @@ import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Abuse of FxA password reset endpoints from a single source address
@@ -25,6 +27,8 @@ public class CustomsPasswordResetAbuse
   private final String monitoredResource;
   private final Integer threshold;
   private boolean escalate;
+
+  private final Logger log = LoggerFactory.getLogger(CustomsAccountCreation.class);
 
   public String getTransformDocDescription() {
     return String.format(
@@ -84,6 +88,10 @@ public class CustomsPasswordResetAbuse
                     }
 
                     if (cf.nominalVariance()) {
+                      log.info(
+                          "{}: skipping notification, variance index {}",
+                          addr,
+                          cf.getVarianceIndex());
                       return;
                     }
 

--- a/src/main/java/com/mozilla/secops/customs/CustomsPreFilter.java
+++ b/src/main/java/com/mozilla/secops/customs/CustomsPreFilter.java
@@ -1,0 +1,53 @@
+package com.mozilla.secops.customs;
+
+import com.mozilla.secops.parser.Event;
+import com.mozilla.secops.parser.Payload;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.PCollection;
+
+/** Basic filtering of ingested events prior to analysis application */
+public class CustomsPreFilter extends PTransform<PCollection<Event>, PCollection<Event>> {
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * Paths that will be filtered from the input stream
+   *
+   * <p>Requests to these paths will be filtered early prior to passing the collection on. Shuffle
+   * operations downstream become too expensive with inclusion of these endpoints.
+   */
+  public static final String[] EXCLUDEPATHS = new String[] {"/v1/verify", "/v1/account/devices"};
+
+  @Override
+  public PCollection<Event> expand(PCollection<Event> col) {
+    return col.apply(
+        "prefilter",
+        ParDo.of(
+            new DoFn<Event, Event>() {
+              private static final long serialVersionUID = 1L;
+
+              @ProcessElement
+              public void processElement(ProcessContext c) {
+                Event e = c.element();
+
+                if (e.getPayloadType().equals(Payload.PayloadType.CFGTICK)) {
+                  c.output(e);
+                  return;
+                }
+
+                String path = CustomsUtil.authGetPath(e);
+                if (path == null) {
+                  return;
+                }
+                for (String i : EXCLUDEPATHS) {
+                  if (path.equals(i)) {
+                    return;
+                  }
+                }
+
+                c.output(e);
+              }
+            }));
+  }
+}

--- a/src/main/java/com/mozilla/secops/customs/SourceLoginFailure.java
+++ b/src/main/java/com/mozilla/secops/customs/SourceLoginFailure.java
@@ -11,6 +11,8 @@ import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Simple detection of excessive login failures per-source across fixed window
@@ -25,6 +27,8 @@ public class SourceLoginFailure
   private final String monitoredResource;
   private final Integer threshold;
   private final boolean escalate;
+
+  private final Logger log = LoggerFactory.getLogger(CustomsAccountCreation.class);
 
   /**
    * Initialize new SourceLoginFailure
@@ -82,6 +86,10 @@ public class SourceLoginFailure
                     }
 
                     if (cf.nominalVariance()) {
+                      log.info(
+                          "{}: skipping notification, variance index {}",
+                          addr,
+                          cf.getVarianceIndex());
                       return;
                     }
 

--- a/src/test/java/com/mozilla/secops/customs/TestCustoms.java
+++ b/src/test/java/com/mozilla/secops/customs/TestCustoms.java
@@ -88,10 +88,10 @@ public class TestCustoms {
         TestStream.create(StringUtf8Coder.of())
             .advanceWatermarkTo(new Instant(0L))
             .addElements(eb1[0], Arrays.copyOfRange(eb1, 1, eb1.length))
-            .advanceProcessingTime(Duration.standardSeconds(60))
+            .advanceProcessingTime(Duration.standardSeconds(5))
             // Add some unrelated elements for the second component
             .addElements(eb2[0], Arrays.copyOfRange(eb2, 1, eb2.length))
-            .advanceProcessingTime(Duration.standardSeconds(60))
+            .advanceProcessingTime(Duration.standardSeconds(5))
             .advanceWatermarkToInfinity();
 
     Customs.CustomsOptions options = getTestOptions();

--- a/src/test/java/com/mozilla/secops/customs/TestCustomsFeatures.java
+++ b/src/test/java/com/mozilla/secops/customs/TestCustomsFeatures.java
@@ -117,6 +117,7 @@ public class TestCustomsFeatures implements Serializable {
                 CustomsFeatures col = v.getValue();
                 if (v.getKey().equals("kirk@mozilla.com")) {
                   assertEquals(12, col.getEvents().size());
+                  assertEquals(12, col.getTotalEvents());
                   assertEquals(12, col.getTotalLoginFailureCount());
                   assertEquals(0, col.getTotalLoginSuccessCount());
                   assertEquals(10, col.getSourceAddressEventCount().size());
@@ -130,7 +131,8 @@ public class TestCustomsFeatures implements Serializable {
                   assertEquals(12, (int) col.getUniquePathRequestCount().get("/v1/account/login"));
                   assertEquals(0, col.getVarianceIndex());
                 } else if (v.getKey().equals("spock@mozilla.com")) {
-                  assertEquals(12, col.getEvents().size());
+                  assertEquals(10, col.getEvents().size());
+                  assertEquals(12, col.getTotalEvents());
                   assertEquals(10, col.getTotalLoginFailureCount());
                   assertEquals(0, col.getTotalLoginSuccessCount());
                   assertEquals(12, (int) col.getSourceAddressEventCount().get("216.160.83.56"));


### PR DESCRIPTION
A few changes as a follow up to #289.

* When storing a raw event list during feature extraction, only store events we need to look at, but keep counters for everything. This reduces collection size and the need to pass around data we will never look at.
* Add early pane firings for windowed collections so we get early results.
* Don't force recalculation during feature merge, and only calculate once results are extracted from the step
* Filter high volume "ping" events that greatly increase the cost of downstream shuffle steps.

Closes #290 