### PR TITLE
go build updates

### DIFF
--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -17,15 +17,14 @@ RUN apt-get update -y && \
 	apt-get upgrade -y && \
 	apt-get install netcat redis-server build-essential \
 	memcached --no-install-recommends -y && \
-	curl -L https://dl.google.com/go/go1.13.7.linux-amd64.tar.gz | \
+	curl -L https://dl.google.com/go/go1.14.linux-amd64.tar.gz | \
 	(cd /usr/local && tar -zxf -) && \
 	curl -sSL https://sdk.cloud.google.com | \
 	CLOUDSDK_CORE_DISABLE_PROMPTS=1 bash && \
 	gcloud config set project foxsec-pipeline && \
 	CLOUDSDK_CORE_DISABLE_PROMPTS=1 gcloud components install cloud-datastore-emulator \
 	pubsub-emulator beta && \
-	go get go.mozilla.org/iprepd && \
-	go install go.mozilla.org/iprepd/cmd/iprepd && \
+	GO111MODULE=on go get go.mozilla.org/iprepd/cmd/iprepd && \
 	mkdir -p /etc/iprepd
 
 COPY docker/iprepd.yaml /etc/iprepd/iprepd.yaml

--- a/Dockerfile-complete
+++ b/Dockerfile-complete
@@ -16,9 +16,7 @@ COPY contrib/slackbot-background/go.* /root/project/contrib/slackbot-background/
 COPY contrib/slackbot-http/go.* /root/project/contrib/slackbot-http/
 COPY pom.xml /root/project/pom.xml
 RUN mvn -B dependency:resolve dependency:resolve-plugins dependency:go-offline && \
-	cd contrib && GO111MODULE=on GOPROXY=https://proxy.golang.org \
-	go get ./... && \
-	go mod download && \
+	cd contrib && go mod download && \
 	(cd auth0pull && go mod download) && \
 	(cd cloudtrail-streamer && go mod download) && \
 	(cd duopull && go mod download) && \


### PR DESCRIPTION
- Use go 1.14
- Set GO111MODULE for iprepd
- Remove some of the commands used in fetching contrib dependencies that
  are not required.