### PR TITLE
Template with links for amo cloud submission alert

### DIFF
--- a/contrib/common/alertmeta.go
+++ b/contrib/common/alertmeta.go
@@ -88,6 +88,7 @@ const (
 	META_TECHNIQUE                         = "technique"
 	META_TEMPLATE_NAME_EMAIL               = "template_name_email"
 	META_TEMPLATE_NAME_SLACK               = "template_name_slack"
+	META_TEMPLATE_NAME_SLACK_CATCHALL      = "template_name_slack_catchall"
 	META_THRESHOLD                         = "threshold"
 	META_THRESHOLD_MODIFIER                = "threshold_modifier"
 	META_TIME_DELTA_SECONDS                = "time_delta_seconds"

--- a/src/main/java/com/mozilla/secops/alert/Alert.java
+++ b/src/main/java/com/mozilla/secops/alert/Alert.java
@@ -117,28 +117,6 @@ public class Alert implements Serializable {
   }
 
   /**
-   * Set a masked summary in the alert
-   *
-   * <p>Some output transforms will prefer the masked summary to the primary summary field, assuming
-   * the masked summary has sensitive information removed.
-   *
-   * @param maskedSummary Masked summary string
-   */
-  public void setMaskedSummary(String maskedSummary) {
-    addMetadata(AlertMeta.Key.MASKED_SUMMARY, maskedSummary);
-  }
-
-  /**
-   * Get any masked summary value in the alert
-   *
-   * @return Masked summary or null if unset
-   */
-  @JsonIgnore
-  public String getMaskedSummary() {
-    return getMetadataValue(AlertMeta.Key.MASKED_SUMMARY);
-  }
-
-  /**
    * Set alert merge key for notifications in metadata
    *
    * <p>If a merge key is set in metadata for an alert, some output transforms will utilize this key
@@ -445,6 +423,25 @@ public class Alert implements Serializable {
   @JsonIgnore
   public String getSlackTemplate() {
     return getMetadataValue(AlertMeta.Key.TEMPLATE_NAME_SLACK);
+  }
+
+  /**
+   * Set slack catchall template name
+   *
+   * @param templateName Freemarker template name with file extension
+   */
+  public void setSlackCatchallTemplate(String templateName) {
+    addMetadata(AlertMeta.Key.TEMPLATE_NAME_SLACK_CATCHALL, templateName);
+  }
+
+  /**
+   * Get slack catchall template name
+   *
+   * @return Freemarker template name with file extension or null if not set.
+   */
+  @JsonIgnore
+  public String getSlackCatchallTemplate() {
+    return getMetadataValue(AlertMeta.Key.TEMPLATE_NAME_SLACK_CATCHALL);
   }
 
   /**

--- a/src/main/java/com/mozilla/secops/alert/AlertMeta.java
+++ b/src/main/java/com/mozilla/secops/alert/AlertMeta.java
@@ -196,6 +196,7 @@ public class AlertMeta implements Serializable {
     TECHNIQUE("technique"),
     TEMPLATE_NAME_EMAIL("template_name_email"),
     TEMPLATE_NAME_SLACK("template_name_slack"),
+    TEMPLATE_NAME_SLACK_CATCHALL("template_name_slack_catchall"),
     THRESHOLD("threshold"),
     THRESHOLD_MODIFIER("threshold_modifier"),
     TIME_DELTA_SECONDS("time_delta_seconds"),

--- a/src/main/java/com/mozilla/secops/alert/AlertSlack.java
+++ b/src/main/java/com/mozilla/secops/alert/AlertSlack.java
@@ -93,12 +93,17 @@ public class AlertSlack {
   public Boolean sendToCatchall(Alert a) {
     log.info("generating catchall slack for {} (channel id)", cfg.getSlackCatchall());
 
-    String summary = a.getSummary();
-    if (a.getMaskedSummary() != null) {
-      summary = a.getMaskedSummary();
+    String text = String.format("%s (%s)", a.getSummary(), a.getAlertId());
+    if (a.getSlackCatchallTemplate() != null) {
+      try {
+        text =
+            templateManager.processTemplate(
+                a.getSlackCatchallTemplate(), a.generateTemplateVariables());
+      } catch (Exception exc) {
+        log.error("slack template processing failed: {}", exc.getMessage());
+      }
     }
 
-    String text = String.format("%s (%s)", summary, a.getAlertId());
     try {
       return slackManager.handleSlackResponse(
           slackManager.sendMessageToChannel(cfg.getSlackCatchall(), text));

--- a/src/main/java/com/mozilla/secops/amo/AddonCloudSubmission.java
+++ b/src/main/java/com/mozilla/secops/amo/AddonCloudSubmission.java
@@ -82,6 +82,7 @@ public class AddonCloudSubmission extends PTransform<PCollection<Event>, PCollec
                     alert.setCategory("amo");
                     alert.setSubcategory("amo_cloud_submission");
                     alert.setNotifyMergeKey("amo_cloud_submission");
+                    alert.setSlackCatchallTemplate(Amo.SLACK_CATCHALL_TEMPLATE);
                     alert.addMetadata(AlertMeta.Key.PROVIDER, f);
                     alert.addMetadata(AlertMeta.Key.SOURCEADDRESS, d.getRemoteIp());
                     if (d.getAddonGuid() != null) {

--- a/src/main/java/com/mozilla/secops/amo/Amo.java
+++ b/src/main/java/com/mozilla/secops/amo/Amo.java
@@ -31,6 +31,8 @@ import org.apache.beam.sdk.values.PCollectionList;
 public class Amo implements Serializable {
   private static final long serialVersionUID = 1L;
 
+  protected static final String SLACK_CATCHALL_TEMPLATE = "slack/catchall/amo.ftlh";
+
   /**
    * Execute AMO pipeline
    *
@@ -297,6 +299,9 @@ public class Amo implements Serializable {
 
   private static void runAmo(AmoOptions options) throws IOException {
     Pipeline p = Pipeline.create(options);
+
+    // Register slack catchall alert templates
+    options.setOutputAlertTemplates(new String[] {SLACK_CATCHALL_TEMPLATE});
 
     PCollection<String> input =
         p.apply("input", Input.compositeInputAdapter(options, buildConfigurationTick(options)));

--- a/src/main/resources/alert/templates/slack/catchall/amo.ftlh
+++ b/src/main/resources/alert/templates/slack/catchall/amo.ftlh
@@ -1,0 +1,6 @@
+<#if category == "amo_cloud_submission">
+${monitored_resource} cloud provider addon submission from ${sourceaddress}, guid <https://addons-internal.prod.mozaws.net/en-US/admin/models/addons/addon/${addon_guid}/change/|${addon_guid}> isapi ${addon_from_api} user_id <https://addons-internal.prod.mozaws.net/en-US/admin/models/users/userprofile/${addon_user_id}/change/|${addon_user_id}> (${alert.alertId})
+</#if>
+<#if category != "amo_cloud_submission">
+${alert.summary}
+</#if>


### PR DESCRIPTION
Adds support for "catchall" templates, exclusive to slack at the moment.
These will be specifically for templates that are meant to be sent to a
shared email or slack channel rather than individualized alerts (i.e. authprofile)

Fixes #404