### PR TITLE
use feature summary registration in prefilter

### DIFF
--- a/src/main/java/com/mozilla/secops/customs/Customs.java
+++ b/src/main/java/com/mozilla/secops/customs/Customs.java
@@ -64,11 +64,14 @@ public class Customs implements Serializable {
 
   /**
    * Return an array of EventSummary values that indicate which events should be stored during
-   * feature extraction
+   * feature extraction and passed through the prefilter.
    *
    * <p>Any EventSummary values returned here will indicate that an event of that type should be
    * stored during feature extraction. This is required if the underlying analysis transform needs
    * to operate on the events themselves.
+   *
+   * <p>If a particular event type is not returned here, it will not be available to any analysis
+   * transforms.
    *
    * @return ArrayList
    */

--- a/src/main/java/com/mozilla/secops/customs/CustomsPreFilter.java
+++ b/src/main/java/com/mozilla/secops/customs/CustomsPreFilter.java
@@ -1,23 +1,22 @@
 package com.mozilla.secops.customs;
 
 import com.mozilla.secops.parser.Event;
+import com.mozilla.secops.parser.FxaAuth;
 import com.mozilla.secops.parser.Payload;
+import java.util.ArrayList;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.PCollection;
 
-/** Basic filtering of ingested events prior to analysis application */
+/**
+ * Basic filtering of ingested events prior to analysis application
+ *
+ * <p>This transform will filter any events from the input collection that are not returned in
+ * {@link Customs#featureSummaryRegistration}.
+ */
 public class CustomsPreFilter extends PTransform<PCollection<Event>, PCollection<Event>> {
   private static final long serialVersionUID = 1L;
-
-  /**
-   * Paths that will be filtered from the input stream
-   *
-   * <p>Requests to these paths will be filtered early prior to passing the collection on. Shuffle
-   * operations downstream become too expensive with inclusion of these endpoints.
-   */
-  public static final String[] EXCLUDEPATHS = new String[] {"/v1/verify", "/v1/account/devices"};
 
   @Override
   public PCollection<Event> expand(PCollection<Event> col) {
@@ -26,6 +25,13 @@ public class CustomsPreFilter extends PTransform<PCollection<Event>, PCollection
         ParDo.of(
             new DoFn<Event, Event>() {
               private static final long serialVersionUID = 1L;
+
+              private ArrayList<FxaAuth.EventSummary> types;
+
+              @Setup
+              public void setup() {
+                types = Customs.featureSummaryRegistration();
+              }
 
               @ProcessElement
               public void processElement(ProcessContext c) {
@@ -36,16 +42,13 @@ public class CustomsPreFilter extends PTransform<PCollection<Event>, PCollection
                   return;
                 }
 
-                String path = CustomsUtil.authGetPath(e);
-                if (path == null) {
+                FxaAuth.EventSummary s = CustomsUtil.authGetEventSummary(e);
+                if (s == null) {
                   return;
                 }
-                for (String i : EXCLUDEPATHS) {
-                  if (path.equals(i)) {
-                    return;
-                  }
+                if (!types.contains(s)) {
+                  return;
                 }
-
                 c.output(e);
               }
             }));


### PR DESCRIPTION
Rather then maintaining a separate set of paths in the prefilter, just
apply the filter using event types from summary registration which will
reduce the number of events being included in feature summaries that are
not being used in analysis.