### PR TITLE
Improve metadata list handling

### DIFF
--- a/src/main/java/com/mozilla/secops/Violation.java
+++ b/src/main/java/com/mozilla/secops/Violation.java
@@ -7,9 +7,11 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mozilla.secops.alert.Alert;
 import com.mozilla.secops.alert.AlertMeta;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -105,7 +107,12 @@ public class Violation {
       if (emails == null) {
         return null;
       }
-      String[] parts = emails.split(", ?");
+      List<String> parts = null;
+      try {
+        parts = AlertMeta.splitListValues(AlertMeta.Key.EMAIL, emails);
+      } catch (IOException exc) {
+        return null;
+      }
       for (String i : parts) {
         ret.add(createViolation(a, i, "email", vType.toString()));
       }
@@ -132,7 +139,14 @@ public class Violation {
               "ip",
               ViolationType.ENDPOINT_ABUSE_VIOLATION.toString()));
       if (a.getMetadataValue(AlertMeta.Key.EMAIL) != null) {
-        String[] parts = a.getMetadataValue(AlertMeta.Key.EMAIL).split(", ?");
+        List<String> parts = null;
+        try {
+          parts =
+              AlertMeta.splitListValues(
+                  AlertMeta.Key.EMAIL, a.getMetadataValue(AlertMeta.Key.EMAIL));
+        } catch (IOException exc) {
+          return null;
+        }
         for (String i : parts) {
           ret.add(
               createViolation(a, i, "email", ViolationType.ABUSIVE_ACCOUNT_VIOLATION.toString()));

--- a/src/main/java/com/mozilla/secops/alert/Alert.java
+++ b/src/main/java/com/mozilla/secops/alert/Alert.java
@@ -11,6 +11,7 @@ import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.locks.ReentrantLock;
 import org.joda.time.DateTime;
@@ -306,6 +307,23 @@ public class Alert implements Serializable {
       metaLock.unlock();
     }
     return true;
+  }
+
+  /**
+   * Add metadata as a list of values
+   *
+   * <p>Only valid for LIST type fields.
+   *
+   * @param key Key
+   * @param value List
+   * @return True if key was successfully set
+   */
+  public boolean addMetadata(AlertMeta.Key key, List<String> value) {
+    try {
+      return addMetadata(key, AlertMeta.joinListValues(key, value));
+    } catch (IOException exc) {
+      return false;
+    }
   }
 
   /**

--- a/src/main/java/com/mozilla/secops/alert/AlertMeta.java
+++ b/src/main/java/com/mozilla/secops/alert/AlertMeta.java
@@ -23,6 +23,13 @@ public class AlertMeta implements Serializable {
 
   private static final Splitter META_VALUE_SPLITTER = Splitter.on(",").trimResults();
 
+  /**
+   * Join a list of values for a specific metadata key
+   *
+   * @param key Key
+   * @param input List of values
+   * @return String
+   */
   public static String joinListValues(Key key, List<String> input) throws IOException {
     if (!key.getValueType().equals(Key.ValueType.LIST)) {
       String buf = String.format("key %s for join is not of type list", key.getKey());
@@ -32,6 +39,13 @@ public class AlertMeta implements Serializable {
     return String.join(", ", input);
   }
 
+  /**
+   * Split a list of values for a specific metadata key
+   *
+   * @param key Key
+   * @param input String
+   * @return List
+   */
   public static List<String> splitListValues(Key key, String input) throws IOException {
     if (!key.getValueType().equals(Key.ValueType.LIST)) {
       String buf = String.format("key %s for split is not of type list", key.getKey());

--- a/src/main/java/com/mozilla/secops/amo/AddonMatcher.java
+++ b/src/main/java/com/mozilla/secops/amo/AddonMatcher.java
@@ -118,14 +118,15 @@ public class AddonMatcher extends PTransform<PCollection<Event>, PCollection<Ale
                         // add the normalized email equivalents
                         if (d.getFxaEmail() != null) {
                           String email = d.getFxaEmail();
-                          String buf = email;
+                          ArrayList<String> buf = new ArrayList<>();
+                          buf.add(email);
                           String nb = MiscUtil.normalizeEmailPlus(email);
                           if (!email.equals(nb)) {
-                            buf += ", " + nb;
+                            buf.add(nb);
                           }
                           nb = MiscUtil.normalizeEmailPlusDotStrip(email);
                           if (!email.equals(nb)) {
-                            buf += ", " + nb;
+                            buf.add(nb);
                           }
                           alert.addMetadata(AlertMeta.Key.EMAIL, buf);
                         }

--- a/src/main/java/com/mozilla/secops/amo/AddonMultiIpLogin.java
+++ b/src/main/java/com/mozilla/secops/amo/AddonMultiIpLogin.java
@@ -231,14 +231,15 @@ public class AddonMultiIpLogin extends PTransform<PCollection<Event>, PCollectio
                     }
 
                     String email = c.element().getKey();
-                    String buf = email;
+                    ArrayList<String> buf = new ArrayList<>();
+                    buf.add(email);
                     String nb = MiscUtil.normalizeEmailPlus(email);
                     if (!email.equals(nb)) {
-                      buf += ", " + nb;
+                      buf.add(nb);
                     }
                     nb = MiscUtil.normalizeEmailPlusDotStrip(email);
                     if (!email.equals(nb)) {
-                      buf += ", " + nb;
+                      buf.add(nb);
                     }
 
                     Alert alert = new Alert();

--- a/src/main/java/com/mozilla/secops/amo/AddonMultiMatch.java
+++ b/src/main/java/com/mozilla/secops/amo/AddonMultiMatch.java
@@ -9,6 +9,7 @@ import com.mozilla.secops.parser.AmoDocker;
 import com.mozilla.secops.parser.Event;
 import com.mozilla.secops.parser.Payload;
 import com.mozilla.secops.window.GlobalTriggers;
+import java.util.ArrayList;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.beam.sdk.transforms.Distinct;
@@ -117,24 +118,20 @@ public class AddonMultiMatch extends PTransform<PCollection<Event>, PCollection<
 
                   @ProcessElement
                   public void processElement(ProcessContext c) {
-                    String buf = "";
+                    ArrayList<String> buf = new ArrayList<>();
                     int cnt = 0;
 
                     for (String s : c.element().getValue()) {
-                      if (buf.isEmpty()) {
-                        buf = s;
-                      } else {
-                        buf += ", " + s;
-                      }
+                      buf.add(s);
                       // When we are building the submission buffer, also include a normalized
                       // version of the address, and a dot normalized version
                       String nb = MiscUtil.normalizeEmailPlus(s);
                       if (!s.equals(nb)) {
-                        buf += ", " + nb;
+                        buf.add(nb);
                       }
                       nb = MiscUtil.normalizeEmailPlusDotStrip(s);
                       if (!s.equals(nb)) {
-                        buf += ", " + nb;
+                        buf.add(nb);
                       }
                       cnt++;
                     }

--- a/src/main/java/com/mozilla/secops/amo/AddonMultiSubmit.java
+++ b/src/main/java/com/mozilla/secops/amo/AddonMultiSubmit.java
@@ -9,6 +9,7 @@ import com.mozilla.secops.parser.AmoDocker;
 import com.mozilla.secops.parser.Event;
 import com.mozilla.secops.parser.Payload;
 import com.mozilla.secops.window.GlobalTriggers;
+import java.util.ArrayList;
 import org.apache.beam.sdk.transforms.Distinct;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.GroupByKey;
@@ -111,24 +112,20 @@ public class AddonMultiSubmit extends PTransform<PCollection<Event>, PCollection
 
                   @ProcessElement
                   public void processElement(ProcessContext c) {
-                    String buf = "";
+                    ArrayList<String> buf = new ArrayList<>();
                     int cnt = 0;
 
                     for (String s : c.element().getValue()) {
-                      if (buf.isEmpty()) {
-                        buf = s;
-                      } else {
-                        buf += ", " + s;
-                      }
+                      buf.add(s);
                       // When we are building the submission buffer, also include a normalized
                       // version of the address, and a dot normalized version
                       String nb = MiscUtil.normalizeEmailPlus(s);
                       if (!s.equals(nb)) {
-                        buf += ", " + nb;
+                        buf.add(nb);
                       }
                       nb = MiscUtil.normalizeEmailPlusDotStrip(s);
                       if (!s.equals(nb)) {
-                        buf += ", " + nb;
+                        buf.add(nb);
                       }
                       cnt++;
                     }

--- a/src/main/java/com/mozilla/secops/amo/FxaAccountAbuseAlias.java
+++ b/src/main/java/com/mozilla/secops/amo/FxaAccountAbuseAlias.java
@@ -115,11 +115,12 @@ public class FxaAccountAbuseAlias extends PTransform<PCollection<Event>, PCollec
                     Iterable<String> alias = c.element().getValue();
                     ArrayList<String> distinct = new ArrayList<>();
 
-                    String metabuf = normalized;
+                    ArrayList<String> metabuf = new ArrayList<>();
+                    metabuf.add(normalized);
                     for (String s : alias) {
                       if (!distinct.contains(s)) {
                         distinct.add(s);
-                        metabuf += ", " + s;
+                        metabuf.add(s);
                       }
                     }
                     if (distinct.size() <= maxAliases) {

--- a/src/main/java/com/mozilla/secops/customs/CustomsAccountCreation.java
+++ b/src/main/java/com/mozilla/secops/customs/CustomsAccountCreation.java
@@ -108,13 +108,9 @@ public class CustomsAccountCreation
                         String.format(
                             "%s suspicious account creation, %s %d",
                             monitoredResource, remoteAddress, cnt));
-                    String buf = "";
+                    ArrayList<String> buf = new ArrayList<>();
                     for (String s : seenAcct) {
-                      if (buf.isEmpty()) {
-                        buf = s;
-                      } else {
-                        buf += ", " + s;
-                      }
+                      buf.add(s);
                     }
                     alert.addMetadata(AlertMeta.Key.EMAIL, buf);
                     if (accountAbuseSuppressRecovery != null) {

--- a/src/main/java/com/mozilla/secops/customs/CustomsAccountCreationDist.java
+++ b/src/main/java/com/mozilla/secops/customs/CustomsAccountCreationDist.java
@@ -112,13 +112,9 @@ public class CustomsAccountCreationDist
                                 "%s suspicious distributed account creation, %s %d",
                                 monitoredResource, remoteAddress, cand.size() + 1));
                         alert.addMetadata(AlertMeta.Key.EMAIL, email);
-                        String buf = "";
+                        ArrayList<String> buf = new ArrayList<>();
                         for (String s : cand) {
-                          if (buf.isEmpty()) {
-                            buf = s;
-                          } else {
-                            buf += ", " + s;
-                          }
+                          buf.add(s);
                         }
                         alert.addMetadata(AlertMeta.Key.EMAIL_SIMILAR, buf);
                         c.output(alert);

--- a/src/main/java/com/mozilla/secops/customs/CustomsAlert.java
+++ b/src/main/java/com/mozilla/secops/customs/CustomsAlert.java
@@ -7,9 +7,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.mozilla.secops.alert.Alert;
 import com.mozilla.secops.alert.AlertMeta;
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.UUID;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -192,7 +194,14 @@ public class CustomsAlert implements Serializable {
             "%s addresses failed login to %s in window",
             a.getMetadataValue(AlertMeta.Key.COUNT), a.getMetadataValue(AlertMeta.Key.EMAIL));
 
-    String[] el = a.getMetadataValue(AlertMeta.Key.SOURCEADDRESSES).split(", ?");
+    List<String> el = null;
+    try {
+      el =
+          AlertMeta.splitListValues(
+              AlertMeta.Key.SOURCEADDRESSES, a.getMetadataValue(AlertMeta.Key.SOURCEADDRESSES));
+    } catch (IOException exc) {
+      return ret;
+    }
     for (String i : el) {
       CustomsAlert ca = baseAlert(a);
       ca.setSeverity(AlertSeverity.WARNING);
@@ -235,7 +244,13 @@ public class CustomsAlert implements Serializable {
     ret.add(buf);
 
     // Create alert for each account identifier
-    String[] parts = a.getMetadataValue(AlertMeta.Key.EMAIL).split(", ?");
+    List<String> parts = null;
+    try {
+      parts =
+          AlertMeta.splitListValues(AlertMeta.Key.EMAIL, a.getMetadataValue(AlertMeta.Key.EMAIL));
+    } catch (IOException exc) {
+      return ret;
+    }
     for (String i : parts) {
       buf = baseAlert(a);
       buf.setSeverity(AlertSeverity.WARNING);

--- a/src/main/java/com/mozilla/secops/customs/SourceLoginFailure.java
+++ b/src/main/java/com/mozilla/secops/customs/SourceLoginFailure.java
@@ -106,13 +106,9 @@ public class SourceLoginFailure
                         String.format(
                             "%s source login failure threshold exceeded, %s %d in 10 minutes",
                             monitoredResource, addr, cnt));
-                    String buf = "";
+                    ArrayList<String> buf = new ArrayList<>();
                     for (String s : accts) {
-                      if (buf.isEmpty()) {
-                        buf = s;
-                      } else {
-                        buf += ", " + s;
-                      }
+                      buf.add(s);
                     }
                     alert.addMetadata(AlertMeta.Key.EMAIL, buf);
                     c.output(alert);

--- a/src/main/java/com/mozilla/secops/customs/SourceLoginFailureDist.java
+++ b/src/main/java/com/mozilla/secops/customs/SourceLoginFailureDist.java
@@ -100,13 +100,9 @@ public class SourceLoginFailureDist
                             "%s distributed source login failure threshold exceeded for single account"
                                 + ", %d addresses in 10 minutes",
                             monitoredResource, cnt));
-                    String buf = "";
+                    ArrayList<String> buf = new ArrayList<>();
                     for (String s : source) {
-                      if (buf.isEmpty()) {
-                        buf = s;
-                      } else {
-                        buf += ", " + s;
-                      }
+                      buf.add(s);
                     }
                     alert.addMetadata(AlertMeta.Key.SOURCEADDRESSES, buf);
                     c.output(alert);

--- a/src/test/java/com/mozilla/secops/alert/TestAlert.java
+++ b/src/test/java/com/mozilla/secops/alert/TestAlert.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import com.mozilla.secops.Violation;
+import java.util.ArrayList;
 import java.util.UUID;
 import org.joda.time.DateTime;
 import org.junit.Test;
@@ -538,15 +539,28 @@ public class TestAlert {
     // Single type value
     assertTrue(new Alert().addMetadata(AlertMeta.Key.SOURCEADDRESS, "1.2.3.4"));
     assertFalse(new Alert().addMetadata(AlertMeta.Key.SOURCEADDRESS, ""));
-    assertFalse(new Alert().addMetadata(AlertMeta.Key.SOURCEADDRESS, null));
+    assertFalse(new Alert().addMetadata(AlertMeta.Key.SOURCEADDRESS, (String) null));
 
     // List type value
     assertTrue(new Alert().addMetadata(AlertMeta.Key.EMAIL, "a@mozilla.com"));
     assertTrue(new Alert().addMetadata(AlertMeta.Key.EMAIL, "a@mozilla.com, b@mozilla.com"));
     assertTrue(new Alert().addMetadata(AlertMeta.Key.EMAIL, "a@mozilla.com,b@mozilla.com"));
     assertFalse(new Alert().addMetadata(AlertMeta.Key.EMAIL, ""));
-    assertFalse(new Alert().addMetadata(AlertMeta.Key.EMAIL, null));
+    assertFalse(new Alert().addMetadata(AlertMeta.Key.EMAIL, (String) null));
     assertFalse(new Alert().addMetadata(AlertMeta.Key.EMAIL, "a@mozilla.com,,b@mozilla.com"));
+
+    // Single type value, List variant
+    ArrayList<String> buf = new ArrayList<>();
+    buf.add("1.2.3.4");
+    assertFalse(new Alert().addMetadata(AlertMeta.Key.SOURCEADDRESS, buf));
+
+    // List type value, List variant
+    buf = new ArrayList<>();
+    buf.add("a@mozilla.com");
+    buf.add("b@mozilla.com");
+    assertTrue(new Alert().addMetadata(AlertMeta.Key.EMAIL, buf));
+    buf.add("");
+    assertFalse(new Alert().addMetadata(AlertMeta.Key.EMAIL, buf));
 
     // Single type value
     assertTrue(new Alert().setMetadataValue(AlertMeta.Key.SOURCEADDRESS, "1.2.3.4"));

--- a/src/test/java/com/mozilla/secops/alert/TestAlert.java
+++ b/src/test/java/com/mozilla/secops/alert/TestAlert.java
@@ -535,15 +535,30 @@ public class TestAlert {
 
   @Test
   public void testMetaValidator() throws Exception {
-    Alert a = new Alert();
-    assertNotNull(a);
+    // Single type value
+    assertTrue(new Alert().addMetadata(AlertMeta.Key.SOURCEADDRESS, "1.2.3.4"));
+    assertFalse(new Alert().addMetadata(AlertMeta.Key.SOURCEADDRESS, ""));
+    assertFalse(new Alert().addMetadata(AlertMeta.Key.SOURCEADDRESS, null));
 
-    assertTrue(a.addMetadata(AlertMeta.Key.SOURCEADDRESS, "1.2.3.4"));
-    assertFalse(a.addMetadata(AlertMeta.Key.EMAIL, ""));
-    assertFalse(a.addMetadata(AlertMeta.Key.EMAIL, null));
+    // List type value
+    assertTrue(new Alert().addMetadata(AlertMeta.Key.EMAIL, "a@mozilla.com"));
+    assertTrue(new Alert().addMetadata(AlertMeta.Key.EMAIL, "a@mozilla.com, b@mozilla.com"));
+    assertTrue(new Alert().addMetadata(AlertMeta.Key.EMAIL, "a@mozilla.com,b@mozilla.com"));
+    assertFalse(new Alert().addMetadata(AlertMeta.Key.EMAIL, ""));
+    assertFalse(new Alert().addMetadata(AlertMeta.Key.EMAIL, null));
+    assertFalse(new Alert().addMetadata(AlertMeta.Key.EMAIL, "a@mozilla.com,,b@mozilla.com"));
 
-    assertTrue(a.setMetadataValue(AlertMeta.Key.SOURCEADDRESS, "1.2.3.4"));
-    assertFalse(a.setMetadataValue(AlertMeta.Key.EMAIL, ""));
-    assertFalse(a.setMetadataValue(AlertMeta.Key.EMAIL, null));
+    // Single type value
+    assertTrue(new Alert().setMetadataValue(AlertMeta.Key.SOURCEADDRESS, "1.2.3.4"));
+    assertFalse(new Alert().setMetadataValue(AlertMeta.Key.SOURCEADDRESS, ""));
+    assertFalse(new Alert().setMetadataValue(AlertMeta.Key.SOURCEADDRESS, null));
+
+    // List type value
+    assertTrue(new Alert().setMetadataValue(AlertMeta.Key.EMAIL, "a@mozilla.com"));
+    assertTrue(new Alert().setMetadataValue(AlertMeta.Key.EMAIL, "a@mozilla.com, b@mozilla.com"));
+    assertTrue(new Alert().setMetadataValue(AlertMeta.Key.EMAIL, "a@mozilla.com,b@mozilla.com"));
+    assertFalse(new Alert().setMetadataValue(AlertMeta.Key.EMAIL, ""));
+    assertFalse(new Alert().setMetadataValue(AlertMeta.Key.EMAIL, null));
+    assertFalse(new Alert().setMetadataValue(AlertMeta.Key.EMAIL, "a@mozilla.com,,b@mozilla.com"));
   }
 }


### PR DESCRIPTION
Adds specific handling for `LIST` type fields.

Removes areas we were manually assembling and splitting list fields and replace with functions from `AlertMeta`.

Closes #182 