### PR TITLE
Check for missing javadocs using checkstyle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,9 @@ jobs:
           name: Spotless check
           command: bin/m spotless:check
       - run:
+          name: Javadoc (checkstyle) check
+          command: bin/m checkstyle:check
+      - run:
           name: Generate version.json
           command: bin/write_version_json.sh
       - run:

--- a/checkstyle/checkstyle-suppressions.xml
+++ b/checkstyle/checkstyle-suppressions.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+     "-//Checkstyle//DTD SuppressionFilter Configuration 1.0//EN"
+     "https://checkstyle.org/dtds/suppressions_1_0.dtd">
+
+<suppressions>
+  <suppress checks="InvalidJavadocPosition"
+             files="KinesisIO.java" />
+  <suppress checks="MissingJavadocMethod"
+             files="KinesisRecord.java" />
+  <suppress checks="JavadocParagraph"
+             files="ShardCheckpoint.java" />
+  <suppress checks="MissingJavadocMethod"
+             files="MemcachedStateInterface.java" />
+  <suppress checks="MissingJavadocMethod"
+             files="DatastoreStateInterface.java" />
+  <suppress checks="MissingJavadocMethod"
+             files="UserIdentity.java" />
+  <suppress checks="MissingJavadocMethod"
+             files="CloudtrailEvent.java" />
+</suppressions>

--- a/checkstyle/checkstyle-suppressions.xml
+++ b/checkstyle/checkstyle-suppressions.xml
@@ -7,14 +7,12 @@
 <suppressions>
   <suppress checks="InvalidJavadocPosition"
              files="KinesisIO.java" />
+  <suppress checks="JavadocMethod"
+             files="KinesisIO.java" />
   <suppress checks="MissingJavadocMethod"
              files="KinesisRecord.java" />
   <suppress checks="JavadocParagraph"
              files="ShardCheckpoint.java" />
-  <suppress checks="MissingJavadocMethod"
-             files="MemcachedStateInterface.java" />
-  <suppress checks="MissingJavadocMethod"
-             files="DatastoreStateInterface.java" />
   <suppress checks="MissingJavadocMethod"
              files="UserIdentity.java" />
   <suppress checks="MissingJavadocMethod"

--- a/checkstyle/foxsec_checks.xml
+++ b/checkstyle/foxsec_checks.xml
@@ -36,8 +36,8 @@
         <module name="JavadocParagraph"/>
         <module name="JavadocMethod">
             <property name="scope" value="public"/>
-            <property name="allowMissingParamTags" value="true"/>
-            <property name="allowMissingReturnTag" value="true"/>
+            <property name="allowMissingParamTags" value="false"/>
+            <property name="allowMissingReturnTag" value="false"/>
             <property name="allowedAnnotations" value="Override, Test, Setup, Teardown, ProcessElement, OnTimer, OnStale"/>
             <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF"/>
         </module>

--- a/checkstyle/foxsec_checks.xml
+++ b/checkstyle/foxsec_checks.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<!--
+    Checkstyle configuration specific to the foxsec-pipeline. This is lacking as we rely
+    heavily on spotless for the majority of linting.
+
+    Checkstyle is very configurable. Be sure to read the documentation at
+    http://checkstyle.org (or in your downloaded distribution).
+
+    To completely disable a check, just comment it out or delete it from the file.
+    To suppress certain violations please review suppression filters.
+ -->
+
+<module name = "Checker">
+    <property name="charset" value="UTF-8"/>
+
+    <property name="fileExtensions" value="java, properties, xml"/>
+    <!-- Excludes all 'module-info.java' files              -->
+    <!-- See https://checkstyle.org/config_filefilters.html -->
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value="module\-info\.java$"/>
+    </module>
+    <!-- https://checkstyle.org/config_filters.html#SuppressionFilter -->
+    <module name="SuppressionFilter">
+        <property name="file" value="${org.checkstyle.google.suppressionfilter.config}"
+                default="checkstyle/checkstyle-suppressions.xml" />
+        <property name="optional" value="true"/>
+    </module>
+
+    <module name="TreeWalker">
+        <module name="InvalidJavadocPosition"/>
+        <module name="JavadocTagContinuationIndentation"/>
+        <module name="JavadocParagraph"/>
+        <module name="JavadocMethod">
+            <property name="scope" value="public"/>
+            <property name="allowMissingParamTags" value="true"/>
+            <property name="allowMissingReturnTag" value="true"/>
+            <property name="allowedAnnotations" value="Override, Test, Setup, Teardown, ProcessElement, OnTimer, OnStale"/>
+            <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF"/>
+        </module>
+        <module name="MissingJavadocMethod">
+            <property name="scope" value="public"/>
+            <property name="minLineCount" value="2"/>
+            <property name="allowedAnnotations" value="Override, Test, Setup, Teardown, ProcessElement, OnTimer, OnStale"/>
+            <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF"/>
+        </module>
+    </module>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,15 @@
                     </java>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.1.1</version>
+                <configuration>
+                    <logViolationsToConsole>true</logViolationsToConsole>
+                    <configLocation>checkstyle/foxsec_checks.xml</configLocation>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/src/main/java/com/mozilla/secops/SourceCorrelation.java
+++ b/src/main/java/com/mozilla/secops/SourceCorrelation.java
@@ -218,6 +218,7 @@ public class SourceCorrelation {
       this.monitoredResource = toggles.getMonitoredResource();
     }
 
