### PR TITLE
fake jdk package installation

### DIFF
--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -9,7 +9,16 @@
 
 FROM maven:3-jdk-8
 
-RUN export CLOUD_SDK_REPO="cloud-sdk-stretch" && \
+RUN apt-get update -y && \
+    apt-get install -y lsb-release equivs
+
+# The image already contains a JDK, so we don't want to install another one.
+# Install a fake openjdk-8-jdk to satisfy the required dependencies of the
+# gcloud emulator packages we need.
+COPY docker/openjdk-8-jdk /root/openjdk-8-jdk
+RUN (cd /root && equivs-build openjdk-8-jdk && dpkg -i openjdk-8-jdk*deb)
+
+RUN export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
     echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
     apt-get update -y && apt-get install google-cloud-sdk -y

--- a/docker/openjdk-8-jdk
+++ b/docker/openjdk-8-jdk
@@ -1,0 +1,30 @@
+### Commented entries have reasonable defaults.
+### Uncomment to edit them.
+# Source: <source package name; defaults to package name>
+Section: misc
+Priority: optional
+# Homepage: <enter URL here; no default>
+Standards-Version: 3.9.2
+
+Package: openjdk-8-jdk
+# Version: <enter version here; defaults to 1.0>
+# Maintainer: Your Name <yourname@example.com>
+# Pre-Depends: <comma-separated list of packages>
+# Depends: <comma-separated list of packages>
+# Recommends: <comma-separated list of packages>
+# Suggests: <comma-separated list of packages>
+# Provides: <comma-separated list of packages>
+# Replaces: <comma-separated list of packages>
+# Architecture: all
+# Multi-Arch: <one of: foreign|same|allowed>
+# Copyright: <copyright file; defaults to GPL2>
+# Changelog: <changelog file; defaults to a generic changelog>
+# Readme: <README.Debian file; defaults to a generic one>
+# Extra-Files: <comma-separated list of additional files for the doc directory>
+# Links: <pair of space-separated paths; First is path symlink points at, second is filename of link>
+# Files: <pair of space-separated paths; First is file to include, second is destination>
+#  <more pairs, if there's more than one file to include. Notice the starting space>
+Description: <short description; defaults to some wise words>
+ long description and info
+ .
+ second paragraph


### PR DESCRIPTION
Install a mock openjdk-8-jdk package to satisfy dependency requirements
within the cloudsdk emulators. Without this, installing the emulators
will fail (and subsequently the image build fails).

I'm not sure why this just started happening but assuming its a change
made in the emulator dependency list.