### PR TITLE
ensure maxmind city getName is not empty

### DIFF
--- a/src/main/java/com/mozilla/secops/alert/AlertFormatter.java
+++ b/src/main/java/com/mozilla/secops/alert/AlertFormatter.java
@@ -81,7 +81,12 @@ public class AlertFormatter extends DoFn<Alert, Alert> {
       if (cityKey != null && countryKey != null) {
         CityResponse cr = geoip.lookupCity(buf);
         if (cr != null) {
-          a.addMetadata(cityKey, cr.getCity().getName());
+          if (cr.getCity() != null) {
+            // getName() can return an empty string in some cases
+            if (cr.getCity().getName() != null && !cr.getCity().getName().isEmpty()) {
+              a.addMetadata(cityKey, cr.getCity().getName());
+            }
+          }
           a.addMetadata(countryKey, cr.getCountry().getIsoCode());
         }
       }

--- a/src/main/java/com/mozilla/secops/parser/SourcePayloadBase.java
+++ b/src/main/java/com/mozilla/secops/parser/SourcePayloadBase.java
@@ -46,7 +46,12 @@ public abstract class SourcePayloadBase extends PayloadBase implements Serializa
       // If we have parser state attempt to resolve GeoIP information
       CityResponse cr = state.getParser().geoIp(sourceAddress);
       if (cr != null) {
-        sourceAddressCity = cr.getCity().getName();
+        if (cr.getCity() != null) {
+          // getName() can return an empty string in some cases
+          if (cr.getCity().getName() != null && !cr.getCity().getName().isEmpty()) {
+            sourceAddressCity = cr.getCity().getName();
+          }
+        }
         sourceAddressCountry = cr.getCountry().getIsoCode();
 
         if ((cr.getLocation() != null)


### PR DESCRIPTION
In some cases, Maxmind City getName() will return "" as a city name. If
this occurs do not attempt to store it as metadata.