### PR TITLE
Upgrade jslack to get new version of okhttp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -244,7 +244,7 @@
         <dependency>
             <groupId>com.github.seratch</groupId>
             <artifactId>jslack</artifactId>
-            <version>1.1.6</version>
+            <version>1.8.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>


### PR DESCRIPTION
Need okhttp version 3.13 or higher so that it won't try and use TLS 1.0
or 1.1 with slack:
https://api.slack.com/changelog/2019-07-deprecate-early-tls-versions