### PR TITLE
add pubsub.NewClient to http.go InitConfig

### DIFF
--- a/contrib/slackbot-http/http.go
+++ b/contrib/slackbot-http/http.go
@@ -46,6 +46,11 @@ func InitConfig() {
 		log.Fatalf("Could not load config file from `%s`: %s", configPath, err)
 	}
 
+	pubsubClient, err = pubsub.NewClient(context.Background(), PROJECT_ID)
+	if err != nil {
+		log.Fatalf("Could not create pubsub client. Err: %s", err)
+	}
+
 	topic := pubsubClient.Topic(config.SlackbotTriggerTopicName)
 	ok, err := topic.Exists(context.Background())
 	if err != nil {


### PR DESCRIPTION
Looks like it was accidentally removed in https://github.com/mozilla-services/foxsec-pipeline/commit/eed8fd591b5da4bffc6949608832b1ca0495043a