### PR TITLE
implement deferred geo attribute resolution

### DIFF
--- a/src/main/java/com/mozilla/secops/InputOptions.java
+++ b/src/main/java/com/mozilla/secops/InputOptions.java
@@ -72,6 +72,12 @@ public interface InputOptions extends PipelineOptions, PubsubOptions, GcpOptions
 
   void setMaxmindIspDbPath(String value);
 
+  @Description("Defer GeoIP resolution until lookup in parser")
+  @Default.Boolean(false)
+  Boolean getDeferGeoIpResolution();
+
+  void setDeferGeoIpResolution(Boolean value);
+
   @Description("Enable XFF address selector; comma delimited list of trusted CIDR format subnets")
   String getXffAddressSelector();
 

--- a/src/main/java/com/mozilla/secops/parser/GeoIP.java
+++ b/src/main/java/com/mozilla/secops/parser/GeoIP.java
@@ -9,6 +9,7 @@ import com.maxmind.geoip2.model.IspResponse;
 import com.mozilla.secops.FileUtil;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Serializable;
 import java.net.InetAddress;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -24,6 +25,223 @@ public class GeoIP {
 
   private static final int CACHE_MAX_SIZE = 16384;
   private static final int EXPIRY_MINUTES = 15;
+
+  /**
+   * Helper class for storing GeoIP related attributes, and for resolving the attributes according
+   * to the resolution mode.
+   *
+   * <p>Objects of this type can integrate heavily with the parser and parser state in order to make
+   * use of previously initialized GeoIP classes. In cases where deferred lookups are being used,
+   * this class will initialize a new GeoIP object using the configuration parameters stored in the
+   * parser configuration for the lookup operation. Because most members of the GeoIP are static and
+   * synchronized, the performance impact associated with this should be minimal.
+   */
+  public static class GeoIPData implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * The resolution mode for GeoIP attributes.
+     *
+     * <p>If set to ON_CREATION, geo-location for IP address values will be performed when the
+     * source address field is set in this object.
+     *
+     * <p>If set to DEFERRED, the resolution will not actually occur until a geo-IP related value is
+     * read for the first time. DEFERRED mode can be useful if the geo-IP data is not actually
+     * required to be created at the onset of event creation.
+     */
+    public enum GeoResolutionMode {
+      /** Attempt geo-IP resolution on source address set */
+      ON_CREATION,
+      /** Attempt geo-IP resolution only when a geo-IP related field is read for the first time. */
+      DEFERRED
+    }
+
+    private GeoResolutionMode resolutionMode;
+    private boolean resolutionGeoSet = false;
+
+    private String sourceAddress;
+    private String sourceAddressCity;
+    private String sourceAddressCountry;
+    private Double sourceAddressLatitude;
+    private Double sourceAddressLongitude;
+    private String sourceTimeZone;
+    private String sourceAddressIsp;
+    private Integer sourceAddressAsn;
+    private String sourceAddressAsOrg;
+
+    private String maxmindCityDbPath;
+    private String maxmindIspDbPath;
+
+    private void resolve(GeoIP geoIp) {
+      if (resolutionGeoSet) {
+        // If we have already resolved the data, just return.
+        return;
+      }
+
+      if (geoIp == null) {
+        // If no GeoIP object was provided, initialize a new one using the previously
+        // cached configuration values.
+        geoIp = new GeoIP(maxmindCityDbPath, maxmindIspDbPath);
+      }
+
+      CityResponse cr = geoIp.lookupCity(sourceAddress);
+      if (cr != null) {
+        // Note that even with a valid response, sometimes the city and country fields we want can
+        // be returned as empty strings. If we see empty strings here treat them the same as if
+        // they
+        // were null. Also do the same for the ISP related lookups.
+        if (cr.getCity() != null) {
+          if (cr.getCity().getName() != null && !cr.getCity().getName().isEmpty()) {
+            sourceAddressCity = cr.getCity().getName();
+          }
+        }
+        if (cr.getCountry() != null) {
+          if (cr.getCountry().getIsoCode() != null && !cr.getCountry().getIsoCode().isEmpty()) {
+            sourceAddressCountry = cr.getCountry().getIsoCode();
+          }
+        }
+
+        if ((cr.getLocation() != null)
+            && (cr.getLocation().getLatitude() != null)
+            && (cr.getLocation().getLongitude() != null)) {
+          sourceAddressLatitude = cr.getLocation().getLatitude();
+          sourceAddressLongitude = cr.getLocation().getLongitude();
+
+          if (cr.getLocation().getTimeZone() != null && !cr.getLocation().getTimeZone().isEmpty()) {
+            sourceTimeZone = cr.getLocation().getTimeZone();
+          }
+        }
+      }
+
+      IspResponse ir = geoIp.lookupIsp(sourceAddress);
+      if (ir != null) {
+        if (ir.getIsp() != null && !ir.getIsp().isEmpty()) {
+          sourceAddressIsp = ir.getIsp();
+        }
+        sourceAddressAsn = ir.getAutonomousSystemNumber();
+        if (ir.getAutonomousSystemOrganization() != null
+            && !ir.getAutonomousSystemOrganization().isEmpty()) {
+          sourceAddressAsOrg = ir.getAutonomousSystemOrganization();
+        }
+      }
+
+      resolutionGeoSet = true;
+    }
+
+    /**
+     * Set source address field
+     *
+     * @param sourceAddress Source address
+     * @param resolutionMode The GeoIP resolution mode to use
+     * @param state Parser state
+     */
+    public void setSourceAddress(
+        String sourceAddress, GeoResolutionMode resolutionMode, ParserState state) {
+      this.sourceAddress = sourceAddress;
+      this.resolutionMode = resolutionMode;
+      if (resolutionMode.equals(GeoResolutionMode.ON_CREATION)) {
+        // If we are set to ON_CREATION, attempt geo-ip resolution immediately using the supplied
+        // parser state
+        resolve(state.getGeoIp());
+      } else {
+        // Otherwise, obtain the configuration parameters for Maxmind from the parser state so we
+        // can reuse them later. Generally the actually database fetch will not occur as the GeoIP
+        // object members usually would have already initialized, since it's shared amongst
+        // threads.
+        maxmindCityDbPath = state.getMaxmindCityDbPath();
+        maxmindIspDbPath = state.getMaxmindIspDbPath();
+      }
+    }
+
+    /**
+     * Get source address set in this GeoIPData object
+     *
+     * @return String
+     */
+    public String getSourceAddress() {
+      return sourceAddress;
+    }
+
+    /**
+     * Get source address city
+     *
+     * @return Source address city field or null if unset
+     */
+    public String getSourceAddressCity() {
+      resolve(null);
+      return sourceAddressCity;
+    }
+
+    /**
+     * Get source address country
+     *
+     * @return Source address country field or null if unset
+     */
+    public String getSourceAddressCountry() {
+      resolve(null);
+      return sourceAddressCountry;
+    }
+
+    /**
+     * Get source address latitude
+     *
+     * @return Latitude or null if unset
+     */
+    public Double getSourceAddressLatitude() {
+      resolve(null);
+      return sourceAddressLatitude;
+    }
+
+    /**
+     * Get source address longitude
+     *
+     * @return Longitude or null if unset
+     */
+    public Double getSourceAddressLongitude() {
+      resolve(null);
+      return sourceAddressLongitude;
+    }
+
+    /**
+     * Get source address time zone
+     *
+     * @return Time zone or null if unset
+     */
+    public String getSourceAddressTimeZone() {
+      resolve(null);
+      return sourceTimeZone;
+    }
+
+    /**
+     * Get source address ISP
+     *
+     * @return ISP or null if unset
+     */
+    public String getSourceAddressIsp() {
+      resolve(null);
+      return sourceAddressIsp;
+    }
+
+    /**
+     * Get source address ASN
+     *
+     * @return ASN or null if unset
+     */
+    public Integer getSourceAddressAsn() {
+      resolve(null);
+      return sourceAddressAsn;
+    }
+
+    /**
+     * Get source address AS organization
+     *
+     * @return AS organization or null if unset
+     */
+    public String getSourceAddressAsOrg() {
+      resolve(null);
+      return sourceAddressAsOrg;
+    }
+  }
 
   /**
    * Lookup city/country from IP address string

--- a/src/main/java/com/mozilla/secops/parser/Normalized.java
+++ b/src/main/java/com/mozilla/secops/parser/Normalized.java
@@ -23,14 +23,7 @@ public class Normalized implements Serializable {
 
   private String subjectUser;
   private String sourceAddress;
-  private String sourceAddressCity;
-  private String sourceAddressCountry;
-  private Double sourceAddressLatitude;
-  private Double sourceAddressLongitude;
-  private String sourceAddressTimeZone;
-  private String sourceAddressIsp;
-  private Integer sourceAddressAsn;
-  private String sourceAddressAsOrg;
+  private GeoIP.GeoIPData geoIpData;
   private Double sourceAddressRiskScore;
   private Boolean sourceAddressIsAnonymous;
   private Boolean sourceAddressIsAnonymousVpn;
@@ -52,6 +45,7 @@ public class Normalized implements Serializable {
 
   Normalized() {
     types = EnumSet.noneOf(Type.class);
+    geoIpData = new GeoIP.GeoIPData();
   }
 
   /**
@@ -133,9 +127,25 @@ public class Normalized implements Serializable {
    * Set source address field
    *
    * @param addr Source address
+   * @param state Parser state
+   */
+  public void setSourceAddress(String addr, ParserState state) {
+    sourceAddress = addr;
+
+    GeoIP.GeoIPData.GeoResolutionMode mode = GeoIP.GeoIPData.GeoResolutionMode.ON_CREATION;
+    if (state != null && state.getDeferGeoIpResolution()) {
+      mode = GeoIP.GeoIPData.GeoResolutionMode.DEFERRED;
+    }
+    geoIpData.setSourceAddress(sourceAddress, mode, state);
+  }
+
+  /**
+   * Set source address field
+   *
+   * @param addr Source address
    */
   public void setSourceAddress(String addr) {
-    sourceAddress = addr;
+    setSourceAddress(addr, null);
   }
 
   /**
@@ -193,21 +203,12 @@ public class Normalized implements Serializable {
   }
 
   /**
-   * Set source address city field
-   *
-   * @param sourceAddressCity City string value
-   */
-  public void setSourceAddressCity(String sourceAddressCity) {
-    this.sourceAddressCity = sourceAddressCity;
-  }
-
-  /**
    * Get source address city field
    *
    * @return Source address city string
    */
   public String getSourceAddressCity() {
-    return sourceAddressCity;
+    return geoIpData.getSourceAddressCity();
   }
 
   /**
@@ -216,16 +217,7 @@ public class Normalized implements Serializable {
    * @return Source address country string
    */
   public String getSourceAddressCountry() {
-    return sourceAddressCountry;
-  }
-
-  /**
-   * Set source address country field
-   *
-   * @param sourceAddressCountry Country string value
-   */
-  public void setSourceAddressCountry(String sourceAddressCountry) {
-    this.sourceAddressCountry = sourceAddressCountry;
+    return geoIpData.getSourceAddressCountry();
   }
 
   /**
@@ -234,16 +226,7 @@ public class Normalized implements Serializable {
    * @return Source address time zone, or null if not present
    */
   public String getSourceAddressTimeZone() {
-    return sourceAddressTimeZone;
-  }
-
-  /**
-   * Set source address time zone field
-   *
-   * @param sourceAddressTimeZone IANA time zone string, e.g., Europe/London
-   */
-  public void setSourceAddressTimeZone(String sourceAddressTimeZone) {
-    this.sourceAddressTimeZone = sourceAddressTimeZone;
+    return geoIpData.getSourceAddressTimeZone();
   }
 
   /**
@@ -252,16 +235,7 @@ public class Normalized implements Serializable {
    * @return Source address latitude
    */
   public Double getSourceAddressLatitude() {
-    return sourceAddressLatitude;
-  }
-
-  /**
-   * Set source address latitude
-   *
-   * @param sourceAddressLatitude Latitude value
-   */
-  void setSourceAddressLatitude(Double sourceAddressLatitude) {
-    this.sourceAddressLatitude = sourceAddressLatitude;
+    return geoIpData.getSourceAddressLatitude();
   }
 
   /**
@@ -270,25 +244,7 @@ public class Normalized implements Serializable {
    * @return Source address longitude
    */
   public Double getSourceAddressLongitude() {
-    return sourceAddressLongitude;
-  }
-
-  /**
-   * Set source address longitude
-   *
-   * @param sourceAddressLongitude Longitude value
-   */
-  void setSourceAddressLongitude(Double sourceAddressLongitude) {
-    this.sourceAddressLongitude = sourceAddressLongitude;
-  }
-
-  /**
-   * Set source address ISP
-   *
-   * @param sourceAddressIsp ISP
-   */
-  public void setSourceAddressIsp(String sourceAddressIsp) {
-    this.sourceAddressIsp = sourceAddressIsp;
+    return geoIpData.getSourceAddressLongitude();
   }
 
   /**
@@ -297,16 +253,7 @@ public class Normalized implements Serializable {
    * @return ISP string or null if unset
    */
   public String getSourceAddressIsp() {
-    return sourceAddressIsp;
-  }
-
-  /**
-   * Set source address ASN
-   *
-   * @param sourceAddressAsn ASN integer
-   */
-  public void setSourceAddressAsn(Integer sourceAddressAsn) {
-    this.sourceAddressAsn = sourceAddressAsn;
+    return geoIpData.getSourceAddressIsp();
   }
 
   /**
@@ -315,16 +262,7 @@ public class Normalized implements Serializable {
    * @return ASN integer or null if unset
    */
   public Integer getSourceAddressAsn() {
-    return sourceAddressAsn;
-  }
-
-  /**
-   * Set source address AS organization
-   *
-   * @param sourceAddressAsOrg AS organization string
-   */
-  public void setSourceAddressAsOrg(String sourceAddressAsOrg) {
-    this.sourceAddressAsOrg = sourceAddressAsOrg;
+    return geoIpData.getSourceAddressAsn();
   }
 
   /**
@@ -333,7 +271,7 @@ public class Normalized implements Serializable {
    * @return AS organization string or null if unset
    */
   public String getSourceAddressAsOrg() {
-    return sourceAddressAsOrg;
+    return geoIpData.getSourceAddressAsOrg();
   }
 
   /**

--- a/src/main/java/com/mozilla/secops/parser/Parser.java
+++ b/src/main/java/com/mozilla/secops/parser/Parser.java
@@ -473,6 +473,10 @@ public class Parser {
     ParserState state = new ParserState(this);
     state.setGoogleJacksonFactory(googleJacksonFactory);
     state.setObjectMapper(mapper);
+    state.setDeferGeoIpResolution(cfg.getDeferGeoIpResolution());
+    state.setGeoIp(geoip);
+    state.setMaxmindCityDbPath(cfg.getMaxmindCityDbPath());
+    state.setMaxmindIspDbPath(cfg.getMaxmindIspDbPath());
 
     if (input == null) {
       input = "";

--- a/src/main/java/com/mozilla/secops/parser/ParserCfg.java
+++ b/src/main/java/com/mozilla/secops/parser/ParserCfg.java
@@ -30,6 +30,8 @@ public class ParserCfg implements Serializable {
   private String stackdriverProjectFilter;
   private String[] stackdriverLabelFilters;
 
+  private Boolean deferGeoIpResolution;
+
   /**
    * Create a parser configuration from pipeline {@link InputOptions}
    *
@@ -41,6 +43,7 @@ public class ParserCfg implements Serializable {
     cfg.setUseEventTimestamp(options.getUseEventTimestamp());
     cfg.setMaxmindCityDbPath(options.getMaxmindCityDbPath());
     cfg.setMaxmindIspDbPath(options.getMaxmindIspDbPath());
+    cfg.setDeferGeoIpResolution(options.getDeferGeoIpResolution());
     cfg.setIdentityManagerPath(options.getIdentityManagerPath());
     cfg.setParserFastMatcher(options.getParserFastMatcher());
     if (options.getXffAddressSelector() != null) {
@@ -265,6 +268,7 @@ public class ParserCfg implements Serializable {
     useEventTimestamp = false;
     disableCloudwatchStrip = false;
     disableMozlogStrip = false;
+    deferGeoIpResolution = false;
   }
 
   /**
@@ -335,5 +339,28 @@ public class ParserCfg implements Serializable {
    */
   public Integer getMaxTimestampDifference() {
     return maxTimestampDifference;
+  }
+
+  /**
+   * Set defer GeoIP resolution
+   *
+   * <p>If set, GeoIP resolution on events will not actually occur until a GeoIP related field is
+   * read. Otherwise, it will occur immediately when a source address field is set if GeoIP is
+   * enabled.
+   *
+   * @param deferGeoIpResolution Boolean
+   */
+  @JsonProperty("defer_geoip_resolution")
+  public void setDeferGeoIpResolution(Boolean deferGeoIpResolution) {
+    this.deferGeoIpResolution = deferGeoIpResolution;
+  }
+
+  /**
+   * Get defer GeoIP resolution setting
+   *
+   * @return Boolean
+   */
+  public Boolean getDeferGeoIpResolution() {
+    return deferGeoIpResolution;
   }
 }

