### PR TITLE
do not replace original message upon receiving operator response

### DIFF
--- a/contrib/slackbot-background/handlers.go
+++ b/contrib/slackbot-background/handlers.go
@@ -106,7 +106,7 @@ func handleAlertConfirm(ctx context.Context, callback common.InteractionData, db
 
 	response := &slack.Msg{
 		Text:            "Error responding; please contact SecOps (secops@mozilla.com)",
-		ReplaceOriginal: true,
+		ReplaceOriginal: false,
 	}
 
 	if !alert.IsStatus(common.ALERT_NEW) {


### PR DESCRIPTION
Fixes #446 

This changes how the Slackbot response is set so it no longer replaces the original message that has the alert details including the operator documentation. Instead the original message remains and the message thanking the operator is sent as a new message from slackbot.

It does mean the action items (boxes for yes and no) are still present but we do have a flow for if they're clicked and an alert is not new.

Alternative would be to insert just info we want to message or if there's multiple fields we want to preserve (which seems like it may be the case), we could retemplate the message with the alert metadata.