### PR TITLE
ignore unknown properties in AwsCidrPrefixEntry

### DIFF
--- a/src/main/java/com/mozilla/secops/CidrUtil.java
+++ b/src/main/java/com/mozilla/secops/CidrUtil.java
@@ -255,6 +255,7 @@ public class CidrUtil {
     add("::1/128");
   }
 
+  @JsonIgnoreProperties(ignoreUnknown = true)
   private static class AwsCidrPrefixEntry {
     String ip4Prefix;
     String ip6Prefix;


### PR DESCRIPTION
A `network_border_group` field was recently added to the AWS CIDR response

Just ignore unknown fields we don't need here.