--- a/src/main/java/com/mozilla/secops/parser/ParserState.java
+++ b/src/main/java/com/mozilla/secops/parser/ParserState.java
@@ -13,6 +13,82 @@ class ParserState {
   private com.google.api.client.json.jackson2.JacksonFactory googleJacksonFactory;
   private ObjectMapper mapper;
   private String stackdriverTypeValue;
+  private GeoIP geoIp;
+  private boolean deferGeoIpResolution = false;
+  private String maxmindCityDbPath;
+  private String maxmindIspDbPath;
+
+  /**
+   * Indicate in state if geo-ip resolution should be deferred
+   *
+   * @param deferGeoIpResolution True to defer geo-ip resolution
+   */
+  public void setDeferGeoIpResolution(boolean deferGeoIpResolution) {
+    this.deferGeoIpResolution = deferGeoIpResolution;
+  }
+
+  /**
+   * Get setting for geo-ip resolution deferral
+   *
+   * @return True if resolution should be deferred
+   */
+  public boolean getDeferGeoIpResolution() {
+    return deferGeoIpResolution;
+  }
+
+  /**
+   * Store GeoIP reference in state
+   *
+   * @param geoIp GeoIP
+   */
+  public void setGeoIp(GeoIP geoIp) {
+    this.geoIp = geoIp;
+  }
+
+  /**
+   * Get GeoIP reference from state
+   *
+   * @return GeoIP or null if unset
+   */
+  public GeoIP getGeoIp() {
+    return geoIp;
+  }
+
+  /**
+   * Cache maxmind city DB path
+   *
+   * @param maxmindCityDbPath String
+   */
+  public void setMaxmindCityDbPath(String maxmindCityDbPath) {
+    this.maxmindCityDbPath = maxmindCityDbPath;
+  }
+
+  /**
+   * Get maxmind city DB path
+   *
+   * @return String
+   */
+  public String getMaxmindCityDbPath() {
+    return maxmindCityDbPath;
+  }
+
+  /**
+   * Set maxmind ISP DB path
+   *
+   * @param maxmindIspDbPath String
+   */
+  public void setMaxmindIspDbPath(String maxmindIspDbPath) {
+    this.maxmindIspDbPath = maxmindIspDbPath;
+  }
+
+  /**
+   * Get maxmind ISP DB path
+   *
+   * @return String
+   */
+  public String getMaxmindIspDbPath() {
+    return maxmindIspDbPath;
+  }
 
   /**
    * Set Stackdriver type value

--- a/src/test/java/com/mozilla/secops/authprofile/TestAuthProfile.java
+++ b/src/test/java/com/mozilla/secops/authprofile/TestAuthProfile.java
@@ -141,6 +141,7 @@ public class TestAuthProfile {
     options.setGenerateConfigurationTicksInterval(1);
     options.setGenerateConfigurationTicksMaximum(5L);
     options.setEnableCritObjectAnalysis(false);
+    options.setDeferGeoIpResolution(true);
     PCollection<String> input =
         p.apply(
             "input",

--- a/src/test/java/com/mozilla/secops/parser/ParserTest.java
+++ b/src/test/java/com/mozilla/secops/parser/ParserTest.java
@@ -1820,6 +1820,37 @@ public class ParserTest {
   }
 
   @Test
+  public void testGeoIpResolutionModes() throws Exception {
+    String buf =
+        "\"216.160.83.56\" - - [19/Mar/2019:14:52:39 -0500] \"GET /assets/scripts/main.js?t=t HTTP/1.1\" 200"
+            + " 3697 \"https://mozilla.org/item/10\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:"
+            + "65.0) Gecko/20100101 Firefox/65.0\"";
+
+    // Create default configuration (for ON_CREATION)
+    ParserCfg cfg = new ParserCfg();
+    cfg.setMaxmindCityDbPath(TEST_GEOIP_DBPATH);
+    cfg.setMaxmindIspDbPath(TEST_ISP_DBPATH);
+    Parser p = new Parser(cfg);
+    Event e = p.parse(buf);
+    ApacheCombined d = e.getPayload();
+    assertEquals("Milton", d.getSourceAddressCity());
+    Normalized n = e.getNormalized();
+    assertEquals("Milton", n.getSourceAddressCity());
+
+    // Create modified configuration (for DEFERRED)
+    cfg = new ParserCfg();
+    cfg.setMaxmindCityDbPath(TEST_GEOIP_DBPATH);
+    cfg.setMaxmindIspDbPath(TEST_ISP_DBPATH);
+    cfg.setDeferGeoIpResolution(true);
+    p = new Parser(cfg);
+    e = p.parse(buf);
+    d = e.getPayload();
+    assertEquals("Milton", d.getSourceAddressCity());
+    n = e.getNormalized();
+    assertEquals("Milton", n.getSourceAddressCity());
+  }
+
+  @Test
   public void testParseApacheCombined() throws Exception {
     String buf =
         "\"216.160.83.56\" - - [19/Mar/2019:14:52:39 -0500] \"GET /assets/scripts/main.js?t=t HTTP/1.1\" 200"


### PR DESCRIPTION
This is a fairly large modification to how we do geo-ip resolution, and has been disabled by default for now with the intent of this becoming the default later.

The parser is heavily optimized, but there are some parts of it we can't optimize much. The biggest part of this is geo-ip resolution through Maxmind, which despite the implementation of an LRUCache in front of it is still slow if a database read is required. The cache helps with certain applications, but is largely not useful with services with extremely high distinct address counts and low request counts per address. The parser currently accounts for about 75% of the processing workload with some pipelines, and Maxmind lookups account for nearly 50% of that.

Populating geo parameters upon ingestion is generally not useful as in the vast majority of cases with events, the information goes unused since it's really only incorporated upon alert or with a subset of heuristics.

This change modifies the way geo-ip resolution happens such that it's optionally deferred until it is actually read from the event. In most cases this will result in significant improvements to parser performance under workloads that do not require this information for every collection element.