### PR TITLE
default alert suppression duration toggle

### DIFF
--- a/src/main/java/com/mozilla/secops/httprequest/HTTPRequestToggles.java
+++ b/src/main/java/com/mozilla/secops/httprequest/HTTPRequestToggles.java
@@ -935,6 +935,7 @@ public class HTTPRequestToggles {
 
     endpointAbuseExtendedVariance = false;
     sessionGapDurationMinutes = 45L;
+    alertSuppressionDurationSeconds = 600L;
 
     ignoreCloudProviderRequests = true;
     ignoreInternalRequests = true;


### PR DESCRIPTION
We set a default for the pipeline options; also set a default in the
toggles for multimode use cases.