### PR TITLE
pin jackson-dataformat-cbor to jackson.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,11 @@
                 <artifactId>guava</artifactId>
                 <version>25.1-jre</version>
             </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-cbor</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <!-- Direct dependencies are declared here. If the dependency is both


### PR DESCRIPTION
Resolves a conflict with an import used by the AWS SDK.