### PR TITLE
log errors on invalid metadata value

### DIFF
--- a/bin/generate_meta.sh
+++ b/bin/generate_meta.sh
@@ -7,5 +7,5 @@
 f=`mktemp`
 outpath=contrib/common/alertmeta.go
 
-java -cp target/classes com.mozilla.secops.alert.AlertMeta "${f}"
+java com.mozilla.secops.alert.AlertMeta "${f}"
 gofmt $f > $outpath

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,23 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.1.1</version>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>build-classpath</goal>
+                        </goals>
+                        <configuration>
+                            <outputProperty>maven.compile.classpath</outputProperty>
+                            <silent>true</silent>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.0</version>
                 <configuration>
@@ -63,6 +80,11 @@
                 </executions>
                 <configuration>
                     <executable>bin/generate_meta.sh</executable>
+                    <environmentVariables>
+                        <CLASSPATH>
+                            ${maven.compile.classpath}:target/classes
+                        </CLASSPATH>
+                    </environmentVariables>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/com/mozilla/secops/alert/Alert.java
+++ b/src/main/java/com/mozilla/secops/alert/Alert.java
@@ -242,21 +242,25 @@ public class Alert implements Serializable {
    *
    * @param key Key to set
    * @param value Value to set for key
+   * @return True if key was successfully set
    */
-  public void setMetadataValue(AlertMeta.Key key, String value) {
-    key.validate(value);
+  public boolean setMetadataValue(AlertMeta.Key key, String value) {
+    if (!key.validate(value)) {
+      return false;
+    }
     metaLock.lock();
     try {
       for (AlertMeta m : metadata) {
         if (m.getKey().equals(key.getKey())) {
           m.setValue(value);
-          return;
+          return true;
         }
       }
       metadata.add(new AlertMeta(key.getKey(), value));
     } finally {
       metaLock.unlock();
     }
+    return true;
   }
 
   /**
@@ -286,9 +290,12 @@ public class Alert implements Serializable {
    *
    * @param key Key
    * @param value Value
+   * @return True if key was successfully set
    */
-  public void addMetadata(AlertMeta.Key key, String value) {
-    key.validate(value);
+  public boolean addMetadata(AlertMeta.Key key, String value) {
+    if (!key.validate(value)) {
+      return false;
+    }
     // Pick up metadata mutex here to prevent ConcurrentModification exception if object is
     // serialized while we are appending to the metadata, see local implementation of
     // writeObject
@@ -298,6 +305,7 @@ public class Alert implements Serializable {
     } finally {
       metaLock.unlock();
     }
+    return true;
   }
 
   /**

--- a/src/main/java/com/mozilla/secops/alert/AlertMeta.java
+++ b/src/main/java/com/mozilla/secops/alert/AlertMeta.java
@@ -6,10 +6,14 @@ import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Serializable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** {@link AlertMeta} is metadata associated with an {@link Alert} */
 public class AlertMeta implements Serializable {
   private static final long serialVersionUID = 1L;
+
+  private static final Logger log = LoggerFactory.getLogger(AlertMeta.class);
 
   private String key;
   private String value;
@@ -24,12 +28,14 @@ public class AlertMeta implements Serializable {
      * Validate value
      *
      * @param value Value for validation
-     * @throws IllegalArgumentException IllegalArgumentException
+     * @return True if value is formatted correctly for key
      */
-    public void validate(String key, String value) {
+    public boolean validate(String key, String value) {
       if (value == null || value.isEmpty()) {
-        throw new IllegalArgumentException(String.format("invalid metadata value for %s", key));
+        log.error("value for key {} is invalid: {}", key, value);
+        return false;
       }
+      return true;
     }
   }
 
@@ -222,13 +228,11 @@ public class AlertMeta implements Serializable {
     /**
      * Validate the format of a value to be used for this key
      *
-     * <p>This method behaves as an assertion and will throw {@link IllegalArgumentException} if the
-     * value is invalid.
-     *
      * @param value Value
+     * @return True if value was formatted correctly for key
      */
-    public void validate(String value) {
-      validator.validate(key, value);
+    public boolean validate(String value) {
+      return validator.validate(key, value);
     }
 
     /**

--- a/src/test/java/com/mozilla/secops/alert/TestAlert.java
+++ b/src/test/java/com/mozilla/secops/alert/TestAlert.java
@@ -532,4 +532,18 @@ public class TestAlert {
     a.setSummary("test alert");
     assertTrue(a.hasCorrectFields());
   }
+
+  @Test
+  public void testMetaValidator() throws Exception {
+    Alert a = new Alert();
+    assertNotNull(a);
+
+    assertTrue(a.addMetadata(AlertMeta.Key.SOURCEADDRESS, "1.2.3.4"));
+    assertFalse(a.addMetadata(AlertMeta.Key.EMAIL, ""));
+    assertFalse(a.addMetadata(AlertMeta.Key.EMAIL, null));
+
+    assertTrue(a.setMetadataValue(AlertMeta.Key.SOURCEADDRESS, "1.2.3.4"));
+    assertFalse(a.setMetadataValue(AlertMeta.Key.EMAIL, ""));
+    assertFalse(a.setMetadataValue(AlertMeta.Key.EMAIL, null));
+  }
 }


### PR DESCRIPTION
Instead of throwing IllegalArgumentException, log these as an error.