### PR TITLE
Fix slack http + improve build

### DIFF
--- a/Dockerfile-complete
+++ b/Dockerfile-complete
@@ -11,11 +11,11 @@ RUN mvn compile
 RUN cd contrib && GO111MODULE=on GOPROXY=https://proxy.golang.org \
 	/usr/local/go/bin/go get ./... && \
 	/usr/local/go/bin/go mod vendor && \
-	(cd auth0pull && /usr/local/go/bin/go mod vendor) && \
-	(cd cloudtrail-streamer && /usr/local/go/bin/go mod vendor) && \
-	(cd duopull && /usr/local/go/bin/go mod vendor) && \
-	(cd slackbot-background && /usr/local/go/bin/go mod vendor) && \
-	(cd slackbot-http && /usr/local/go/bin/go mod vendor)
+	(cd auth0pull && /usr/local/go/bin/go mod vendor && /usr/local/go/bin/go build) && \
+	(cd cloudtrail-streamer && /usr/local/go/bin/go mod vendor && /usr/local/go/bin/go build) && \
+	(cd duopull && /usr/local/go/bin/go mod vendor && /usr/local/go/bin/go build) && \
+	(cd slackbot-background && /usr/local/go/bin/go mod vendor && /usr/local/go/bin/go build) && \
+	(cd slackbot-http && /usr/local/go/bin/go mod vendor && /usr/local/go/bin/go build)
 RUN mkdir -p /app && cp version.json /app/version.json
 
 ENV FOXSEC_PIPELINE_IMAGE complete

--- a/bin/run_contrib_tests.sh
+++ b/bin/run_contrib_tests.sh
@@ -11,5 +11,8 @@ export PATH
 
 cd /root/project/contrib
 go test -v ./...
+(cd auth0pull && go test -v)
+(cd cloudtrail-streamer && go test -v)
 (cd duopull && go test -v)
 (cd slackbot-background && go test -v)
+(cd slackbot-http && go test -v)

--- a/contrib/slackbot-http/http.go
+++ b/contrib/slackbot-http/http.go
@@ -129,7 +129,7 @@ func SlackbotHTTP(w http.ResponseWriter, r *http.Request) {
 		data = &common.TriggerData{
 			Action: common.Interaction,
 			Interaction: common.InteractionData{
-				ActionName:  callback.Actions[0].Name,
+				ActionName:  callback.ActionCallback.AttachmentActions[0].Name,
 				CallbackID:  callback.CallbackID,
 				ResponseURL: callback.ResponseURL,
 			},


### PR DESCRIPTION
1. This fixes an error in slack http because of a change to a dependency.
2. Adds all modules to the test script because I believe one day we will have tests. (No test files should not cause a build to fail)
3. Adds building to the docker file as a sanity test for compile errors.