### PR TITLE
Use radix tree for CIDR lookup in CidrUtil

### DIFF
--- a/src/main/java/com/mozilla/secops/CidrUtil.java
+++ b/src/main/java/com/mozilla/secops/CidrUtil.java
@@ -181,6 +181,16 @@ public class CidrUtil {
   }
 
   /**
+   * Determine if an address is an IPv4 address
+   *
+   * @param addr Address
+   * @return boolean
+   */
+  public static boolean isInet4(String addr) {
+    return InetAddresses.forString(addr).getAddress().length == 4 ? true : false;
+  }
+
+  /**
    * Strip the mask component from a CIDR subnet.
    *
    * <p>For example, given 192.168.0.0/24 return 192.168.0.0.
@@ -203,8 +213,7 @@ public class CidrUtil {
    * @return True if any loaded subnet contains the address
    */
   public Boolean contains(String addr) {
-    int il = InetAddresses.forString(addr).getAddress().length;
-    if (il == 4) {
+    if (isInet4(addr)) {
       if (inetTree.contains(addr)) {
         return true;
       }
@@ -361,8 +370,7 @@ public class CidrUtil {
     if (addr == null) {
       throw new IllegalArgumentException(String.format("bad format, %s", cidr));
     }
-    int il = InetAddresses.forString(addr).getAddress().length;
-    if (il == 4) {
+    if (isInet4(addr)) {
       inetTree.add(cidr);
     } else {
       subnets.add(new IpAddressMatcher(cidr));

--- a/src/main/java/com/mozilla/secops/InetRadix.java
+++ b/src/main/java/com/mozilla/secops/InetRadix.java
@@ -1,0 +1,137 @@
+package com.mozilla.secops;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
+
+/**
+ * CIDR lookup using radix tree search
+ *
+ * <p>Only supports IPv4.
+ */
+public class InetRadix {
+  private static class Node {
+    public Node l, r, p;
+    public Boolean v;
+
+    Node() {
+      l = r = p = null;
+      v = null;
+    }
+  }
+
+  private static class Tree {
+    Node root;
+
+    private long startBit = 0x80000000L;
+
+    public boolean contains(long ip) {
+      long bit = startBit;
+      Node n = root;
+      boolean ret = false;
+
+      while (n != null) {
+        if (n.v != null) {
+          ret = n.v;
+        }
+        if ((ip & bit) != 0) {
+          n = n.r;
+        } else {
+          n = n.l;
+        }
+        if ((0xffffffffL & bit) == 0) {
+          break;
+        }
+        bit = bit >> 1;
+      }
+      return ret;
+    }
+
+    public void insert(long ip, long mask) {
+      long bit = startBit;
+
+      Node n = root;
+      Node next = n;
+
+      while ((bit & mask) != 0) {
+        if ((ip & bit) != 0) {
+          next = n.r;
+        } else {
+          next = n.l;
+        }
+        if (next == null) {
+          break;
+        }
+        bit = bit >> 1;
+        n = next;
+      }
+
+      if (next != null) {
+        n.v = true;
+        return;
+      }
+
+      while ((bit & mask) != 0) {
+        next = new Node();
+        next.p = n;
+        if ((ip & bit) != 0) {
+          n.r = next;
+        } else {
+          n.l = next;
+        }
+        bit = bit >> 1;
+        n = next;
+      }
+
+      n.v = true;
+    }
+
+    Tree() {
+      root = new Node();
+    }
+  }
+
+  private Tree tree;
+
+  private long longFromString(String ip) {
+    ByteBuffer bb = ByteBuffer.allocate(8);
+    bb.putInt(0);
+    try {
+      bb.put(InetAddress.getByName(ip).getAddress());
+    } catch (UnknownHostException exc) {
+      throw new IllegalArgumentException(exc.getMessage());
+    }
+    bb.rewind();
+    return bb.getLong();
+  }
+
+  /**
+   * Determine if tree contains a subnet that would contain IP
+   *
+   * @param ip IP address
+   * @return True if tree contained subnet that contains IP
+   */
+  public boolean contains(String ip) {
+    return tree.contains(longFromString(ip));
+  }
+
+  /**
+   * Add IPv4 CIDR subnet to tree
+   *
+   * @param cidr CIDR subnet specification
+   */
+  public void add(String cidr) {
+    int i = cidr.indexOf("/");
+    String ip = cidr.substring(0, i);
+    int m = Integer.parseInt(cidr.substring(i + 1));
+
+    long mask = ((1L << (32 - m)) - 1L) ^ 0xffffffffL;
+
+    tree.insert(longFromString(ip), mask);
+  }
+
+  /** Create new InetRadix */
+  InetRadix() {
+    tree = new Tree();
+  }
+}

--- a/src/test/java/com/mozilla/secops/BenchCidrUtil.java
+++ b/src/test/java/com/mozilla/secops/BenchCidrUtil.java
@@ -1,0 +1,30 @@
+package com.mozilla.secops;
+
+import static org.junit.Assert.*;
+
+import com.carrotsearch.junitbenchmarks.BenchmarkOptions;
+import com.carrotsearch.junitbenchmarks.BenchmarkRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+public class BenchCidrUtil {
+  @Rule public TestRule benchmarkRun = new BenchmarkRule();
+
+  @BenchmarkOptions(benchmarkRounds = 20, warmupRounds = 5)
+  @Test
+  public void benchmarkContains() throws Exception {
+    CidrUtil c = new CidrUtil();
+
+    // We could use loadInternalSubnets, but load a bunch manually here so the
+    // size of the list is larger.
+    for (int i = 0; i < 254; i++) {
+      c.add(String.format("192.168.%d.0/24", i));
+      c.add(String.format("10.0.%d.0/24", i));
+    }
+
+    for (int i = 0; i < 15000; i++) {
+      c.contains("172.16.10.1");
+    }
+  }
+}

--- a/src/test/java/com/mozilla/secops/TestInetRadix.java
+++ b/src/test/java/com/mozilla/secops/TestInetRadix.java
@@ -28,5 +28,89 @@ public class TestInetRadix {
     assertTrue(r.contains("1.255.255.255"));
     assertTrue(r.contains("192.168.10.1"));
     assertTrue(r.contains("192.168.10.15"));
+
+    r = new InetRadix();
+
+    assertFalse(r.contains("1.2.3.3"));
+    assertFalse(r.contains("1.2.3.4"));
+    assertFalse(r.contains("1.2.3.5"));
+    r.add("1.2.3.4/32");
+    assertFalse(r.contains("1.2.3.3"));
+    assertTrue(r.contains("1.2.3.4"));
+    assertFalse(r.contains("1.2.3.5"));
+    r.add("1.2.3.4/30");
+    assertFalse(r.contains("1.2.3.3"));
+    assertTrue(r.contains("1.2.3.4"));
+    assertTrue(r.contains("1.2.3.5"));
+    assertTrue(r.contains("1.2.3.6"));
+    assertTrue(r.contains("1.2.3.7"));
+    assertFalse(r.contains("1.2.3.8"));
+
+    r.add("1.2.4.4/30");
+    assertFalse(r.contains("1.2.3.3"));
+    assertTrue(r.contains("1.2.3.4"));
+    assertTrue(r.contains("1.2.3.5"));
+    assertTrue(r.contains("1.2.3.6"));
+    assertTrue(r.contains("1.2.3.7"));
+    assertFalse(r.contains("1.2.3.8"));
+    assertFalse(r.contains("1.2.4.3"));
+    assertTrue(r.contains("1.2.4.4"));
+    assertTrue(r.contains("1.2.4.5"));
+    assertTrue(r.contains("1.2.4.6"));
+    assertTrue(r.contains("1.2.4.7"));
+    assertFalse(r.contains("1.2.4.8"));
+    r.add("1.2.4.4/32");
+    assertFalse(r.contains("1.2.3.3"));
+    assertTrue(r.contains("1.2.3.4"));
+    assertTrue(r.contains("1.2.3.5"));
+    assertTrue(r.contains("1.2.3.6"));
+    assertTrue(r.contains("1.2.3.7"));
+    assertFalse(r.contains("1.2.3.8"));
+    assertFalse(r.contains("1.2.4.3"));
+    assertTrue(r.contains("1.2.4.4"));
+    assertTrue(r.contains("1.2.4.5"));
+    assertTrue(r.contains("1.2.4.6"));
+    assertTrue(r.contains("1.2.4.7"));
+    assertFalse(r.contains("1.2.4.8"));
+
+    r = new InetRadix();
+    r.add("1.0.0.0/24");
+    r.add("1.0.0.1/24");
+    r.add("1.0.0.2/24");
+    assertTrue(r.contains("1.0.0.0"));
+    assertTrue(r.contains("1.0.0.1"));
+    assertTrue(r.contains("1.0.0.2"));
+    assertTrue(r.contains("1.0.0.200"));
+    assertFalse(r.contains("1.0.1.0"));
+
+    r = new InetRadix();
+    r.add("10.0.0.0/16");
+    r.add("10.2.0.0/16");
+    r.add("10.4.0.0/16");
+    r.add("10.6.0.0/16");
+    r.add("10.8.0.0/16");
+    r.add("10.10.0.0/16");
+    r.add("10.12.0.0/16");
+    r.add("10.14.0.0/16");
+    r.add("10.16.0.0/16");
+    r.add("10.18.0.0/16");
+    r.add("10.20.0.0/24");
+    r.add("10.22.0.0/24");
+    r.add("10.24.0.0/24");
+    r.add("10.26.0.0/24");
+    r.add("10.28.0.0/24");
+
+    assertTrue(r.contains("10.0.0.1"));
+    assertFalse(r.contains("10.1.0.1"));
+    assertTrue(r.contains("10.2.0.1"));
+    assertFalse(r.contains("10.3.0.1"));
+    assertTrue(r.contains("10.4.0.1"));
+    assertFalse(r.contains("10.5.0.1"));
+    assertTrue(r.contains("10.6.0.1"));
+    assertFalse(r.contains("10.7.0.1"));
+    assertTrue(r.contains("10.8.0.1"));
+
+    assertTrue(r.contains("10.24.0.200"));
+    assertFalse(r.contains("10.24.1.200"));
   }
 }

--- a/src/test/java/com/mozilla/secops/TestInetRadix.java
+++ b/src/test/java/com/mozilla/secops/TestInetRadix.java
@@ -1,0 +1,32 @@
+package com.mozilla.secops;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class TestInetRadix {
+  @Test
+  public void testLookup() throws Exception {
+    InetRadix r = new InetRadix();
+
+    r.add("192.168.0.0/24");
+    r.add("10.10.10.10/32");
+    r.add("1.0.0.0/8");
+    r.add("192.168.10.0/28");
+
+    assertFalse(r.contains("10.0.0.1"));
+    assertFalse(r.contains("192.168.1.1"));
+    assertFalse(r.contains("10.10.10.9"));
+    assertFalse(r.contains("10.10.10.11"));
+    assertFalse(r.contains("255.255.255.255"));
+    assertFalse(r.contains("0.0.0.0"));
+    assertFalse(r.contains("192.168.10.16"));
+
+    assertTrue(r.contains("192.168.0.10"));
+    assertTrue(r.contains("10.10.10.10"));
+    assertTrue(r.contains("1.0.0.1"));
+    assertTrue(r.contains("1.255.255.255"));
+    assertTrue(r.contains("192.168.10.1"));
+    assertTrue(r.contains("192.168.10.15"));
+  }
+}


### PR DESCRIPTION
CidrUtil is currently very inefficient in the sense for each check, it walks a flat list from beginning to end to see if an IP address matches any configured subnet. This issue manifests itself the most when combined with the parser, where we apply a check for every single event.

Convert inet4 lookups to make use of a radix tree which increases the performance of these methods by orders of magnitude.