### PR TITLE
Make alert category in bmo manager env unique

### DIFF
--- a/contrib/bugzilla-alert-manager/manager_test.go
+++ b/contrib/bugzilla-alert-manager/manager_test.go
@@ -169,7 +169,7 @@ func createMockServer(t *testing.T) *httptest.Server {
 			err = json.Unmarshal(body, cb)
 			assert.NoError(t, err)
 			assert.Equal(t, cb.Product, "TEST_PRODUCT")
-			assert.Contains(t, cb.Summary, "gatekeeper:aws alerts")
+			assert.Contains(t, cb.Summary, "gatekeeper:aws-dev alerts")
 			assert.Contains(t, cb.Description, "lowtestunique")
 			assert.NotContains(t, cb.Description, "hightestunique")
 			assert.Equal(t, cb.Blocks, "123")
@@ -212,6 +212,7 @@ func TestBugzillaAlertManager(t *testing.T) {
 	client := pagerduty.NewClient("testkey", pagerduty.WithAPIEndpoint(server.URL))
 	globals.pagerdutyClient = client
 	globals.bugzillaClient = common.NewBugzillaClient(config.BugzillaConfig, server.URL)
+	globals.environment = config.Environment
 
 	// Start test with high sev
 	err = BugzillaAlertManager(ctx, generateHighSevTestAlert())

--- a/contrib/bugzilla-alert-manager/test_config.yaml
+++ b/contrib/bugzilla-alert-manager/test_config.yaml
@@ -1,5 +1,6 @@
+env: "dev"
 pagerduty_ticket_duty_schedule_id: "1"
 bugzilla_config:
     product: "TEST_PRODUCT"
     category_to_tracker:
-        gatekeeper:aws: "123"
+        gatekeeper:aws-dev: "123"

--- a/contrib/common/configuration.go
+++ b/contrib/common/configuration.go
@@ -21,6 +21,8 @@ import (
 // either a local file or from GCS. If it is encrypted with sops, it will
 // decrypt it.
 type Configuration struct {
+	Environment string `yaml:"env,omitempty"`
+
 	AwsAccessKeyId     string `yaml:"aws_access_key_id"`
 	AwsSecretAccessKey string `yaml:"aws_secret_access_key"`
 	AwsRegion          string `yaml:"aws_region"`


### PR DESCRIPTION
Append the env to the alert category in bmo alert manager so that the
alert is marked correctly and routed correctly.