### PR TITLE
prevent CfgTickUnboundedReader with no interval

### DIFF
--- a/src/main/java/com/mozilla/secops/metrics/CfgTickUnboundedReader.java
+++ b/src/main/java/com/mozilla/secops/metrics/CfgTickUnboundedReader.java
@@ -26,6 +26,9 @@ class CfgTickUnboundedReader extends UnboundedSource.UnboundedReader<String>
    * @param source Source for reader
    */
   public CfgTickUnboundedReader(CfgTickUnboundedSource source) {
+    if (source.getInterval() <= 0) {
+      throw new IllegalArgumentException("interval must be > 0");
+    }
     this.source = source;
     current = null;
     lastTick = null;

--- a/src/test/java/com/mozilla/secops/metrics/TestCfgTickGenerator.java
+++ b/src/test/java/com/mozilla/secops/metrics/TestCfgTickGenerator.java
@@ -39,7 +39,7 @@ public class TestCfgTickGenerator implements Serializable {
   public void cfgTickGeneratorTest() throws Exception {
     CfgTickGeneratorOptions o = getOptions();
 
-    CfgTickBuilder builder = new CfgTickBuilder().includePipelineOptions(getOptions());
+    CfgTickBuilder builder = new CfgTickBuilder().includePipelineOptions(o);
 
     PCollection<Event> results =
         pipeline
@@ -63,6 +63,35 @@ public class TestCfgTickGenerator implements Serializable {
                 cnt++;
               }
               assertEquals(2, cnt);
+              return null;
+            });
+
+    pipeline.run().waitUntilFinish();
+  }
+
+  @Test
+  public void cfgTickGeneratorTestZeroInterval() throws Exception {
+    CfgTickGeneratorOptions o = getOptions();
+    o.setGenerateConfigurationTicksInterval(0);
+
+    CfgTickBuilder builder = new CfgTickBuilder().includePipelineOptions(o);
+
+    PCollection<Event> results =
+        pipeline
+            .apply(Input.compositeInputAdapter(o, builder.build()))
+            .apply(ParDo.of(new ParserDoFn()));
+
+    PAssert.that(results)
+        .satisfies(
+            i -> {
+              int cnt = 0;
+              for (Event e : i) {
+                if (e.getPayloadType() != Payload.PayloadType.CFGTICK) {
+                  continue;
+                }
+                cnt++;
+              }
+              assertEquals(0, cnt);
               return null;
             });
 

--- a/src/test/java/com/mozilla/secops/metrics/TestCfgTickUnboundedReader.java
+++ b/src/test/java/com/mozilla/secops/metrics/TestCfgTickUnboundedReader.java
@@ -1,0 +1,14 @@
+package com.mozilla.secops.metrics;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class TestCfgTickUnboundedReader {
+  public TestCfgTickUnboundedReader() {}
+
+  @Test(expected = IllegalArgumentException.class)
+  public void cfgTickUnboundedReaderBadInterval() throws Exception {
+    new CfgTickUnboundedReader(new CfgTickUnboundedSource("", 0));
+  }
+}


### PR DESCRIPTION
Some code paths will verify that the interval makes sense, but in some
cases it is possible to create a configuration tick generator with an
interval of zero, in which case it will flood out messages.

Prevent this by validating this value in reader/source setup.