### PR TITLE
exclude 429 from per endpoint error rate analysis and escalate to iprepd

### DIFF
--- a/docker/iprepd.yaml
+++ b/docker/iprepd.yaml
@@ -24,6 +24,27 @@ violations:
     penalty: 100
   - name: hard_limit_violation
     penalty: 10
+  - name: violation5
+    penalty: 5
+    decreaselimit: 0
+  - name: violation10
+    penalty: 10
+    decreaselimit: 0
+  - name: violation20
+    penalty: 20
+    decreaselimit: 0
+  - name: violation25
+    penalty: 25
+    decreaselimit: 0
+  - name: violation50
+    penalty: 50
+    decreaselimit: 0
+  - name: violation75
+    penalty: 75
+    decreaselimit: 0
+  - name: violation100
+    penalty: 100
+    decreaselimit: 0
 decay:
   points: 0
   interval: 1s

--- a/src/main/java/com/mozilla/secops/Violation.java
+++ b/src/main/java/com/mozilla/secops/Violation.java
@@ -63,6 +63,12 @@ public class Violation {
       public String toString() {
         return "abusive_account_violation";
       }
+    },
+    PER_ENDPOINT_ERROR_RATE_VIOLATION {
+      @Override
+      public String toString() {
+        return "violation75";
+      }
     }
   }
 
@@ -175,6 +181,9 @@ public class Violation {
         "useragent_blacklist",
         new GenericSourceViolationGenerator(ViolationType.USERAGENT_BLACKLIST_VIOLATION));
     vMap.put("hard_limit", new GenericSourceViolationGenerator(ViolationType.HARD_LIMIT_VIOLATION));
+    vMap.put(
+        "per_endpoint_error_rate",
+        new GenericSourceViolationGenerator(ViolationType.PER_ENDPOINT_ERROR_RATE_VIOLATION));
 
     // Customs
     vMap.put(

--- a/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
+++ b/src/main/java/com/mozilla/secops/httprequest/HTTPRequest.java
@@ -1384,7 +1384,7 @@ public class HTTPRequest implements Serializable {
       this.enableIprepdDatastoreWhitelist = enableIprepdDatastoreWhitelist;
       this.iprepdDatastoreWhitelistProject = iprepdDatastoreWhitelistProject;
       this.suppressRecovery = toggles.getPerEndpointErrorRateSuppressRecovery();
-      this.sessionGapDurationMinutes = toggles.getSessionGapDurationMinutes();
+      this.sessionGapDurationMinutes = toggles.getErrorSessionGapDurationMinutes();
       this.alertSuppressionDurationSeconds =
           toggles.getPerEndpointErrorRateAlertSuppressionDurationSeconds();
 
@@ -1569,10 +1569,7 @@ public class HTTPRequest implements Serializable {
     }
   }
 
-  /**
-   * Function to be used with filter transform in order to exclude any events that do not have a
-   * request status in the 400s
-   */
+  /** Function to be used with filter transform in order to include only client errors */
   public static class Has4xxRequestStatus implements SerializableFunction<Event, Boolean> {
     private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
1) Adds escalation to iprepd using the generic violations.
2) Excludes 429s from the error session as these requests were already blocked.

fixes #427 