### PR TITLE
Reopen bugs with status 'REOPENED' in bmo manager

### DIFF
--- a/contrib/bugzilla-alert-manager/manager.go
+++ b/contrib/bugzilla-alert-manager/manager.go
@@ -152,7 +152,7 @@ func BugzillaAlertManager(ctx context.Context, psmsg pubsub.Message) error {
 				contextLogger.Infof("Adding %s to bugzilla bug %d", alert.Id, newestBug.Id)
 				// If bug is closed, re-open
 				if !newestBug.IsOpen {
-					err := globals.bugzillaClient.UpdateBug(newestBug.Id, &common.UpdateBugReq{Status: common.ASSIGNED})
+					err := globals.bugzillaClient.UpdateBug(newestBug.Id, &common.UpdateBugReq{Status: common.REOPENED})
 					if err != nil {
 						log.Errorf("Error re-opening closed bug: %s", err)
 					}

--- a/contrib/bugzilla-alert-manager/manager_test.go
+++ b/contrib/bugzilla-alert-manager/manager_test.go
@@ -155,7 +155,7 @@ func createMockServer(t *testing.T) *httptest.Server {
 		ub := &common.UpdateBugReq{}
 		err = json.Unmarshal(body, ub)
 		assert.NoError(t, err)
-		assert.Equal(t, ub.Status, common.ASSIGNED)
+		assert.Equal(t, ub.Status, common.REOPENED)
 	})
 
 	// Bugzilla Bug Mock

--- a/contrib/common/bugzilla.go
+++ b/contrib/common/bugzilla.go
@@ -219,6 +219,7 @@ type UpdateBugReq struct {
 }
 
 const ASSIGNED = "ASSIGNED"
+const REOPENED = "REOPENED"
 
 func (bc *BugzillaClient) UpdateBug(bugId int, updateReq *UpdateBugReq) error {
 	updateJson, err := json.Marshal(updateReq)


### PR DESCRIPTION
Fixes #355

Example: https://bugzilla.mozilla.org/show_bug.cgi?id=1650780#a24931_610245