### PR TITLE
Fix BAM race condition

### DIFF
--- a/contrib/bugzilla-alert-manager/manager.go
+++ b/contrib/bugzilla-alert-manager/manager.go
@@ -23,8 +23,8 @@ var (
 
 	config = &common.Configuration{}
 
-	// Support retries for events for a told of 30 seconds.
-	EXPIRATION = time.Second * 30
+	// Support retries for events for up to 3 minutes before expiring
+	EXPIRATION = time.Minute * 3
 
 	// dirty hack to disable init in unit tests
 	_testing = false

--- a/contrib/common/bugzilla.go
+++ b/contrib/common/bugzilla.go
@@ -52,6 +52,7 @@ type CreateBug struct {
 	Version     string   `json:"version"`
 	Component   string   `json:"component"`
 	Summary     string   `json:"summary"`
+	Alias       string   `json:"alias"`
 	Description string   `json:"description"`
 	AssignedTo  string   `json:"assigned_to"`
 	Blocks      string   `json:"blocks"`
@@ -61,7 +62,9 @@ type CreateBug struct {
 }
 
 func (bc *BugzillaClient) CreateBugFromAlerts(assignedTo, category string, alerts []*Alert) (int, error) {
-	summary := fmt.Sprintf("%s alerts for %s", category, time.Now().Format("2006-01-02"))
+	n := time.Now().Format("2006-01-02")
+	summary := fmt.Sprintf("%s alerts for %s", category, n)
+	alias := fmt.Sprintf("foxsec-%s-%s", category, n)
 
 	bugText := fmt.Sprintf("## %s alerts\n---\n", category)
 	for _, alert := range alerts {
@@ -69,16 +72,17 @@ func (bc *BugzillaClient) CreateBugFromAlerts(assignedTo, category string, alert
 	}
 
 	bugJson, err := json.Marshal(&CreateBug{
-		bc.Config.Product,
-		"unspecified",
-		bc.Config.Component,
-		summary,
-		bugText,
-		assignedTo,
-		bc.Config.CategoryToTracker[category],
-		"task",
-		bc.Config.Groups,
-		category,
+		Product:     bc.Config.Product,
+		Version:     "unspecified",
+		Component:   bc.Config.Component,
+		Summary:     summary,
+		Alias:       alias,
+		Description: bugText,
+		AssignedTo:  assignedTo,
+		Blocks:      bc.Config.CategoryToTracker[category],
+		Type:        "task",
+		Groups:      bc.Config.Groups,
+		Whiteboard:  category,
 	})
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
Use BMO's alias param to deal with race conditions on bug creation.
Extend the timeout for retries to handle multiple coming in at once and
having to retry.