### PR TITLE
fixes for 0.6

### DIFF
--- a/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
+++ b/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
@@ -222,7 +222,8 @@ public class AuthProfile implements Serializable {
 
                         // Auto-ignore GCP audit records for accounts prefixed with
                         // system:serviceaccount:
-                        if (n.getSubjectUser().startsWith("system:serviceaccount:")) {
+                        if (n.getSubjectUser().startsWith("system:serviceaccount:")
+                            || n.getSubjectUser().startsWith("system:node:")) {
                           log.info(
                               "{}: ignoring GCP system service account entry", n.getSubjectUser());
                           return;

--- a/src/main/java/com/mozilla/secops/parser/FxaAuth.java
+++ b/src/main/java/com/mozilla/secops/parser/FxaAuth.java
@@ -1,9 +1,7 @@
 package com.mozilla.secops.parser;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.joda.JodaModule;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -110,18 +108,13 @@ public class FxaAuth extends SourcePayloadBase implements Serializable {
     return null;
   }
 
-  private ObjectMapper getObjectMapper() {
-    ObjectMapper mapper = new ObjectMapper();
-    mapper.registerModule(new JodaModule());
-    mapper.configure(
-        com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
-    mapper.configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true);
-    return mapper;
+  private ObjectMapper getObjectMapper(ParserState state) {
+    return state.getObjectMapper();
   }
 
   @Override
   public Boolean matcher(String input, ParserState state) {
-    ObjectMapper mapper = getObjectMapper();
+    ObjectMapper mapper = getObjectMapper(state);
     com.mozilla.secops.parser.models.fxaauth.FxaAuth d;
     try {
       d = mapper.readValue(input, com.mozilla.secops.parser.models.fxaauth.FxaAuth.class);
@@ -383,7 +376,7 @@ public class FxaAuth extends SourcePayloadBase implements Serializable {
    * @param state State
    */
   public FxaAuth(String input, Event e, ParserState state) {
-    ObjectMapper mapper = getObjectMapper();
+    ObjectMapper mapper = getObjectMapper(state);
     try {
       fxaAuthData = mapper.readValue(input, com.mozilla.secops.parser.models.fxaauth.FxaAuth.class);
       if (fxaAuthData == null) {

--- a/src/main/java/com/mozilla/secops/parser/Parser.java
+++ b/src/main/java/com/mozilla/secops/parser/Parser.java
@@ -387,6 +387,7 @@ public class Parser {
 
     ParserState state = new ParserState(this);
     state.setGoogleJacksonFactory(googleJacksonFactory);
+    state.setObjectMapper(mapper);
 
     if (input == null) {
       input = "";

--- a/src/main/java/com/mozilla/secops/parser/ParserState.java
+++ b/src/main/java/com/mozilla/secops/parser/ParserState.java
@@ -1,5 +1,6 @@
 package com.mozilla.secops.parser;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.services.logging.v2.model.LogEntry;
 import com.mozilla.secops.parser.models.cloudwatch.CloudWatchEvent;
 
@@ -10,6 +11,7 @@ class ParserState {
   private CloudWatchEvent cloudwatchEvent;
   private Mozlog mozLogHint;
   private com.google.api.client.json.jackson2.JacksonFactory googleJacksonFactory;
+  private ObjectMapper mapper;
 
   /**
    * Get LogEntry hint
@@ -82,6 +84,24 @@ class ParserState {
    */
   public com.google.api.client.json.jackson2.JacksonFactory getGoogleJacksonFactory() {
     return googleJacksonFactory;
+  }
+
+  /**
+   * Set ObjectMapper
+   *
+   * @param mapper ObjectMapper
+   */
+  public void setObjectMapper(ObjectMapper mapper) {
+    this.mapper = mapper;
+  }
+
+  /**
+   * Get ObjectMapper
+   *
+   * @return ObjectMapper, or null if unset
+   */
+  public ObjectMapper getObjectMapper() {
+    return mapper;
   }
 
   /**


### PR DESCRIPTION
* Ignore another high volume system user in `AuthProfile`
* Use `ObjectMapper` from `ParserState` to avoid reallocation for each event