### PR TITLE
Update Taskcluster's log model

### DIFF
--- a/src/main/java/com/mozilla/secops/parser/models/taskcluster/Taskcluster.java
+++ b/src/main/java/com/mozilla/secops/parser/models/taskcluster/Taskcluster.java
@@ -9,10 +9,11 @@ import java.io.Serializable;
 public class Taskcluster implements Serializable {
   private static final long serialVersionUID = 1L;
 
+  private String apiVersion;
   private String clientId;
   private Double duration;
   private String expires;
-  private Boolean hasAuthed;
+  private Boolean authenticated;
   private String method;
   private String name;
   private Boolean isPublic;
@@ -20,6 +21,16 @@ public class Taskcluster implements Serializable {
   private String[] satisfyingScopes;
   private String sourceIp;
   private Integer statusCode;
+
+  /**
+   * Get api version
+   *
+   * @return String
+   */
+  @JsonProperty("apiVersion")
+  public String getApiVersion() {
+    return apiVersion;
+  }
 
   /**
    * Get client ID
@@ -52,13 +63,13 @@ public class Taskcluster implements Serializable {
   }
 
   /**
-   * Get hasAuthed
+   * Get authenticated
    *
    * @return Boolean
    */
-  @JsonProperty("hasAuthed")
-  public Boolean getHasAuthed() {
-    return hasAuthed;
+  @JsonProperty("authenticated")
+  public Boolean getAuthenticated() {
+    return authenticated;
   }
 
   /**

--- a/src/main/java/com/mozilla/secops/parser/models/taskcluster/Taskcluster.java
+++ b/src/main/java/com/mozilla/secops/parser/models/taskcluster/Taskcluster.java
@@ -1,5 +1,6 @@
 package com.mozilla.secops.parser.models.taskcluster;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
@@ -68,6 +69,7 @@ public class Taskcluster implements Serializable {
    * @return Boolean
    */
   @JsonProperty("authenticated")
+  @JsonAlias("hasAuthed")
   public Boolean getAuthenticated() {
     return authenticated;
   }

--- a/src/test/java/com/mozilla/secops/parser/ParserTest.java
+++ b/src/test/java/com/mozilla/secops/parser/ParserTest.java
@@ -956,7 +956,7 @@ public class ParserTest {
     assertNotNull(d);
     com.mozilla.secops.parser.models.taskcluster.Taskcluster data = d.getTaskclusterData();
     assertNotNull(data);
-    assertEquals(data.getApiVersion(), "v1");
+    assertEquals(data.getApiVersion(), "v2");
     assertEquals("mozilla-auth0/ad|Mozilla-LDAP|riker/services", data.getClientId());
     assertEquals(20159.03, (double) data.getDuration(), 0.5);
     assertEquals("3017-02-01T05:00:00.000Z", data.getExpires());

--- a/src/test/java/com/mozilla/secops/parser/ParserTest.java
+++ b/src/test/java/com/mozilla/secops/parser/ParserTest.java
@@ -932,9 +932,9 @@ public class ParserTest {
   public void testParseTaskcluster() throws Exception {
     String buf =
         "{\"insertId\":\"AAAAAAAAAAAAAAA\",\"jsonPayload\":{\"EnvVersion\":\"2.0\",\"Fields"
-            + "\":{\"apiVersion\":\"v1\",\"clientId\":\"mozilla-auth0/ad|Mozilla-LDAP|riker/servi"
-            + "ces\",\"duration\":20159.035803,\"expires\":\"3017-02-01T05:00:00.000Z\",\"hasAuth"
-            + "ed\":true,\"method\":\"POST\",\"name\":\"claimWork\",\"public\":false,\"resource\""
+            + "\":{\"apiVersion\":\"v2\",\"clientId\":\"mozilla-auth0/ad|Mozilla-LDAP|riker/servi"
+            + "ces\",\"duration\":20159.035803,\"expires\":\"3017-02-01T05:00:00.000Z\",\"authenti"
+            + "cated\":true,\"method\":\"POST\",\"name\":\"claimWork\",\"public\":false,\"resource\""
             + ":\"/v1/claim-work/test-provisioner/macos-workers\",\"satisfyingScopes\":[\"queue:c"
             + "laim-work:test-provisioner/macos-workers\",\"queue:worker-id:test-worker-group/test\""
             + "],\"sourceIp\":\"216.160.83.56\",\"statusCode\":200,\"v\":1},\"Hostname\":\"000000"
@@ -956,10 +956,11 @@ public class ParserTest {
     assertNotNull(d);
     com.mozilla.secops.parser.models.taskcluster.Taskcluster data = d.getTaskclusterData();
     assertNotNull(data);
+    assertEquals(data.getApiVersion(), "v1");
     assertEquals("mozilla-auth0/ad|Mozilla-LDAP|riker/services", data.getClientId());
     assertEquals(20159.03, (double) data.getDuration(), 0.5);
     assertEquals("3017-02-01T05:00:00.000Z", data.getExpires());
-    assertTrue(data.getHasAuthed());
+    assertTrue(data.getAuthenticated());
     assertEquals("216.160.83.56", data.getSourceIp());
     assertEquals(200, (int) data.getStatusCode());
     assertEquals("riker", d.getResolvedSubject());


### PR DESCRIPTION
per changes in https://github.com/taskcluster/taskcluster/pull/3615

additionally, adds `apiVersion` to the model in case we need to support multiple versions in the future.