### PR TITLE
handle AMO log messages with empty address field

### DIFF
--- a/src/main/java/com/mozilla/secops/parser/AmoDocker.java
+++ b/src/main/java/com/mozilla/secops/parser/AmoDocker.java
@@ -214,6 +214,15 @@ public class AmoDocker extends SourcePayloadBase implements Serializable {
         || (amoData.getUid() == null)) {
       return;
     }
+
+    // AMO can send log messages with the remote address field set to an empty string,
+    // if this happens just stop here and don't classify the event. Also set the value in
+    // the data set to null.
+    if (amoData.getRemoteAddressChain().isEmpty()) {
+      amoData.setRemoteAddressChain(null);
+      return;
+    }
+
     // Set source address; pass null for the normalized component since we don't want to
     // set the fields in there for this event type
     setSourceAddress(amoData.getRemoteAddressChain(), state, null);

--- a/src/main/java/com/mozilla/secops/parser/models/amo/Amo.java
+++ b/src/main/java/com/mozilla/secops/parser/models/amo/Amo.java
@@ -48,11 +48,20 @@ public class Amo implements Serializable {
   }
 
   /**
+   * Set remoteAddressChain
+   *
+   * @param remoteAddressChain String
+   */
+  @JsonProperty("remoteAddressChain")
+  public void setRemoteAddressChain(String remoteAddressChain) {
+    this.remoteAddressChain = remoteAddressChain;
+  }
+
+  /**
    * Get remoteAddressChain
    *
    * @return String
    */
-  @JsonProperty("remoteAddressChain")
   public String getRemoteAddressChain() {
     return remoteAddressChain;
   }


### PR DESCRIPTION
If a log message is received with an empty address field, don't classify
it and set it to null in the underlying model.