### PR TITLE
refactor deduplication for aws cross account correlator

### DIFF
--- a/src/main/java/com/mozilla/secops/authprofile/AwsAssumeRoleCorrelator.java
+++ b/src/main/java/com/mozilla/secops/authprofile/AwsAssumeRoleCorrelator.java
@@ -8,12 +8,12 @@ import com.mozilla.secops.parser.EventFilterPayload.StringProperty;
 import com.mozilla.secops.parser.Normalized;
 import com.mozilla.secops.parser.Payload.PayloadType;
 import java.util.ArrayList;
-import org.apache.beam.sdk.transforms.Deduplicate;
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.GroupByKey;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
-import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.windowing.AfterPane;
 import org.apache.beam.sdk.transforms.windowing.AfterWatermark;
 import org.apache.beam.sdk.transforms.windowing.Sessions;
@@ -48,9 +48,6 @@ public class AwsAssumeRoleCorrelator extends PTransform<PCollection<Event>, PCol
     return input
         .apply("filter assume role events", ParDo.of(new CrossAccountAssumeRoleFilter()))
         .apply(
-            Deduplicate.<KV<String, Event>, String>withRepresentativeValueFn(new ExtractEventID())
-                .withDuration(Duration.standardMinutes(2)))
-        .apply(
             Window.<KV<String, Event>>into(
                     Sessions.withGapDuration(Duration.standardSeconds(sessionGapDuration)))
                 .triggering(
@@ -62,28 +59,19 @@ public class AwsAssumeRoleCorrelator extends PTransform<PCollection<Event>, PCol
         .apply(ParDo.of(new FixUpNormalized()));
   }
 
-  private class ExtractEventID implements SerializableFunction<KV<String, Event>, String> {
-
-    private static final long serialVersionUID = 1L;
-
-    @Override
-    public String apply(KV<String, Event> input) {
-      Event e = input.getValue();
-      String account = e.getNormalized().getObject();
-      if (e.getPayloadType().equals(PayloadType.CLOUDTRAIL)) {
-        Cloudtrail ct = e.getPayload();
-        String eventID = ct.getEventID();
-        if (eventID != null) {
-          // use account_cloudtrailEventID as deduplicaton key
-          return String.format("%s_%s", account, eventID);
-        }
+  private static String extractCloudTrailEventID(Event e) {
+    String account = e.getNormalized().getObject();
+    if (e.getPayloadType().equals(PayloadType.CLOUDTRAIL)) {
+      Cloudtrail ct = e.getPayload();
+      String eventID = ct.getEventID();
+      if (eventID != null) {
+        // use account_cloudtrailEventID as deduplicaton key
+        return String.format("%s_%s", account, eventID);
       }
-      // events have been already filtered so this shouldn't be possible
-      // but if we can't get id, use empty string and allow the collision
-      log.error("Event is not a cloudtrail event with id. SharedID: {}", input.getKey());
-      return "";
     }
+    return "";
   }
+
   /**
    * Creates an auth event using the assume role events from both the trusted and trusting account
    * that allows us to analyze which user was accessing the trusting account
@@ -96,7 +84,18 @@ public class AwsAssumeRoleCorrelator extends PTransform<PCollection<Event>, PCol
     public void processElement(ProcessContext c) {
       String key = c.element().getKey();
       ArrayList<Event> events = new ArrayList<>();
-      c.element().getValue().forEach(events::add);
+      // deduplicate based on cloudtrail event ID
+      Map<String, Boolean> processedEvents = new HashMap<>();
+      c.element()
+          .getValue()
+          .forEach(
+              e -> {
+                String id = extractCloudTrailEventID(e);
+                if (!processedEvents.containsKey(id)) {
+                  events.add(e);
+                  processedEvents.put(id, true);
+                }
+              });
 
       // if we have only one event and this is the last pane
       // we are missing the other event, log this for now

--- a/src/main/java/com/mozilla/secops/authprofile/AwsAssumeRoleCorrelator.java
+++ b/src/main/java/com/mozilla/secops/authprofile/AwsAssumeRoleCorrelator.java
@@ -91,7 +91,9 @@ public class AwsAssumeRoleCorrelator extends PTransform<PCollection<Event>, PCol
           .forEach(
               e -> {
                 String id = extractCloudTrailEventID(e);
-                if (!processedEvents.containsKey(id)) {
+                if (processedEvents.containsKey(id)) {
+                  log.warn("Found duplicate cloudtrail event: {}", id);
+                } else {
                   events.add(e);
                   processedEvents.put(id, true);
                 }


### PR DESCRIPTION
follow up to #496 

#496 resulted in a non updateable graph because of the deduplication transform. I also tried switching it to streaming engine to see as recommended by the error message, but that also failed with no further details, so this simply moves the deduplication to after we've windowed and GBK.

Because we deduplicate after this, it means if the first event we receive is duplicated, it can take a long time to generate the alert as it'll won't happen on the early firing and instead occurs when the window closes and in practice we need to set the session gap to be ~8 minutes. But since the duplicate event issue has been fixed and this is an edge case I don't think the delay is concerning.