### PR TITLE
Aws AssumeRole Correlator fixes

### DIFF
--- a/src/main/java/com/mozilla/secops/authprofile/AwsAssumeRoleCorrelator.java
+++ b/src/main/java/com/mozilla/secops/authprofile/AwsAssumeRoleCorrelator.java
@@ -103,7 +103,7 @@ public class AwsAssumeRoleCorrelator extends PTransform<PCollection<Event>, PCol
       // but we may want to output it so we can determine
       // if we are missing the source event for any critical objects
       if (events.size() == 1 && c.pane().isLast()) {
-        log.info("Found only one event for sharedEventID {}: {}", key, events.get(0).toJSON());
+        log.info("Found only one event for sharedEventID {}", key);
         return;
       }
       if (events.size() != 2) {
@@ -135,7 +135,6 @@ public class AwsAssumeRoleCorrelator extends PTransform<PCollection<Event>, PCol
               .orElse(null);
 
       if (trustedAccountEvent == null || trustingAccountEvent == null) {
-        events.forEach(e -> log.info("event: {}", e.toJSON()));
         log.error("Cannot determine trusted and trusting accounts for sharedEventID {}", key);
         return;
       }

--- a/src/main/java/com/mozilla/secops/parser/Cloudtrail.java
+++ b/src/main/java/com/mozilla/secops/parser/Cloudtrail.java
@@ -270,6 +270,15 @@ public class Cloudtrail extends SourcePayloadBase implements Serializable {
   }
 
   /**
+   * Returns the event id of the cloudtrail event
+   *
+   * @return value of eventID field
+   */
+  public String getEventID() {
+    return event.getEventID();
+  }
+
+  /**
    * Utility method for returning the resource the event was acting on, used for adding context to
    * an {@link com.mozilla.secops.alert.Alert}.
    *

--- a/src/test/java/com/mozilla/secops/authprofile/TestAwsAssumeRoleCorrelator.java
+++ b/src/test/java/com/mozilla/secops/authprofile/TestAwsAssumeRoleCorrelator.java
@@ -350,4 +350,85 @@ public class TestAwsAssumeRoleCorrelator {
 
     p.run().waitUntilFinish();
   }
+
+  @Test
+  public void critObjectAwsAssumeRoleCrossAccountWithDuplicateEvent() throws Exception {
+    // This testcase tests when a user assumes a role in a critical resource
+    // from another account, but we have event duplication so the first event comes
+    // twice.
+    AuthProfile.AuthProfileOptions options = getTestOptions();
+
+    String[] eb1 = TestUtil.getTestInputArray("/testdata/authprof_awscorr1a.txt");
+    String[] eb2 = TestUtil.getTestInputArray("/testdata/authprof_awscorr1c.txt");
+    TestStream<String> s =
+        TestStream.create(StringUtf8Coder.of())
+            .advanceWatermarkTo(Instant.parse("2020-10-20T15:21:00Z"))
+            .addElements(eb1[0], Arrays.copyOfRange(eb1, 1, eb1.length))
+            .addElements(eb1[0], Arrays.copyOfRange(eb1, 1, eb1.length))
+            .advanceWatermarkTo(Instant.parse("2020-10-20T15:22:00Z"))
+            .advanceProcessingTime(Duration.standardSeconds(70))
+            .addElements(eb2[0], Arrays.copyOfRange(eb2, 1, eb2.length))
+            .advanceWatermarkToInfinity();
+
+    Input input = TestAuthProfileUtil.wiredInputStream(options, s);
+    PCollection<Alert> res = AuthProfile.processInput(p.apply(input.simplexReadRaw()), options);
+
+    PAssert.that(res)
+        .satisfies(
+            results -> {
+              long cnt = 0;
+              long cfgTickCnt = 0;
+              for (Alert a : results) {
+                if (a.getMetadataValue(AlertMeta.Key.ALERT_SUBCATEGORY_FIELD)
+                    .equals("critical_object_analyze")) {
+                  assertEquals(Alert.AlertSeverity.CRITICAL, a.getSeverity());
+                  assertEquals(
+                      "critical authentication event observed "
+                          + "uhura to super-important-account, 127.0.0.1 [unknown/unknown]",
+                      a.getSummary());
+                  assertThat(
+                      a.getPayload(),
+                      containsString(
+                          "This destination object is configured as a critical resource"));
+                  assertEquals(
+                      "critical_object_analyze",
+                      a.getMetadataValue(AlertMeta.Key.ALERT_SUBCATEGORY_FIELD));
+                  assertEquals(
+                      "section31@mozilla.com",
+                      a.getMetadataValue(AlertMeta.Key.NOTIFY_EMAIL_DIRECT));
+                  assertEquals("uhura", a.getMetadataValue(AlertMeta.Key.USERNAME));
+                  assertEquals("super-important-account", a.getMetadataValue(AlertMeta.Key.OBJECT));
+                  assertEquals("127.0.0.1", a.getMetadataValue(AlertMeta.Key.SOURCEADDRESS));
+                  assertEquals("unknown", a.getMetadataValue(AlertMeta.Key.SOURCEADDRESS_CITY));
+                  assertEquals("unknown", a.getMetadataValue(AlertMeta.Key.SOURCEADDRESS_COUNTRY));
+                  assertEquals("email/authprofile.ftlh", a.getEmailTemplate());
+                  assertEquals("slack/authprofile.ftlh", a.getSlackTemplate());
+                  assertEquals("auth", a.getMetadataValue(AlertMeta.Key.AUTH_ALERT_TYPE));
+                  cnt++;
+                } else if (a.getMetadataValue(AlertMeta.Key.ALERT_SUBCATEGORY_FIELD)
+                    .equals("cfgtick")) {
+                  cfgTickCnt++;
+                  assertEquals("authprofile-cfgtick", a.getCategory());
+                  assertEquals(
+                      "^projects/test$, super-important-account",
+                      a.getCustomMetadataValue("critObjects"));
+                  assertEquals(
+                      "section31@mozilla.com",
+                      a.getCustomMetadataValue("criticalNotificationEmail"));
+                  assertEquals("^riker@mozilla.com$", a.getCustomMetadataValue("ignoreUserRegex"));
+                  assertEquals("5", a.getCustomMetadataValue("generateConfigurationTicksMaximum"));
+                  assertEquals(
+                      "Alert via section31@mozilla.com immediately on auth events to specified objects: [^projects/test$, super-important-account]",
+                      a.getCustomMetadataValue("heuristic_CritObjectAnalyze"));
+                } else {
+                  fail("unexpected category");
+                }
+              }
+              assertEquals(5L, cfgTickCnt);
+              assertEquals(1L, cnt);
+              return null;
+            });
+
+    p.run().waitUntilFinish();
+  }
 }


### PR DESCRIPTION
Adds deduplication of cloudtrail events based on the cloudtrail event ID.
(Note: We should clean up the cloudtrail log shipping as we're doing double from an account, but this adds some resiliency)