+    /** Transform documentation for users - see {@link DocumentingTransform} */
     public String getTransformDoc() {
       return String.format(
           "Source address alerting correlation, ISP analysis on minimum %d "

--- a/src/main/java/com/mozilla/secops/SourceCorrelation.java
+++ b/src/main/java/com/mozilla/secops/SourceCorrelation.java
@@ -218,7 +218,7 @@ public class SourceCorrelation {
       this.monitoredResource = toggles.getMonitoredResource();
     }
 
-    /** Transform documentation for users - see {@link DocumentingTransform} */
+    /** {@inheritDoc} */
     public String getTransformDoc() {
       return String.format(
           "Source address alerting correlation, ISP analysis on minimum %d "

--- a/src/main/java/com/mozilla/secops/amo/AddonMatcher.java
+++ b/src/main/java/com/mozilla/secops/amo/AddonMatcher.java
@@ -45,7 +45,7 @@ public class AddonMatcher extends PTransform<PCollection<Event>, PCollection<Ale
     this.matchCriteria = matchCriteria;
   }
 
-  /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
+  /** {@inheritDoc} */
   public String getTransformDoc() {
     return String.format(
         "Match abusive addon uploads using these patterns %s and generate alerts",

--- a/src/main/java/com/mozilla/secops/amo/AddonMatcher.java
+++ b/src/main/java/com/mozilla/secops/amo/AddonMatcher.java
@@ -45,6 +45,7 @@ public class AddonMatcher extends PTransform<PCollection<Event>, PCollection<Ale
     this.matchCriteria = matchCriteria;
   }
 
+  /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
   public String getTransformDoc() {
     return String.format(
         "Match abusive addon uploads using these patterns %s and generate alerts",

--- a/src/main/java/com/mozilla/secops/amo/AddonMultiIpLogin.java
+++ b/src/main/java/com/mozilla/secops/amo/AddonMultiIpLogin.java
@@ -69,7 +69,7 @@ public class AddonMultiIpLogin extends PTransform<PCollection<Event>, PCollectio
     this.aggMatchers = aggMatchers;
   }
 
-  /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
+  /** {@inheritDoc} */
   public String getTransformDoc() {
     return String.format(
         "Detect multiple account logins for the same account from different source addresses associated with different country codes. Alert on %s different countries and %s different IPs. Regex for account exceptions: %s",

--- a/src/main/java/com/mozilla/secops/amo/AddonMultiIpLogin.java
+++ b/src/main/java/com/mozilla/secops/amo/AddonMultiIpLogin.java
@@ -69,6 +69,7 @@ public class AddonMultiIpLogin extends PTransform<PCollection<Event>, PCollectio
     this.aggMatchers = aggMatchers;
   }
 
+  /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
   public String getTransformDoc() {
     return String.format(
         "Detect multiple account logins for the same account from different source addresses associated with different country codes. Alert on %s different countries and %s different IPs. Regex for account exceptions: %s",

--- a/src/main/java/com/mozilla/secops/amo/AddonMultiMatch.java
+++ b/src/main/java/com/mozilla/secops/amo/AddonMultiMatch.java
@@ -49,7 +49,7 @@ public class AddonMultiMatch extends PTransform<PCollection<Event>, PCollection<
     this.matchAlertOn = matchAlertOn;
   }
 
-  /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
+  /** {@inheritDoc} */
   public String getTransformDoc() {
     return String.format(
         "Detect distributed AMO submissions with the same file name. Alert on %s submissions of the same file name.",

--- a/src/main/java/com/mozilla/secops/amo/AddonMultiMatch.java
+++ b/src/main/java/com/mozilla/secops/amo/AddonMultiMatch.java
@@ -49,6 +49,7 @@ public class AddonMultiMatch extends PTransform<PCollection<Event>, PCollection<
     this.matchAlertOn = matchAlertOn;
   }
 
+  /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
   public String getTransformDoc() {
     return String.format(
         "Detect distributed AMO submissions with the same file name. Alert on %s submissions of the same file name.",

--- a/src/main/java/com/mozilla/secops/amo/AddonMultiSubmit.java
+++ b/src/main/java/com/mozilla/secops/amo/AddonMultiSubmit.java
@@ -48,7 +48,7 @@ public class AddonMultiSubmit extends PTransform<PCollection<Event>, PCollection
     this.matchAlertOn = matchAlertOn;
   }
 
-  /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
+  /** {@inheritDoc} */
   public String getTransformDoc() {
     return String.format(
         "Detect distributed submissions based on file size intervals. Alert on %s submissions of the same rounded interval.",

--- a/src/main/java/com/mozilla/secops/amo/AddonMultiSubmit.java
+++ b/src/main/java/com/mozilla/secops/amo/AddonMultiSubmit.java
@@ -48,6 +48,7 @@ public class AddonMultiSubmit extends PTransform<PCollection<Event>, PCollection
     this.matchAlertOn = matchAlertOn;
   }
 
+  /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
   public String getTransformDoc() {
     return String.format(
         "Detect distributed submissions based on file size intervals. Alert on %s submissions of the same rounded interval.",

--- a/src/main/java/com/mozilla/secops/amo/FxaAccountAbuseAlias.java
+++ b/src/main/java/com/mozilla/secops/amo/FxaAccountAbuseAlias.java
@@ -52,6 +52,7 @@ public class FxaAccountAbuseAlias extends PTransform<PCollection<Event>, PCollec
     this.maxAliases = maxAliases;
   }
 
+  /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
   public String getTransformDoc() {
     return String.format(
         "Alerts on aliased FxA accounts usage. A max of %s are allowed for one account in a given session.",

--- a/src/main/java/com/mozilla/secops/amo/FxaAccountAbuseAlias.java
+++ b/src/main/java/com/mozilla/secops/amo/FxaAccountAbuseAlias.java
@@ -52,7 +52,7 @@ public class FxaAccountAbuseAlias extends PTransform<PCollection<Event>, PCollec
     this.maxAliases = maxAliases;
   }
 
-  /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
+  /** {@inheritDoc} */
   public String getTransformDoc() {
     return String.format(
         "Alerts on aliased FxA accounts usage. A max of %s are allowed for one account in a given session.",

--- a/src/main/java/com/mozilla/secops/amo/FxaAccountAbuseNewVersion.java
+++ b/src/main/java/com/mozilla/secops/amo/FxaAccountAbuseNewVersion.java
@@ -56,6 +56,7 @@ public class FxaAccountAbuseNewVersion extends PTransform<PCollection<Event>, PC
     this.project = project;
   }
 
+  /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
   public String getTransformDoc() {
     return String.format(
         "Correlates AMO addon submissions with abusive FxA account creation alerts via iprepd. Also includes blacklisted accounts regex: %s",

--- a/src/main/java/com/mozilla/secops/amo/FxaAccountAbuseNewVersion.java
+++ b/src/main/java/com/mozilla/secops/amo/FxaAccountAbuseNewVersion.java
@@ -56,7 +56,7 @@ public class FxaAccountAbuseNewVersion extends PTransform<PCollection<Event>, PC
     this.project = project;
   }
 
-  /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
+  /** {@inheritDoc} */
   public String getTransformDoc() {
     return String.format(
         "Correlates AMO addon submissions with abusive FxA account creation alerts via iprepd. Also includes blacklisted accounts regex: %s",

--- a/src/main/java/com/mozilla/secops/amo/ReportRestriction.java
+++ b/src/main/java/com/mozilla/secops/amo/ReportRestriction.java
@@ -27,7 +27,7 @@ public class ReportRestriction extends PTransform<PCollection<Event>, PCollectio
     this.monitoredResource = monitoredResource;
   }
 
-  /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
+  /** {@inheritDoc} */
   public String getTransformDoc() {
     return "Reports on request restrictions from AMO";
   }

--- a/src/main/java/com/mozilla/secops/amo/ReportRestriction.java
+++ b/src/main/java/com/mozilla/secops/amo/ReportRestriction.java
@@ -27,6 +27,7 @@ public class ReportRestriction extends PTransform<PCollection<Event>, PCollectio
     this.monitoredResource = monitoredResource;
   }
 
+  /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
   public String getTransformDoc() {
     return "Reports on request restrictions from AMO";
   }

--- a/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
+++ b/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
@@ -340,7 +340,7 @@ public class AuthProfile implements Serializable {
       useEventTimestampForAlert = options.getUseEventTimestampForAlert();
     }
 
-    /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
+    /** {@inheritDoc} */
     public String getTransformDoc() {
       return String.format(
           "Alert via %s immediately on auth events to specified objects: %s",
@@ -546,7 +546,7 @@ public class AuthProfile implements Serializable {
       useEventTimestampForAlert = options.getUseEventTimestampForAlert();
     }
 
-    /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
+    /** {@inheritDoc} */
     public String getTransformDoc() {
       return "Alert if an identity (can be thought of as a user) authenticates from a new IP";
     }

--- a/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
+++ b/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
@@ -340,6 +340,7 @@ public class AuthProfile implements Serializable {
       useEventTimestampForAlert = options.getUseEventTimestampForAlert();
     }
 
+    /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
     public String getTransformDoc() {
       return String.format(
           "Alert via %s immediately on auth events to specified objects: %s",
@@ -545,6 +546,7 @@ public class AuthProfile implements Serializable {
       useEventTimestampForAlert = options.getUseEventTimestampForAlert();
     }
 
+    /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
     public String getTransformDoc() {
       return "Alert if an identity (can be thought of as a user) authenticates from a new IP";
     }

--- a/src/main/java/com/mozilla/secops/authstate/PruningStrategyEntryAge.java
+++ b/src/main/java/com/mozilla/secops/authstate/PruningStrategyEntryAge.java
@@ -23,6 +23,11 @@ public class PruningStrategyEntryAge implements PruningStrategy {
     this.entryAgePruningSeconds = entryAgePruningSeconds;
   }
 
+  /**
+   * Implementation of method of {@link PruningStrategyEntryAge}
+   *
+   * <p>See {@link PruningStrategy}
+   */
   public void pruneState(AuthStateModel s) {
     Map<String, AuthStateModel.ModelEntry> entries = s.getEntries();
 

--- a/src/main/java/com/mozilla/secops/authstate/PruningStrategyEntryAge.java
+++ b/src/main/java/com/mozilla/secops/authstate/PruningStrategyEntryAge.java
@@ -24,9 +24,9 @@ public class PruningStrategyEntryAge implements PruningStrategy {
   }
 
   /**
-   * Implementation of method of {@link PruningStrategyEntryAge}
+   * {@inheritDoc}
    *
-   * <p>See {@link PruningStrategy}
+   * <p>Implementation of method of {@link PruningStrategyEntryAge}
    */
   public void pruneState(AuthStateModel s) {
     Map<String, AuthStateModel.ModelEntry> entries = s.getEntries();

--- a/src/main/java/com/mozilla/secops/authstate/PruningStrategyLatest.java
+++ b/src/main/java/com/mozilla/secops/authstate/PruningStrategyLatest.java
@@ -8,6 +8,11 @@ import java.util.HashMap;
  * All entries are removed from the model with the exception of the entry with the latest timestamp.
  */
 public class PruningStrategyLatest implements PruningStrategy {
+  /**
+   * Implementation of method of {@link PruningStrategyLatest}
+   *
+   * <p>See {@link PruningStrategy}
+   */
   public void pruneState(AuthStateModel s) {
     ArrayList<AbstractMap.SimpleEntry<String, AuthStateModel.ModelEntry>> sorted =
         s.timeSortedEntries();

--- a/src/main/java/com/mozilla/secops/authstate/PruningStrategyLatest.java
+++ b/src/main/java/com/mozilla/secops/authstate/PruningStrategyLatest.java
@@ -9,9 +9,9 @@ import java.util.HashMap;
  */
 public class PruningStrategyLatest implements PruningStrategy {
   /**
-   * Implementation of method of {@link PruningStrategyLatest}
+   * {@inheritDoc}
    *
-   * <p>See {@link PruningStrategy}
+   * <p>Implementation of method of {@link PruningStrategyLatest}
    */
   public void pruneState(AuthStateModel s) {
     ArrayList<AbstractMap.SimpleEntry<String, AuthStateModel.ModelEntry>> sorted =

--- a/src/main/java/com/mozilla/secops/awsbehavior/AwsBehavior.java
+++ b/src/main/java/com/mozilla/secops/awsbehavior/AwsBehavior.java
@@ -79,7 +79,11 @@ public class AwsBehavior implements Serializable {
 
     private Logger log;
 
-    /** Initialize new Matcher with a {@link CloudtrailMatcher} */
+    /**
+     * Initialize new Matcher with a {@link CloudtrailMatcher}
+     *
+     * @param cm {@link CloudtrailMatcher}
+     */
     public Matcher(CloudtrailMatcher cm) {
       this.cm = cm;
       log = LoggerFactory.getLogger(Matcher.class);
@@ -148,7 +152,11 @@ public class AwsBehavior implements Serializable {
     private CloudtrailMatcherManager cmmanager;
     private Logger log;
 
-    /** Initialize new Matchers with {@link AwsBehaviorOptions} */
+    /**
+     * Initialize new Matchers with {@link AwsBehaviorOptions}
+     *
+     * @param options {@link AwsBehaviorOptions}
+     */
     public Matchers(AwsBehaviorOptions options) throws IOException {
       log = LoggerFactory.getLogger(Matchers.class);
       cmmanagerPath = options.getCloudtrailMatcherManagerPath();

--- a/src/main/java/com/mozilla/secops/awsbehavior/AwsBehavior.java
+++ b/src/main/java/com/mozilla/secops/awsbehavior/AwsBehavior.java
@@ -79,6 +79,7 @@ public class AwsBehavior implements Serializable {
 
     private Logger log;
 
+    /** Initialize new Matcher with a {@link CloudtrailMatcher} */
     public Matcher(CloudtrailMatcher cm) {
       this.cm = cm;
       log = LoggerFactory.getLogger(Matcher.class);
@@ -147,6 +148,7 @@ public class AwsBehavior implements Serializable {
     private CloudtrailMatcherManager cmmanager;
     private Logger log;
 
+    /** Initialize new Matchers with {@link AwsBehaviorOptions} */
     public Matchers(AwsBehaviorOptions options) throws IOException {
       log = LoggerFactory.getLogger(Matchers.class);
       cmmanagerPath = options.getCloudtrailMatcherManagerPath();

--- a/src/main/java/com/mozilla/secops/customs/Customs.java
+++ b/src/main/java/com/mozilla/secops/customs/Customs.java
@@ -103,6 +103,7 @@ public class Customs implements Serializable {
       monitoredResource = options.getMonitoredResourceIndicator();
     }
 
+    /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
     public String getTransformDoc() {
       return "Summarizes various event counts over 15 minute period.";
     }

--- a/src/main/java/com/mozilla/secops/customs/Customs.java
+++ b/src/main/java/com/mozilla/secops/customs/Customs.java
@@ -103,7 +103,7 @@ public class Customs implements Serializable {
       monitoredResource = options.getMonitoredResourceIndicator();
     }
 
-    /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
+    /** {@inheritDoc} */
     public String getTransformDoc() {
       return "Summarizes various event counts over 15 minute period.";
     }

--- a/src/main/java/com/mozilla/secops/customs/CustomsAccountCreation.java
+++ b/src/main/java/com/mozilla/secops/customs/CustomsAccountCreation.java
@@ -45,6 +45,7 @@ public class CustomsAccountCreation
     this.escalate = options.getEscalateAccountCreation();
   }
 
+  /** Transform documentation for users - see {@link CustomsDocumentingTransform} */
   public String getTransformDocDescription() {
     return String.format(
         "Alert if single source address creates %d or more accounts within 10 minute"

--- a/src/main/java/com/mozilla/secops/customs/CustomsAccountCreation.java
+++ b/src/main/java/com/mozilla/secops/customs/CustomsAccountCreation.java
@@ -45,7 +45,7 @@ public class CustomsAccountCreation
     this.escalate = options.getEscalateAccountCreation();
   }
 
-  /** Transform documentation for users - see {@link CustomsDocumentingTransform} */
+  /** {@inheritDoc} */
   public String getTransformDocDescription() {
     return String.format(
         "Alert if single source address creates %d or more accounts within 10 minute"

--- a/src/main/java/com/mozilla/secops/customs/CustomsAccountCreationDist.java
+++ b/src/main/java/com/mozilla/secops/customs/CustomsAccountCreationDist.java
@@ -43,6 +43,7 @@ public class CustomsAccountCreationDist
     this.escalate = options.getEscalateAccountCreationDistributed();
   }
 
+  /** Transform documentation for users - see {@link CustomsDocumentingTransform} */
   public String getTransformDocDescription() {
     return String.format(
         "Alert if at least %d accounts are created from different source addresses in a 10 "

--- a/src/main/java/com/mozilla/secops/customs/CustomsAccountCreationDist.java
+++ b/src/main/java/com/mozilla/secops/customs/CustomsAccountCreationDist.java
@@ -43,7 +43,7 @@ public class CustomsAccountCreationDist
     this.escalate = options.getEscalateAccountCreationDistributed();
   }
 
-  /** Transform documentation for users - see {@link CustomsDocumentingTransform} */
+  /** {@inheritDoc} */
   public String getTransformDocDescription() {
     return String.format(
         "Alert if at least %d accounts are created from different source addresses in a 10 "

--- a/src/main/java/com/mozilla/secops/customs/CustomsAlert.java
+++ b/src/main/java/com/mozilla/secops/customs/CustomsAlert.java
@@ -150,6 +150,12 @@ public class CustomsAlert implements Serializable {
     return ret;
   }
 
+  /**
+   * Convert source login failure alert into a list of customs alerts.
+   *
+   * @param a Alert to convert
+   * @return ArrayList of CustomsAlert created
+   */
   public static ArrayList<CustomsAlert> convertSourceLoginFailure(Alert a) {
     ArrayList<CustomsAlert> ret = new ArrayList<>();
 
@@ -170,6 +176,12 @@ public class CustomsAlert implements Serializable {
     return ret;
   }
 
+  /**
+   * Convert a distributed source login failure alert into a list of customs alerts.
+   *
+   * @param a Alert to convert
+   * @return ArrayList of CustomsAlert created
+   */
   public static ArrayList<CustomsAlert> convertSourceLoginFailureDist(Alert a) {
     ArrayList<CustomsAlert> ret = new ArrayList<>();
 

--- a/src/main/java/com/mozilla/secops/customs/CustomsPasswordResetAbuse.java
+++ b/src/main/java/com/mozilla/secops/customs/CustomsPasswordResetAbuse.java
@@ -30,6 +30,7 @@ public class CustomsPasswordResetAbuse
 
   private final Logger log = LoggerFactory.getLogger(CustomsAccountCreation.class);
 
+  /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
   public String getTransformDocDescription() {
     return String.format(
         "Alert if single source requests password reset for at least %d distinct accounts "

--- a/src/main/java/com/mozilla/secops/customs/CustomsPasswordResetAbuse.java
+++ b/src/main/java/com/mozilla/secops/customs/CustomsPasswordResetAbuse.java
@@ -30,7 +30,7 @@ public class CustomsPasswordResetAbuse
 
   private final Logger log = LoggerFactory.getLogger(CustomsAccountCreation.class);
 
-  /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
+  /** {@inheritDoc} */
   public String getTransformDocDescription() {
     return String.format(
         "Alert if single source requests password reset for at least %d distinct accounts "

--- a/src/main/java/com/mozilla/secops/customs/CustomsVelocity.java
+++ b/src/main/java/com/mozilla/secops/customs/CustomsVelocity.java
@@ -45,6 +45,7 @@ public class CustomsVelocity extends PTransform<PCollection<Event>, PCollection<
   private final String maxmindCityDbPath;
   private final String maxmindIspDbPath;
 
+  /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
   public String getTransformDocDescription() {
     return String.format(
         "Alert based on applying location velocity analysis to FxA events,"

--- a/src/main/java/com/mozilla/secops/customs/CustomsVelocity.java
+++ b/src/main/java/com/mozilla/secops/customs/CustomsVelocity.java
@@ -45,7 +45,7 @@ public class CustomsVelocity extends PTransform<PCollection<Event>, PCollection<
   private final String maxmindCityDbPath;
   private final String maxmindIspDbPath;
 
-  /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
+  /** {@inheritDoc} */
   public String getTransformDocDescription() {
     return String.format(
         "Alert based on applying location velocity analysis to FxA events,"

--- a/src/main/java/com/mozilla/secops/customs/SourceLoginFailure.java
+++ b/src/main/java/com/mozilla/secops/customs/SourceLoginFailure.java
@@ -41,7 +41,7 @@ public class SourceLoginFailure
     escalate = options.getEscalateSourceLoginFailure();
   }
 
-  /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
+  /** {@inheritDoc} */
   public String getTransformDocDescription() {
     return String.format(
         "Alert on %d login failures from a single source in a 10 minute window.", threshold);

--- a/src/main/java/com/mozilla/secops/customs/SourceLoginFailure.java
+++ b/src/main/java/com/mozilla/secops/customs/SourceLoginFailure.java
@@ -41,6 +41,7 @@ public class SourceLoginFailure
     escalate = options.getEscalateSourceLoginFailure();
   }
 
+  /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
   public String getTransformDocDescription() {
     return String.format(
         "Alert on %d login failures from a single source in a 10 minute window.", threshold);

--- a/src/main/java/com/mozilla/secops/customs/SourceLoginFailureDist.java
+++ b/src/main/java/com/mozilla/secops/customs/SourceLoginFailureDist.java
@@ -37,7 +37,7 @@ public class SourceLoginFailureDist
     escalate = options.getEscalateSourceLoginFailureDistributed();
   }
 
-  /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
+  /** {@inheritDoc} */
   public String getTransformDocDescription() {
     return String.format(
         "Alert on login failures for a particular account from %d different source addresses "

--- a/src/main/java/com/mozilla/secops/customs/SourceLoginFailureDist.java
+++ b/src/main/java/com/mozilla/secops/customs/SourceLoginFailureDist.java
@@ -37,6 +37,7 @@ public class SourceLoginFailureDist
     escalate = options.getEscalateSourceLoginFailureDistributed();
   }
 
+  /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
   public String getTransformDocDescription() {
     return String.format(
         "Alert on login failures for a particular account from %d different source addresses "

--- a/src/main/java/com/mozilla/secops/gatekeeper/ETDTransforms.java
+++ b/src/main/java/com/mozilla/secops/gatekeeper/ETDTransforms.java
@@ -133,7 +133,7 @@ public class ETDTransforms implements Serializable {
       }
     }
 
-    /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
+    /** {@inheritDoc} */
     public String getTransformDoc() {
       return "Alerts are generated based on events sent from GCP's Event Threat Detection.";
     }

--- a/src/main/java/com/mozilla/secops/gatekeeper/ETDTransforms.java
+++ b/src/main/java/com/mozilla/secops/gatekeeper/ETDTransforms.java
@@ -133,6 +133,7 @@ public class ETDTransforms implements Serializable {
       }
     }
 
+    /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
     public String getTransformDoc() {
       return "Alerts are generated based on events sent from GCP's Event Threat Detection.";
     }

--- a/src/main/java/com/mozilla/secops/gatekeeper/GuardDutyTransforms.java
+++ b/src/main/java/com/mozilla/secops/gatekeeper/GuardDutyTransforms.java
@@ -145,7 +145,7 @@ public class GuardDutyTransforms implements Serializable {
       }
     }
 
-    /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
+    /** {@inheritDoc} */
     public String getTransformDoc() {
       return "Alerts are generated based on events sent from AWS's Guardduty.";
     }

--- a/src/main/java/com/mozilla/secops/gatekeeper/GuardDutyTransforms.java
+++ b/src/main/java/com/mozilla/secops/gatekeeper/GuardDutyTransforms.java
@@ -145,6 +145,7 @@ public class GuardDutyTransforms implements Serializable {
       }
     }
 
+    /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
     public String getTransformDoc() {
       return "Alerts are generated based on events sent from AWS's Guardduty.";
     }

--- a/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
+++ b/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
@@ -195,7 +195,7 @@ public class HTTPRequest implements Serializable {
       log = LoggerFactory.getLogger(ErrorRateAnalysis.class);
     }
 
-    /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
+    /** {@inheritDoc} */
     public String getTransformDoc() {
       return String.format(
           "Alert if a single source address generates more than %d 4xx errors in a "
@@ -306,7 +306,7 @@ public class HTTPRequest implements Serializable {
       log = LoggerFactory.getLogger(HardLimitAnalysis.class);
     }
 
-    /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
+    /** {@inheritDoc} */
     public String getTransformDoc() {
       return String.format(
           "Alert if single source address makes more than %d requests in a 1 minute window.",
@@ -427,7 +427,7 @@ public class HTTPRequest implements Serializable {
       log = LoggerFactory.getLogger(UserAgentBlacklistAnalysis.class);
     }
 
-    /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
+    /** {@inheritDoc} */
     public String getTransformDoc() {
       return new String(
           "Alert if client makes request with user agent that matches entry in blacklist.");
@@ -616,7 +616,7 @@ public class HTTPRequest implements Serializable {
       }
     }
 
-    /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
+    /** {@inheritDoc} */
     public String getTransformDoc() {
       String buf = null;
       for (int i = 0; i < endpoints.length; i++) {
@@ -849,7 +849,7 @@ public class HTTPRequest implements Serializable {
       log = LoggerFactory.getLogger(ThresholdAnalysis.class);
     }
 
-    /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
+    /** {@inheritDoc} */
     public String getTransformDoc() {
       return String.format(
           "Alert if a single source address makes more than %.2f times the calculated"
@@ -1014,7 +1014,11 @@ public class HTTPRequest implements Serializable {
       public String secondMethod;
       public String secondPath;
 
-      /** Convert configuration to String */
+      /**
+       * Convert configuration to String
+       *
+       * @return Class parameters as a string
+       */
       public String toString() {
         return String.format(
             "%d:%s:%s:%d:%s:%s",
@@ -1061,7 +1065,7 @@ public class HTTPRequest implements Serializable {
       }
     }
 
-    /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
+    /** {@inheritDoc} */
     public String getTransformDoc() {
       String buf = null;
       for (int i = 0; i < endpointPatterns.length; i++) {

--- a/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
+++ b/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
@@ -195,6 +195,7 @@ public class HTTPRequest implements Serializable {
       log = LoggerFactory.getLogger(ErrorRateAnalysis.class);
     }
 
+    /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
     public String getTransformDoc() {
       return String.format(
           "Alert if a single source address generates more than %d 4xx errors in a "
@@ -305,6 +306,7 @@ public class HTTPRequest implements Serializable {
       log = LoggerFactory.getLogger(HardLimitAnalysis.class);
     }
 
+    /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
     public String getTransformDoc() {
       return String.format(
           "Alert if single source address makes more than %d requests in a 1 minute window.",
@@ -425,6 +427,7 @@ public class HTTPRequest implements Serializable {
       log = LoggerFactory.getLogger(UserAgentBlacklistAnalysis.class);
     }
 
+    /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
     public String getTransformDoc() {
       return new String(
           "Alert if client makes request with user agent that matches entry in blacklist.");
@@ -613,6 +616,7 @@ public class HTTPRequest implements Serializable {
       }
     }
 
+    /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
     public String getTransformDoc() {
       String buf = null;
       for (int i = 0; i < endpoints.length; i++) {
@@ -845,6 +849,7 @@ public class HTTPRequest implements Serializable {
       log = LoggerFactory.getLogger(ThresholdAnalysis.class);
     }
 
+    /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
     public String getTransformDoc() {
       return String.format(
           "Alert if a single source address makes more than %.2f times the calculated"
@@ -1009,6 +1014,7 @@ public class HTTPRequest implements Serializable {
       public String secondMethod;
       public String secondPath;
 
+      /** Convert configuration to String */
       public String toString() {
         return String.format(
             "%d:%s:%s:%d:%s:%s",
@@ -1055,6 +1061,7 @@ public class HTTPRequest implements Serializable {
       }
     }
 
+    /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
     public String getTransformDoc() {
       String buf = null;
       for (int i = 0; i < endpointPatterns.length; i++) {

--- a/src/main/java/com/mozilla/secops/metrics/CfgTickBuilder.java
+++ b/src/main/java/com/mozilla/secops/metrics/CfgTickBuilder.java
@@ -35,7 +35,7 @@ public class CfgTickBuilder {
   /**
    * Add documentation about a transform to the configuration tick
    *
-   * @param t {@link DocumentingTransform}
+   * @param t {@link com.mozilla.secops.DocumentingTransform}
    */
   public void withTransformDoc(DocumentingTransform t) {
     cfgData.put(String.format("heuristic_%s", t.getClass().getSimpleName()), t.getTransformDoc());

--- a/src/main/java/com/mozilla/secops/parser/FxaAuth.java
+++ b/src/main/java/com/mozilla/secops/parser/FxaAuth.java
@@ -310,7 +310,7 @@ public class FxaAuth extends SourcePayloadBase implements Serializable {
   }
 
   /**
-   * Check if the auth event contained a successful certifcate signing
+   * Check if the auth event contained a successful certificate signing
    *
    * @return Boolean
    */

--- a/src/main/java/com/mozilla/secops/parser/FxaAuth.java
+++ b/src/main/java/com/mozilla/secops/parser/FxaAuth.java
@@ -309,6 +309,11 @@ public class FxaAuth extends SourcePayloadBase implements Serializable {
     return false;
   }
 
+  /**
+   * Check if the auth event contained a successful certifcate signing
+   *
+   * @return Boolean
+   */
   public Boolean discernCertificateSignSuccess() {
     if (!(fxaAuthData.getPath().equals("/v1/certificate/sign"))) {
       return false;

--- a/src/main/java/com/mozilla/secops/parser/KeyedEvent.java
+++ b/src/main/java/com/mozilla/secops/parser/KeyedEvent.java
@@ -15,7 +15,11 @@ public class KeyedEvent implements Serializable {
   private final String key;
   private final Event event;
 
-  /** Convert KeyedEvent to {@link KV} */
+  /**
+   * Convert KeyedEvent to {@link KV}
+   *
+   * @return {@link KV}
+   */
   public KV<String, Event> toKV() {
     if ((key == null) || (event == null)) {
       return null;
@@ -23,7 +27,12 @@ public class KeyedEvent implements Serializable {
     return KV.of(key, event);
   }
 
-  /** Initialize new KeyedEvent */
+  /**
+   * Initialize new KeyedEvent
+   *
+   * @param key Key string
+   * @param event Event
+   */
   public KeyedEvent(String key, Event event) {
     this.key = key;
     this.event = event;

--- a/src/main/java/com/mozilla/secops/parser/KeyedEvent.java
+++ b/src/main/java/com/mozilla/secops/parser/KeyedEvent.java
@@ -15,6 +15,7 @@ public class KeyedEvent implements Serializable {
   private final String key;
   private final Event event;
 
+  /** Convert KeyedEvent to {@link KV} */
   public KV<String, Event> toKV() {
     if ((key == null) || (event == null)) {
       return null;
@@ -22,6 +23,7 @@ public class KeyedEvent implements Serializable {
     return KV.of(key, event);
   }
 
+  /** Initialize new KeyedEvent */
   public KeyedEvent(String key, Event event) {
     this.key = key;
     this.event = event;

--- a/src/main/java/com/mozilla/secops/parser/models/cloudtrail/CloudtrailEvent.java
+++ b/src/main/java/com/mozilla/secops/parser/models/cloudtrail/CloudtrailEvent.java
@@ -4,7 +4,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
 import java.util.HashMap;
 
-/** Model for Cloudtrail Events JSON parsing */
+/**
+ * Model for Cloudtrail Events JSON parsing
+ *
+ * <p>Read about Cloudtrail events here:
+ * https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-event-reference-record-contents.html
+ */
 public class CloudtrailEvent implements Serializable {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/mozilla/secops/parser/models/cloudtrail/UserIdentity.java
+++ b/src/main/java/com/mozilla/secops/parser/models/cloudtrail/UserIdentity.java
@@ -3,7 +3,12 @@ package com.mozilla.secops.parser.models.cloudtrail;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import java.io.Serializable;
 
-/** Model for userIdentity element in Cloudtrail Events */
+/**
+ * Model for userIdentity element in Cloudtrail Events
+ *
+ * <p>Read about the UserIdentity record here:
+ * https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-event-reference-user-identity.html
+ */
 public class UserIdentity implements Serializable {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/mozilla/secops/parser/models/fxaauth/FxaAuth.java
+++ b/src/main/java/com/mozilla/secops/parser/models/fxaauth/FxaAuth.java
@@ -100,6 +100,12 @@ public class FxaAuth implements Serializable {
       return value;
     }
 
+    /**
+     * Get Errno from int value
+     *
+     * @param errno int value
+     * @return Errno
+     */
     @JsonCreator
     public static Errno forValue(int errno) {
       for (Errno e : values()) {

--- a/src/main/java/com/mozilla/secops/postprocessing/AlertSummary.java
+++ b/src/main/java/com/mozilla/secops/postprocessing/AlertSummary.java
@@ -69,6 +69,7 @@ public class AlertSummary extends PTransform<PCollection<Alert>, PCollection<Ale
 
   private Logger log;
 
+  /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
   public String getTransformDoc() {
     return String.format(
         "Analyze alerts across windows to identify threshold violations"

--- a/src/main/java/com/mozilla/secops/postprocessing/AlertSummary.java
+++ b/src/main/java/com/mozilla/secops/postprocessing/AlertSummary.java
@@ -69,7 +69,7 @@ public class AlertSummary extends PTransform<PCollection<Alert>, PCollection<Ale
 
   private Logger log;
 
-  /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
+  /** {@inheritDoc} */
   public String getTransformDoc() {
     return String.format(
         "Analyze alerts across windows to identify threshold violations"

--- a/src/main/java/com/mozilla/secops/postprocessing/PostProcessing.java
+++ b/src/main/java/com/mozilla/secops/postprocessing/PostProcessing.java
@@ -159,7 +159,11 @@ public class PostProcessing implements Serializable {
       }
     }
 
-    /** Initialize WatchlistAnaylze with {@link PostProcessingOptions} */
+    /**
+     * Initialize WatchlistAnaylze with {@link PostProcessingOptions}
+     *
+     * @param options {@link PostProcessingOptions}
+     */
     public WatchlistAnalyze(PostProcessingOptions options) {
       warningEmail = options.getWarningSeverityEmail();
       criticalEmail = options.getCriticalSeverityEmail();
@@ -167,7 +171,7 @@ public class PostProcessing implements Serializable {
           Metrics.distribution(METRICS_NAMESPACE, WATCHLIST_ALERT_PROCESSING_TIME_METRIC);
     }
 
-    /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
+    /** {@inheritDoc} */
     public String getTransformDoc() {
       return "Alert on matched watchlist entries in incoming alerts from other pipelines.";
     }

--- a/src/main/java/com/mozilla/secops/postprocessing/PostProcessing.java
+++ b/src/main/java/com/mozilla/secops/postprocessing/PostProcessing.java
@@ -160,7 +160,7 @@ public class PostProcessing implements Serializable {
     }
 
     /**
-     * Initialize WatchlistAnaylze with {@link PostProcessingOptions}
+     * Initialize WatchlistAnalyze with {@link PostProcessingOptions}
      *
      * @param options {@link PostProcessingOptions}
      */

--- a/src/main/java/com/mozilla/secops/postprocessing/PostProcessing.java
+++ b/src/main/java/com/mozilla/secops/postprocessing/PostProcessing.java
@@ -159,6 +159,7 @@ public class PostProcessing implements Serializable {
       }
     }
 
+    /** Initialize WatchlistAnaylze with {@link PostProcessingOptions} */
     public WatchlistAnalyze(PostProcessingOptions options) {
       warningEmail = options.getWarningSeverityEmail();
       criticalEmail = options.getCriticalSeverityEmail();
@@ -166,6 +167,7 @@ public class PostProcessing implements Serializable {
           Metrics.distribution(METRICS_NAMESPACE, WATCHLIST_ALERT_PROCESSING_TIME_METRIC);
     }
 
+    /** Transform documentation for users - see {@link com.mozilla.secops.DocumentingTransform} */
     public String getTransformDoc() {
       return "Alert on matched watchlist entries in incoming alerts from other pipelines.";
     }

--- a/src/main/java/com/mozilla/secops/state/DatastoreStateCursor.java
+++ b/src/main/java/com/mozilla/secops/state/DatastoreStateCursor.java
@@ -147,6 +147,7 @@ public class DatastoreStateCursor<T> extends StateCursor<T> {
    * @param d Initialized {@link Datastore} object
    * @param namespace Datastore namespace
    * @param kind Datastore kind
+   * @param stateClass Class used in stage storage
    * @param transaction True to initialize cursor as a transaction
    */
   public DatastoreStateCursor(

--- a/src/main/java/com/mozilla/secops/state/DatastoreStateCursor.java
+++ b/src/main/java/com/mozilla/secops/state/DatastoreStateCursor.java
@@ -24,6 +24,11 @@ public class DatastoreStateCursor<T> extends StateCursor<T> {
   private KeyFactory keyFactory;
   private Transaction tx;
 
+  /**
+   * Commit datastore transaction
+   *
+   * @throws StateException
+   */
   public void commit() throws StateException {
     if (tx == null) {
       throw new StateException("datastore cursor not configured as transaction");

--- a/src/main/java/com/mozilla/secops/state/DatastoreStateInterface.java
+++ b/src/main/java/com/mozilla/secops/state/DatastoreStateInterface.java
@@ -18,6 +18,7 @@ public class DatastoreStateInterface implements StateInterface {
   private String project;
   private HttpTransportOptions transportOpts;
 
+  /** {@inheritDoc} */
   public <T> StateCursor<T> newCursor(Class<T> stateClass, boolean transaction)
       throws StateException {
     try {
@@ -27,8 +28,14 @@ public class DatastoreStateInterface implements StateInterface {
     }
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>noop for datastore
+   */
   public void done() {}
 
+  /** {@inheritDoc} */
   public void initialize() throws StateException {
     String emulatorHost = System.getenv("DATASTORE_HOST");
     String emulatorProject = System.getenv("DATASTORE_PROJECT_ID");
@@ -54,6 +61,7 @@ public class DatastoreStateInterface implements StateInterface {
     }
   }
 
+  /** {@inheritDoc} */
   public void deleteAll() throws StateException {
     StructuredQuery<Entity> query =
         Query.newEntityQueryBuilder().setNamespace(namespace).setKind(kind).build();

--- a/src/main/java/com/mozilla/secops/state/MemcachedStateInterface.java
+++ b/src/main/java/com/mozilla/secops/state/MemcachedStateInterface.java
@@ -10,6 +10,7 @@ public class MemcachedStateInterface implements StateInterface {
   private final int memcachedPort;
   private MemcachedClient memclient;
 
+  /** {@inheritDoc} */
   public <T> StateCursor<T> newCursor(Class<T> stateClass, boolean transaction)
       throws StateException {
     if (transaction) {
@@ -18,14 +19,17 @@ public class MemcachedStateInterface implements StateInterface {
     return new MemcachedStateCursor<T>(memclient, stateClass);
   }
 
+  /** {@inheritDoc} */
   public void done() {
     memclient.shutdown();
   }
 
+  /** {@inheritDoc} */
   public void deleteAll() throws StateException {
     memclient.flush();
   }
 
+  /** {@inheritDoc} */
   public void initialize() throws StateException {
     try {
       memclient = new MemcachedClient(new InetSocketAddress(memcachedHost, memcachedPort));

--- a/src/main/java/com/mozilla/secops/state/State.java
+++ b/src/main/java/com/mozilla/secops/state/State.java
@@ -36,6 +36,7 @@ public class State {
    * <p>If the transaction flag is true, the new cursor will be allocated as a transaction. In this
    * case be sure to properly commit the transaction in the cursor when complete.
    *
+   * @param <T> Class used in state storage
    * @param stateClass Class used in stage storage
    * @param transaction If true, allocate cursor as a transaction
    * @return {@link StateCursor}

--- a/src/main/java/com/mozilla/secops/state/StateInterface.java
+++ b/src/main/java/com/mozilla/secops/state/StateInterface.java
@@ -22,6 +22,7 @@ public interface StateInterface {
   /**
    * Allocate new state cursor
    *
+   * @param <T> Class used in state storage
    * @param stateClass Class used in state storage
    * @param transaction If true, allocate cursor as a transaction
    * @return StateCursor


### PR DESCRIPTION
Adds checkstyle:check within CircleCI building process that will check for missing javadoc comments from public methods. The configuration is stored in `checkstyle/*`

You can see an example of the CircleCI output for missing javadoc comments here: https://circleci.com/gh/mozilla-services/foxsec-pipeline/196

A few files have been excluded using `checkstyle/checkstyle-suppressions.xml` and a couple of in-use Beam Annotations (Setup, Teardown, ProcessElement, OnTimer, OnStale) have been excluded as well.