### PR TITLE
additional details in AuthProfile templates

### DIFF
--- a/src/main/java/com/mozilla/secops/alert/Alert.java
+++ b/src/main/java/com/mozilla/secops/alert/Alert.java
@@ -217,6 +217,30 @@ public class Alert implements Serializable {
   }
 
   /**
+   * Change an existing metadata value
+   *
+   * <p>If the key does not exist, it will be added. Note that if multiple entries exist with the
+   * same key, this method will only change the first encountered.
+   *
+   * @param key Key to set
+   * @param value Value to set for key
+   */
+  public void setMetadataValue(String key, String value) {
+    metaLock.lock();
+    try {
+      for (AlertMeta m : metadata) {
+        if (m.getKey().equals(key)) {
+          m.setValue(value);
+          return;
+        }
+      }
+      metadata.add(new AlertMeta(key, value));
+    } finally {
+      metaLock.unlock();
+    }
+  }
+
+  /**
    * Get alert metadata
    *
    * @return Alert metadata

--- a/src/main/java/com/mozilla/secops/alert/AlertMeta.java
+++ b/src/main/java/com/mozilla/secops/alert/AlertMeta.java
@@ -22,11 +22,20 @@ public class AlertMeta implements Serializable {
   }
 
   /**
+   * Set metadata value
+   *
+   * @param value Value to set
+   */
+  @JsonProperty("value")
+  public void setValue(String value) {
+    this.value = value;
+  }
+
+  /**
    * Get metadata value
    *
    * @return Value string
    */
-  @JsonProperty("value")
   public String getValue() {
     return value;
   }

--- a/src/main/resources/alert/templates/slack/authprofile.ftlh
+++ b/src/main/resources/alert/templates/slack/authprofile.ftlh
@@ -1,0 +1,37 @@
+<#if auth_alert_type == "auth">
+An authentication event for user ${username} was detected to access ${object} from ${sourceaddress} [${sourceaddress_city}/${sourceaddress_country}].
+<#elseif auth_alert_type == "auth_session">
+A sensitive event within ${object} was performed by user ${username} from ${sourceaddress} [${sourceaddress_city}/${sourceaddress_country}].
+</#if>
+<#if event_timestamp??>
+
+This event occurred at ${event_timestamp}.
+</#if>
+<#if state_action_type??>
+<#if state_action_type == "unknown_ip_within_geo">
+
+The source address was new, however is near a previously known location so this message is informational.
+<#elseif state_action_type == "unknown_ip_outside_geo">
+
+The source address was new, and does not appear to be near any previously known location.
+<#elseif state_action_type == "unknown_ip_hosting_provider">
+
+The source address appears to be associated with a hosting provider.
+<#elseif state_action_type == "unknown_ip_anon_network">
+
+The source address appears to be associated with a known anonymity network.
+</#if>
+</#if>
+<#if alert_notification_type??>
+<#if alert_notification_type == "slack_confirmation">
+
+If you have any questions about this alert, please refer to our user guide: ${doc_link}
+<#elseif alert_notification_type == "slack_notification">
+
+If this was not you, or you have any questions about this alert, email us at ${email_contact} with the alert id.
+
+As well, you can refer to our user guide: ${doc_link}
+</#if>
+</#if>
+
+alert id: ${alert.alertId}

--- a/src/test/java/com/mozilla/secops/authprofile/TestCritObject.java
+++ b/src/test/java/com/mozilla/secops/authprofile/TestCritObject.java
@@ -29,6 +29,8 @@ public class TestCritObject {
     ret.setCritObjects(new String[] {"^projects/test$"});
     ret.setCriticalNotificationEmail("section31@mozilla.com");
     ret.setIgnoreUserRegex(new String[] {"^riker@mozilla.com$"});
+    ret.setContactEmail("test@localhost");
+    ret.setDocLink("https://localhost");
     return ret;
   }
 
