### PR TITLE
improve handling of null input value

### DIFF
--- a/src/main/java/com/mozilla/secops/parser/Auth0.java
+++ b/src/main/java/com/mozilla/secops/parser/Auth0.java
@@ -25,6 +25,7 @@ public class Auth0 extends SourcePayloadBase implements Serializable {
   private LogEvent event;
 
   private static ArrayList<String> AuthTypes;
+  private static JacksonFactory jfmatcher = new JacksonFactory();
 
   // List of auth0 type codes that are auth events
   // https://auth0.com/docs/logs#log-data-event-listing
@@ -170,7 +171,6 @@ public class Auth0 extends SourcePayloadBase implements Serializable {
   private LogEvent parseInput(String input) throws IOException {
     JsonParser jp = null;
     try {
-      JacksonFactory jfmatcher = new JacksonFactory();
       jp = jfmatcher.createJsonParser(input);
       LogEntry entry = jp.parse(LogEntry.class);
       Map<String, Object> m = entry.getJsonPayload();
@@ -191,6 +191,9 @@ public class Auth0 extends SourcePayloadBase implements Serializable {
 
     try {
       LogEvent _event = mapper.readValue(input, LogEvent.class);
+      if (_event == null) {
+        return null;
+      }
       if (_event.getClientId() != null) {
         return _event;
       }

--- a/src/main/java/com/mozilla/secops/parser/Duopull.java
+++ b/src/main/java/com/mozilla/secops/parser/Duopull.java
@@ -30,6 +30,9 @@ public class Duopull extends SourcePayloadBase implements Serializable {
     } catch (IOException exc) {
       return false;
     }
+    if (d == null) {
+      return false;
+    }
     String msg = d.getMsg();
     if (msg != null && msg.equals("duopull event")) {
       return true;

--- a/src/main/java/com/mozilla/secops/parser/Parser.java
+++ b/src/main/java/com/mozilla/secops/parser/Parser.java
@@ -268,6 +268,15 @@ public class Parser {
       jp = jf.createJsonParser(input);
       LogEntry entry = jp.parse(LogEntry.class);
 
+      // For us to consider this a valid Stackdriver log entry, we need to have either the
+      // textPayload, jsonPayload, or protoPayload value set. If none of these are set, just
+      // return the value as is.
+      if ((entry.getTextPayload() == null)
+          && (entry.getJsonPayload() == null)
+          && (entry.getProtoPayload() == null)) {
+        return input;
+      }
+
       e.setStackdriverProject(getStackdriverProject(entry));
       e.setStackdriverLabels(entry.getLabels());
       if (entry.getTimestamp() != null) {
@@ -351,7 +360,8 @@ public class Parser {
   private String stripCloudWatch(Event e, String input, ParserState state) {
     try {
       CloudWatchEvent cwe = mapper.readValue(input, CloudWatchEvent.class);
-      if (cwe.getDetail() == null || cwe.getDetailType() == null || cwe.getAccount() == null) {
+      if ((cwe == null)
+          || (cwe.getDetail() == null || cwe.getDetailType() == null || cwe.getAccount() == null)) {
         return input;
       }
       state.setCloudWatchEvent(cwe);

--- a/src/main/java/com/mozilla/secops/parser/models/cloudtrail/CloudtrailEvent.java
+++ b/src/main/java/com/mozilla/secops/parser/models/cloudtrail/CloudtrailEvent.java
@@ -1,5 +1,6 @@
 package com.mozilla.secops.parser.models.cloudtrail;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
 import java.util.HashMap;
@@ -10,6 +11,7 @@ import java.util.HashMap;
  * <p>Read about Cloudtrail events here:
  * https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-event-reference-record-contents.html
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class CloudtrailEvent implements Serializable {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/mozilla/secops/parser/models/cloudtrail/SessionContext.java
+++ b/src/main/java/com/mozilla/secops/parser/models/cloudtrail/SessionContext.java
@@ -1,10 +1,12 @@
 package com.mozilla.secops.parser.models.cloudtrail;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import java.io.Serializable;
 import java.util.HashMap;
 
 /** Model for sessionContext element in Cloudtrail Events */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class SessionContext implements Serializable {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/mozilla/secops/parser/models/cloudtrail/UserIdentity.java
+++ b/src/main/java/com/mozilla/secops/parser/models/cloudtrail/UserIdentity.java
@@ -1,5 +1,6 @@
 package com.mozilla.secops.parser.models.cloudtrail;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import java.io.Serializable;
 
@@ -9,6 +10,7 @@ import java.io.Serializable;
  * <p>Read about the UserIdentity record here:
  * https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-event-reference-user-identity.html
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class UserIdentity implements Serializable {
   private static final long serialVersionUID = 1L;
 

--- a/src/test/java/com/mozilla/secops/parser/ParserTest.java
+++ b/src/test/java/com/mozilla/secops/parser/ParserTest.java
@@ -65,6 +65,21 @@ public class ParserTest {
   }
 
   @Test
+  public void testParseJsonNull() throws Exception {
+    // The string "null" is valid JSON and represents a null object. Ensure proper handling
+    // of this case.
+    String buf = "null";
+    Parser p = getTestParser();
+    assertNotNull(p);
+    Event e = p.parse(buf);
+    assertNotNull(p);
+    assertEquals(Payload.PayloadType.RAW, e.getPayloadType());
+    Raw r = e.getPayload();
+    assertNotNull(r);
+    assertEquals("null", r.getRaw());
+  }
+
+  @Test
   public void testParseRaw() throws Exception {
     Parser p = getTestParser();
     assertNotNull(p);


### PR DESCRIPTION
The string null is considered valid JSON input, and when processed by
jackson will return null from readValue() and will not trigger any sort
of JSON processing exception.

This causes problems in certain parsers that expect a non-null result if
the JSON parsing method does not throw an exception.

This change adds a test case for this scenario and adjusts the impacted
parsers.

In addition,

- Avoid reallocation of JacksonFactory for each CloudTrail message.
- Make sure relevant data is present while processing the Stackdriver
  header before we begin setting hints in parser state.

Based on #435 