@@ -83,7 +85,7 @@ public class TestCritObject {
                         tmgr.processTemplate(a.getEmailTemplate(), a.generateTemplateVariables());
                     assertEquals(
                         TestAuthProfile.renderTestTemplate(
-                            "/testdata/templateoutput/authprof_critobj.html", a),
+                            "/testdata/templateoutput/email/authprof_critobj.html", a),
                         templateOutput);
                   } catch (Exception exc) {
                     fail(exc.getMessage());

--- a/src/test/resources/testdata/templateoutput/email/authprof_critobj.html
+++ b/src/test/resources/testdata/templateoutput/email/authprof_critobj.html
@@ -109,57 +109,27 @@
                       <td style="font-family: sans-serif; font-size: 14px; vertical-align: top;">
 
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
-                        We noticed a login for ${username} to ${object} at ${event_timestamp}.
+                        We noticed a login for laforge@mozilla.com to projects/test at DATESTAMP.
                         </p>
 
-                        <#if category == "state_analyze">
-                        <#if state_action_type == "known_ip">
-                        <p>This occurred from a known source address.</p>
-                        <#else>
-                        <p>This occurred from a source address that was unknown to the system.
-                        <#if state_action_type == "unknown_ip_outside_geo">
-                        Additionally, the source address does not appear to be near any previously known location.
-                        <#elseif state_action_type == "unknown_ip_within_geo">
-                        However, the source address is near a previously known location so this message is informational.
-                        <#elseif state_action_type == "unknown_ip_hosting_provider">
-                        The source address also appears to be associated with a hosting provider.
-                        <#elseif state_action_type == "unknown_ip_anon_network">
-                        The source address also appears to be associated with a known anonymity network.
-                        </#if>
-                        </p>
-                        </#if>
-                        <#elseif category == "critical_object_analyze">
                         <p>This destination object is configured as a critical resource for which alerts are always generated.</p>
-                        </#if>
 
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
-                        ${event_timestamp} - ${sourceaddress} - ${sourceaddress_city}, ${sourceaddress_country}
-                        </p>
-
-                        <#if event_timestamp_source_local??>
-                        <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
-                        Timestamp for login based on source address time zone was ${event_timestamp_source_local}.
-                        </p>
-                        </#if>
-
-                        <#if category == "state_analyze">
-                        <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
-                        <strong>If this was not you</strong>, please respond to this email and let the Firefox Operations Security team know this access should be investigated.
+                        DATESTAMP - 216.160.83.56 - Milton, US
                         </p>
 
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
-                        These alerts are sent when a user logs into a monitored service from an “unknown IP”. The inactivity expiry for IPs is 10 days.
+                        Timestamp for login based on source address time zone was DATELOCALSTAMP.
                         </p>
-                        <#elseif category == "critical_object_analyze">
+
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
                         These alerts are always generated when authentication activity is seen for objects configured as critical.
                         </p>
-                        </#if>
 
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
                         If you have any questions about this notification, check out
-                        <a href="${doc_link}">our user guide for fraud alerts</a>
-                        or email us at ${email_contact}.
+                        <a href="https://localhost">our user guide for fraud alerts</a>
+                        or email us at test@localhost.
                         </p>
                       </td>
                     </tr>
@@ -175,7 +145,7 @@
               <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
                 <tr>
                   <td class="content-block" style="font-family: sans-serif; vertical-align: top; padding-bottom: 10px; padding-top: 10px; font-size: 12px; color: #999999; text-align: center;">
-                        alert id: ${alert.alertId}
+                        alert id: ALERTID
                   </td>
                 </tr>
               </table>

--- a/src/test/resources/testdata/templateoutput/email/authprof_state_known.html
+++ b/src/test/resources/testdata/templateoutput/email/authprof_state_known.html
@@ -109,40 +109,19 @@
                       <td style="font-family: sans-serif; font-size: 14px; vertical-align: top;">
 
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
-                        We noticed a login for ${username} to ${object} at ${event_timestamp}.
+                        We noticed a login for riker to emit-bastion at DATESTAMP.
                         </p>
 
-                        <#if category == "state_analyze">
-                        <#if state_action_type == "known_ip">
                         <p>This occurred from a known source address.</p>
-                        <#else>
-                        <p>This occurred from a source address that was unknown to the system.
-                        <#if state_action_type == "unknown_ip_outside_geo">
-                        Additionally, the source address does not appear to be near any previously known location.
-                        <#elseif state_action_type == "unknown_ip_within_geo">
-                        However, the source address is near a previously known location so this message is informational.
-                        <#elseif state_action_type == "unknown_ip_hosting_provider">
-                        The source address also appears to be associated with a hosting provider.
-                        <#elseif state_action_type == "unknown_ip_anon_network">
-                        The source address also appears to be associated with a known anonymity network.
-                        </#if>
-                        </p>
-                        </#if>
-                        <#elseif category == "critical_object_analyze">
-                        <p>This destination object is configured as a critical resource for which alerts are always generated.</p>
-                        </#if>
 
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
-                        ${event_timestamp} - ${sourceaddress} - ${sourceaddress_city}, ${sourceaddress_country}
+                        DATESTAMP - 216.160.83.56 - Milton, US
                         </p>
 
-                        <#if event_timestamp_source_local??>
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
-                        Timestamp for login based on source address time zone was ${event_timestamp_source_local}.
+                        Timestamp for login based on source address time zone was DATELOCALSTAMP.
                         </p>
-                        </#if>
 
-                        <#if category == "state_analyze">
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
                         <strong>If this was not you</strong>, please respond to this email and let the Firefox Operations Security team know this access should be investigated.
                         </p>
@@ -150,16 +129,11 @@
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
                         These alerts are sent when a user logs into a monitored service from an “unknown IP”. The inactivity expiry for IPs is 10 days.
                         </p>
-                        <#elseif category == "critical_object_analyze">
-                        <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
-                        These alerts are always generated when authentication activity is seen for objects configured as critical.
-                        </p>
-                        </#if>
 
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
                         If you have any questions about this notification, check out
-                        <a href="${doc_link}">our user guide for fraud alerts</a>
-                        or email us at ${email_contact}.
+                        <a href="https://localhost">our user guide for fraud alerts</a>
+                        or email us at test@localhost.
                         </p>
                       </td>
                     </tr>
@@ -175,7 +149,7 @@
               <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
                 <tr>
                   <td class="content-block" style="font-family: sans-serif; vertical-align: top; padding-bottom: 10px; padding-top: 10px; font-size: 12px; color: #999999; text-align: center;">
-                        alert id: ${alert.alertId}
+                        alert id: ALERTID
                   </td>
                 </tr>
               </table>

--- a/src/test/resources/testdata/templateoutput/email/authprof_state_new.html
+++ b/src/test/resources/testdata/templateoutput/email/authprof_state_new.html
@@ -109,40 +109,20 @@
                       <td style="font-family: sans-serif; font-size: 14px; vertical-align: top;">
 
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
-                        We noticed a login for ${username} to ${object} at ${event_timestamp}.
+                        We noticed a login for riker to emit-bastion at DATESTAMP.
                         </p>
 
-                        <#if category == "state_analyze">
-                        <#if state_action_type == "known_ip">
-                        <p>This occurred from a known source address.</p>
-                        <#else>
                         <p>This occurred from a source address that was unknown to the system.
-                        <#if state_action_type == "unknown_ip_outside_geo">
-                        Additionally, the source address does not appear to be near any previously known location.
-                        <#elseif state_action_type == "unknown_ip_within_geo">
-                        However, the source address is near a previously known location so this message is informational.
-                        <#elseif state_action_type == "unknown_ip_hosting_provider">
-                        The source address also appears to be associated with a hosting provider.
-                        <#elseif state_action_type == "unknown_ip_anon_network">
-                        The source address also appears to be associated with a known anonymity network.
-                        </#if>
                         </p>
-                        </#if>
-                        <#elseif category == "critical_object_analyze">
-                        <p>This destination object is configured as a critical resource for which alerts are always generated.</p>
-                        </#if>
 
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
-                        ${event_timestamp} - ${sourceaddress} - ${sourceaddress_city}, ${sourceaddress_country}
+                        DATESTAMP - 216.160.83.56 - Milton, US
                         </p>
 
-                        <#if event_timestamp_source_local??>
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
-                        Timestamp for login based on source address time zone was ${event_timestamp_source_local}.
+                        Timestamp for login based on source address time zone was DATELOCALSTAMP.
                         </p>
-                        </#if>
 
-                        <#if category == "state_analyze">
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
                         <strong>If this was not you</strong>, please respond to this email and let the Firefox Operations Security team know this access should be investigated.
                         </p>
@@ -150,16 +130,11 @@
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
                         These alerts are sent when a user logs into a monitored service from an “unknown IP”. The inactivity expiry for IPs is 10 days.
                         </p>
-                        <#elseif category == "critical_object_analyze">
-                        <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
-                        These alerts are always generated when authentication activity is seen for objects configured as critical.
-                        </p>
-                        </#if>
 
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
                         If you have any questions about this notification, check out
-                        <a href="${doc_link}">our user guide for fraud alerts</a>
-                        or email us at ${email_contact}.
+                        <a href="https://localhost">our user guide for fraud alerts</a>
+                        or email us at test@localhost.
                         </p>
                       </td>
                     </tr>
@@ -175,7 +150,7 @@
               <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
                 <tr>
                   <td class="content-block" style="font-family: sans-serif; vertical-align: top; padding-bottom: 10px; padding-top: 10px; font-size: 12px; color: #999999; text-align: center;">
-                        alert id: ${alert.alertId}
+                        alert id: ALERTID
                   </td>
                 </tr>
               </table>

--- a/src/test/resources/testdata/templateoutput/email/authprof_state_new_anon.html
+++ b/src/test/resources/testdata/templateoutput/email/authprof_state_new_anon.html
@@ -112,7 +112,9 @@
                         We noticed a login for riker to emit-bastion at DATESTAMP.
                         </p>
 
-			<p>This occurred from a source address that was unknown to the system.</p>
+                        <p>This occurred from a source address that was unknown to the system.
+                        The source address also appears to be associated with a known anonymity network.
+                        </p>
 
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
                         DATESTAMP - 216.160.83.56 - Milton, US
@@ -131,7 +133,9 @@
                         </p>
 
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
-                        If you have any questions about this notification, email us at secops@mozilla.com.
+                        If you have any questions about this notification, check out
+                        <a href="https://localhost">our user guide for fraud alerts</a>
+                        or email us at test@localhost.
                         </p>
                       </td>
                     </tr>

--- a/src/test/resources/testdata/templateoutput/email/authprof_state_new_hosting.html
+++ b/src/test/resources/testdata/templateoutput/email/authprof_state_new_hosting.html
@@ -109,40 +109,21 @@
                       <td style="font-family: sans-serif; font-size: 14px; vertical-align: top;">
 
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
-                        We noticed a login for ${username} to ${object} at ${event_timestamp}.
+                        We noticed a login for riker to emit-bastion at DATESTAMP.
                         </p>
 
-                        <#if category == "state_analyze">
-                        <#if state_action_type == "known_ip">
-                        <p>This occurred from a known source address.</p>
-                        <#else>
                         <p>This occurred from a source address that was unknown to the system.
-                        <#if state_action_type == "unknown_ip_outside_geo">
-                        Additionally, the source address does not appear to be near any previously known location.
-                        <#elseif state_action_type == "unknown_ip_within_geo">
-                        However, the source address is near a previously known location so this message is informational.
-                        <#elseif state_action_type == "unknown_ip_hosting_provider">
                         The source address also appears to be associated with a hosting provider.
-                        <#elseif state_action_type == "unknown_ip_anon_network">
-                        The source address also appears to be associated with a known anonymity network.
-                        </#if>
                         </p>
-                        </#if>
-                        <#elseif category == "critical_object_analyze">
-                        <p>This destination object is configured as a critical resource for which alerts are always generated.</p>
-                        </#if>
 
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
-                        ${event_timestamp} - ${sourceaddress} - ${sourceaddress_city}, ${sourceaddress_country}
+                        DATESTAMP - 216.160.83.56 - Milton, US
                         </p>
 
-                        <#if event_timestamp_source_local??>
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
-                        Timestamp for login based on source address time zone was ${event_timestamp_source_local}.
+                        Timestamp for login based on source address time zone was DATELOCALSTAMP.
                         </p>
-                        </#if>
 
-                        <#if category == "state_analyze">
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
                         <strong>If this was not you</strong>, please respond to this email and let the Firefox Operations Security team know this access should be investigated.
                         </p>
@@ -150,16 +131,11 @@
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
                         These alerts are sent when a user logs into a monitored service from an “unknown IP”. The inactivity expiry for IPs is 10 days.
                         </p>
-                        <#elseif category == "critical_object_analyze">
-                        <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
-                        These alerts are always generated when authentication activity is seen for objects configured as critical.
-                        </p>
-                        </#if>
 
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
                         If you have any questions about this notification, check out
-                        <a href="${doc_link}">our user guide for fraud alerts</a>
-                        or email us at ${email_contact}.
+                        <a href="https://localhost">our user guide for fraud alerts</a>
+                        or email us at test@localhost.
                         </p>
                       </td>
                     </tr>
@@ -175,7 +151,7 @@
               <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
                 <tr>
                   <td class="content-block" style="font-family: sans-serif; vertical-align: top; padding-bottom: 10px; padding-top: 10px; font-size: 12px; color: #999999; text-align: center;">
-                        alert id: ${alert.alertId}
+                        alert id: ALERTID
                   </td>
                 </tr>
               </table>

--- a/src/test/resources/testdata/templateoutput/email/authprof_state_new_outside_geo.html
+++ b/src/test/resources/testdata/templateoutput/email/authprof_state_new_outside_geo.html
@@ -109,10 +109,12 @@
                       <td style="font-family: sans-serif; font-size: 14px; vertical-align: top;">
 
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
-                        We noticed a login for laforge@mozilla.com to projects/test at DATESTAMP.
+                        We noticed a login for riker to emit-bastion at DATESTAMP.
                         </p>
 
-                        <p>This destination object is configured as a critical resource for which alerts are always generated.</p>
+                        <p>This occurred from a source address that was unknown to the system.
+                        Additionally, the source address does not appear to be near any previously known location.
+                        </p>
 
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
                         DATESTAMP - 216.160.83.56 - Milton, US
@@ -123,11 +125,17 @@
                         </p>
 
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
-                        These alerts are always generated when authentication activity is seen for objects configured as critical.
+                        <strong>If this was not you</strong>, please respond to this email and let the Firefox Operations Security team know this access should be investigated.
                         </p>
 
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
-                        If you have any questions about this notification, email us at secops@mozilla.com.
+                        These alerts are sent when a user logs into a monitored service from an “unknown IP”. The inactivity expiry for IPs is 10 days.
+                        </p>
+
+                        <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
+                        If you have any questions about this notification, check out
+                        <a href="https://localhost">our user guide for fraud alerts</a>
+                        or email us at test@localhost.
                         </p>
                       </td>
                     </tr>

--- a/src/test/resources/testdata/templateoutput/email/authprof_state_new_within_geo.html
+++ b/src/test/resources/testdata/templateoutput/email/authprof_state_new_within_geo.html
@@ -112,7 +112,9 @@
                         We noticed a login for riker to emit-bastion at DATESTAMP.
                         </p>
 
-			<p>This occurred from a known source address.</p>
+                        <p>This occurred from a source address that was unknown to the system.
+                        However, the source address is near a previously known location so this message is informational.
+                        </p>
 
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
                         DATESTAMP - 216.160.83.56 - Milton, US
@@ -131,7 +133,9 @@
                         </p>
 
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">
-                        If you have any questions about this notification, email us at secops@mozilla.com.
+                        If you have any questions about this notification, check out
+                        <a href="https://localhost">our user guide for fraud alerts</a>
+                        or email us at test@localhost.
                         </p>
                       </td>
                     </tr>

--- a/src/test/resources/testdata/templateoutput/slack/authprof_state_new.txt
+++ b/src/test/resources/testdata/templateoutput/slack/authprof_state_new.txt
@@ -1,0 +1,7 @@
+An authentication event for user riker was detected to access emit-bastion from 216.160.83.56 [Milton/US].
+
+This event occurred at DATESTAMP.
+
+If you have any questions about this alert, please refer to our user guide: https://localhost
+
+alert id: ALERTID

--- a/src/test/resources/testdata/templateoutput/slack/authprof_state_new_anon.txt
+++ b/src/test/resources/testdata/templateoutput/slack/authprof_state_new_anon.txt
@@ -1,0 +1,9 @@
+An authentication event for user riker was detected to access emit-bastion from 216.160.83.56 [Milton/US].
+
+This event occurred at DATESTAMP.
+
+The source address appears to be associated with a known anonymity network.
+
+If you have any questions about this alert, please refer to our user guide: https://localhost
+
+alert id: ALERTID

--- a/src/test/resources/testdata/templateoutput/slack/authprof_state_new_hosting.txt
+++ b/src/test/resources/testdata/templateoutput/slack/authprof_state_new_hosting.txt
@@ -1,0 +1,9 @@
+An authentication event for user riker was detected to access emit-bastion from 216.160.83.56 [Milton/US].
+
+This event occurred at DATESTAMP.
+
+The source address appears to be associated with a hosting provider.
+
+If you have any questions about this alert, please refer to our user guide: https://localhost
+
+alert id: ALERTID

--- a/src/test/resources/testdata/templateoutput/slack/authprof_state_new_outside_geo.txt
+++ b/src/test/resources/testdata/templateoutput/slack/authprof_state_new_outside_geo.txt
@@ -1,0 +1,9 @@
+An authentication event for user riker was detected to access emit-bastion from 216.160.83.56 [Milton/US].
+
+This event occurred at DATESTAMP.
+
+The source address was new, and does not appear to be near any previously known location.
+
+If you have any questions about this alert, please refer to our user guide: https://localhost
+
+alert id: ALERTID

--- a/src/test/resources/testdata/templateoutput/slack/authprof_state_new_within_geo.txt
+++ b/src/test/resources/testdata/templateoutput/slack/authprof_state_new_within_geo.txt
@@ -1,0 +1,11 @@
+An authentication event for user riker was detected to access emit-bastion from 216.160.83.56 [Milton/US].
+
+This event occurred at DATESTAMP.
+
+The source address was new, however is near a previously known location so this message is informational.
+
+If this was not you, or you have any questions about this alert, email us at test@localhost with the alert id.
+
+As well, you can refer to our user guide: https://localhost
+
+alert id: ALERTID


### PR DESCRIPTION
Include additional details in rendered alert templates on the specifics
associated with the alert.

This also adds the Slack template and applicable tests.