### PR TITLE
Enrich authprofile alerts

### DIFF
--- a/contrib/common/alertmeta.go
+++ b/contrib/common/alertmeta.go
@@ -62,6 +62,7 @@ const (
 	META_PROVIDER                          = "provider"
 	META_REAL_ADDRESS_HASH_ACTUAL          = "real_address_hash_actual"
 	META_REAL_ADDRESS_HASH_EXPECTED        = "real_address_hash_expected"
+	META_REFERENCE_ID                      = "reference_id"
 	META_REQUEST_THRESHOLD                 = "request_threshold"
 	META_RESOURCE                          = "resource"
 	META_RESTRICTED_VALUE                  = "restricted_value"

--- a/src/main/java/com/mozilla/secops/alert/AlertMeta.java
+++ b/src/main/java/com/mozilla/secops/alert/AlertMeta.java
@@ -170,6 +170,7 @@ public class AlertMeta implements Serializable {
     PROVIDER("provider"),
     REAL_ADDRESS_HASH_ACTUAL("real_address_hash_actual"),
     REAL_ADDRESS_HASH_EXPECTED("real_address_hash_expected"),
+    REFERENCE_ID("reference_id"),
     REQUEST_THRESHOLD("request_threshold"),
     RESOURCE("resource"),
     RESTRICTED_VALUE("restricted_value"),

--- a/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
+++ b/src/main/java/com/mozilla/secops/authprofile/AuthProfile.java
@@ -930,6 +930,10 @@ public class AuthProfile implements Serializable {
       }
     }
 
+    if (e.getNormalized().getReferenceID() != null) {
+      a.addMetadata(AlertMeta.Key.REFERENCE_ID, e.getNormalized().getReferenceID());
+    }
+
     return a;
   }
 

--- a/src/main/java/com/mozilla/secops/authprofile/CritObjectAnalyze.java
+++ b/src/main/java/com/mozilla/secops/authprofile/CritObjectAnalyze.java
@@ -113,12 +113,14 @@ public class CritObjectAnalyze
         a.addMetadata(
             AlertMeta.Key.SLACK_SUPPLEMENTARY_MESSAGE,
             String.format(
-                "<!channel> critical authentication event observed %s to %s, %s [%s/%s]",
+                "<!channel> critical authentication event observed %s to %s, %s [%s/%s]%n"
+                    + "alert id: %s",
                 a.getMetadataValue(AlertMeta.Key.USERNAME),
                 a.getMetadataValue(AlertMeta.Key.OBJECT),
                 a.getMetadataValue(AlertMeta.Key.SOURCEADDRESS),
                 a.getMetadataValue(AlertMeta.Key.SOURCEADDRESS_CITY),
-                a.getMetadataValue(AlertMeta.Key.SOURCEADDRESS_COUNTRY)));
+                a.getMetadataValue(AlertMeta.Key.SOURCEADDRESS_COUNTRY),
+                a.getAlertId().toString()));
         return;
       } else {
         // The alert doesn't match the alternate policy; add the supplementary slack notification
@@ -128,13 +130,15 @@ public class CritObjectAnalyze
             AlertMeta.Key.SLACK_SUPPLEMENTARY_MESSAGE,
             String.format(
                 "critical authentication event observed %s to %s, %s [%s/%s]%n"
-                    + "Notification has been sent to %s",
+                    + "Notification has been sent to %s%n"
+                    + "alert id: %s",
                 a.getMetadataValue(AlertMeta.Key.USERNAME),
                 a.getMetadataValue(AlertMeta.Key.OBJECT),
                 a.getMetadataValue(AlertMeta.Key.SOURCEADDRESS),
                 a.getMetadataValue(AlertMeta.Key.SOURCEADDRESS_CITY),
                 a.getMetadataValue(AlertMeta.Key.SOURCEADDRESS_COUNTRY),
-                ofNullable(critNotifyEmail).orElse("no one! <!channel>")));
+                ofNullable(critNotifyEmail).orElse("no one! <!channel>"),
+                a.getAlertId().toString()));
       }
     }
     if (critNotifyEmail != null) {

--- a/src/main/java/com/mozilla/secops/parser/Cloudtrail.java
+++ b/src/main/java/com/mozilla/secops/parser/Cloudtrail.java
@@ -72,12 +72,15 @@ public class Cloudtrail extends SourcePayloadBase implements Serializable {
           e.setTimestamp(t);
         }
       }
+      Normalized n = e.getNormalized();
       // If we have a source address field in the model, pull that into the inherited field
       if (event.getSourceIPAddress() != null) {
-        setSourceAddress(event.getSourceIPAddress(), state, e.getNormalized());
+        setSourceAddress(event.getSourceIPAddress(), state, n);
       }
+
+      n.setReferenceID(event.getEventID());
+
       if (isAuthEvent()) {
-        Normalized n = e.getNormalized();
         n.addType(Normalized.Type.AUTH);
         n.setSubjectUser(getUser());
         n.setObject(event.getRecipientAccountId());

--- a/src/main/java/com/mozilla/secops/parser/Normalized.java
+++ b/src/main/java/com/mozilla/secops/parser/Normalized.java
@@ -50,6 +50,7 @@ public class Normalized implements Serializable {
   private String urlRequestHost; // Extracted request host component
   private Integer requestStatus;
   private String userAgent;
+  private String referenceID; // ID from the original event if available
 
   /* Following can typically only be set if the parser has been configured
    * to use an identity manager for lookups */
@@ -547,6 +548,19 @@ public class Normalized implements Serializable {
    */
   public void setUserAgent(String userAgent) {
     this.userAgent = userAgent;
+  }
+
+  /**
+   * Get the reference ID (identifier from the event source)
+   *
+   * @return ID from the original event
+   */
+  public String getReferenceID() {
+    return referenceID;
+  }
+
+  public void setReferenceID(String referenceID) {
+    this.referenceID = referenceID;
   }
 
   /**

--- a/src/test/java/com/mozilla/secops/authprofile/TestAwsAssumeRoleCorrelator.java
+++ b/src/test/java/com/mozilla/secops/authprofile/TestAwsAssumeRoleCorrelator.java
@@ -176,6 +176,9 @@ public class TestAwsAssumeRoleCorrelator {
                   assertEquals("127.0.0.1", a.getMetadataValue(AlertMeta.Key.SOURCEADDRESS));
                   assertEquals("unknown", a.getMetadataValue(AlertMeta.Key.SOURCEADDRESS_CITY));
                   assertEquals("unknown", a.getMetadataValue(AlertMeta.Key.SOURCEADDRESS_COUNTRY));
+                  assertEquals(
+                      "5b147f6e-6da4-491f-92da-20fff616dcff",
+                      a.getMetadataValue(AlertMeta.Key.REFERENCE_ID));
                   assertEquals("email/authprofile.ftlh", a.getEmailTemplate());
                   assertEquals("slack/authprofile.ftlh", a.getSlackTemplate());
                   assertEquals("auth", a.getMetadataValue(AlertMeta.Key.AUTH_ALERT_TYPE));
@@ -320,6 +323,9 @@ public class TestAwsAssumeRoleCorrelator {
                   assertEquals("127.0.0.1", a.getMetadataValue(AlertMeta.Key.SOURCEADDRESS));
                   assertEquals("unknown", a.getMetadataValue(AlertMeta.Key.SOURCEADDRESS_CITY));
                   assertEquals("unknown", a.getMetadataValue(AlertMeta.Key.SOURCEADDRESS_COUNTRY));
+                  assertEquals(
+                      "fa1b3d9a-7070-4f5a-bd44-01572f488268",
+                      a.getMetadataValue(AlertMeta.Key.REFERENCE_ID));
                   assertEquals("email/authprofile.ftlh", a.getEmailTemplate());
                   assertEquals("slack/authprofile.ftlh", a.getSlackTemplate());
                   assertEquals("auth", a.getMetadataValue(AlertMeta.Key.AUTH_ALERT_TYPE));
@@ -401,6 +407,9 @@ public class TestAwsAssumeRoleCorrelator {
                   assertEquals("127.0.0.1", a.getMetadataValue(AlertMeta.Key.SOURCEADDRESS));
                   assertEquals("unknown", a.getMetadataValue(AlertMeta.Key.SOURCEADDRESS_CITY));
                   assertEquals("unknown", a.getMetadataValue(AlertMeta.Key.SOURCEADDRESS_COUNTRY));
+                  assertEquals(
+                      "fa1b3d9a-7070-4f5a-bd44-01572f488268",
+                      a.getMetadataValue(AlertMeta.Key.REFERENCE_ID));
                   assertEquals("email/authprofile.ftlh", a.getEmailTemplate());
                   assertEquals("slack/authprofile.ftlh", a.getSlackTemplate());
                   assertEquals("auth", a.getMetadataValue(AlertMeta.Key.AUTH_ALERT_TYPE));

--- a/src/test/java/com/mozilla/secops/authprofile/TestCritObject.java
+++ b/src/test/java/com/mozilla/secops/authprofile/TestCritObject.java
@@ -237,10 +237,12 @@ public class TestCritObject {
                 if (m == 1546349400000L) {
                   // Will be our alternate escalation
                   assertNull(a.getMetadataValue(AlertMeta.Key.NOTIFY_EMAIL_DIRECT));
-                  assertEquals(
-                      "<!channel> critical authentication event observed laforge@mozilla.com to "
-                          + "projects/test, 216.160.83.56 [Milton/US]",
-                      a.getMetadataValue(AlertMeta.Key.SLACK_SUPPLEMENTARY_MESSAGE));
+                  assertThat(
+                      a.getMetadataValue(AlertMeta.Key.SLACK_SUPPLEMENTARY_MESSAGE),
+                      containsString(
+                          "<!channel> critical authentication event observed laforge@mozilla.com to "
+                              + "projects/test, 216.160.83.56 [Milton/US]\n"
+                              + "alert id:"));
                   assertEquals(
                       "test", a.getMetadataValue(AlertMeta.Key.NOTIFY_SLACK_SUPPLEMENTARY));
                   scnt++;
@@ -249,11 +251,13 @@ public class TestCritObject {
                   assertEquals(
                       "section31@mozilla.com",
                       a.getMetadataValue(AlertMeta.Key.NOTIFY_EMAIL_DIRECT));
-                  assertEquals(
-                      "critical authentication event observed laforge@mozilla.com to "
-                          + "projects/test, 216.160.83.56 [Milton/US]\n"
-                          + "Notification has been sent to section31@mozilla.com",
-                      a.getMetadataValue(AlertMeta.Key.SLACK_SUPPLEMENTARY_MESSAGE));
+                  assertThat(
+                      a.getMetadataValue(AlertMeta.Key.SLACK_SUPPLEMENTARY_MESSAGE),
+                      containsString(
+                          "critical authentication event observed laforge@mozilla.com to "
+                              + "projects/test, 216.160.83.56 [Milton/US]\n"
+                              + "Notification has been sent to section31@mozilla.com\n"
+                              + "alert id: "));
                   assertEquals(
                       "test", a.getMetadataValue(AlertMeta.Key.NOTIFY_SLACK_SUPPLEMENTARY));
                   ncnt++;
@@ -300,20 +304,24 @@ public class TestCritObject {
                 if (m == 1546349400000L) {
                   // Will be our alternate escalation
                   assertNull(a.getMetadataValue(AlertMeta.Key.NOTIFY_EMAIL_DIRECT));
-                  assertEquals(
-                      "<!channel> critical authentication event observed laforge@mozilla.com to "
-                          + "projects/test, 216.160.83.56 [Milton/US]",
-                      a.getMetadataValue(AlertMeta.Key.SLACK_SUPPLEMENTARY_MESSAGE));
+                  assertThat(
+                      a.getMetadataValue(AlertMeta.Key.SLACK_SUPPLEMENTARY_MESSAGE),
+                      containsString(
+                          "<!channel> critical authentication event observed laforge@mozilla.com to "
+                              + "projects/test, 216.160.83.56 [Milton/US]\n"
+                              + "alert id:"));
                   assertEquals(
                       "test", a.getMetadataValue(AlertMeta.Key.NOTIFY_SLACK_SUPPLEMENTARY));
                   scnt++;
                 } else if (m == 1546383600000L || m == 1546695000000L) {
                   // No standard escalation cos email not set
-                  assertEquals(
-                      "critical authentication event observed laforge@mozilla.com to "
-                          + "projects/test, 216.160.83.56 [Milton/US]\n"
-                          + "Notification has been sent to no one! <!channel>",
-                      a.getMetadataValue(AlertMeta.Key.SLACK_SUPPLEMENTARY_MESSAGE));
+                  assertThat(
+                      a.getMetadataValue(AlertMeta.Key.SLACK_SUPPLEMENTARY_MESSAGE),
+                      containsString(
+                          "critical authentication event observed laforge@mozilla.com to "
+                              + "projects/test, 216.160.83.56 [Milton/US]\n"
+                              + "Notification has been sent to no one! <!channel>\n"
+                              + "alert id: "));
                   assertEquals(
                       "test", a.getMetadataValue(AlertMeta.Key.NOTIFY_SLACK_SUPPLEMENTARY));
                   ncnt++;

--- a/src/test/java/com/mozilla/secops/parser/ParserTest.java
+++ b/src/test/java/com/mozilla/secops/parser/ParserTest.java
@@ -1174,6 +1174,9 @@ public class ParserTest {
     assertNotNull(ct);
     assertEquals("uhura", ct.getUser());
     assertEquals("127.0.0.1", ct.getSourceAddress());
+    Normalized n = e.getNormalized();
+    assertNotNull(n);
+    assertEquals("55555343-132e-43bb-8d5d-23d0ef81178e", n.getReferenceID());
   }
 
   @Test
@@ -1207,6 +1210,7 @@ public class ParserTest {
     assertEquals("riker", n.getSubjectUser());
     assertEquals("127.0.0.1", n.getSourceAddress());
     assertEquals("999999999999", n.getObject());
+    assertEquals("00000000-0000-0000-0000-000000000000", n.getReferenceID());
   }
 
   @Test
@@ -1238,6 +1242,7 @@ public class ParserTest {
     assertEquals("riker", n.getSubjectUser());
     assertEquals("127.0.0.1", n.getSourceAddress());
     assertEquals("XXXXXXXX", n.getObject());
+    assertEquals("000000000-000000", n.getReferenceID());
   }
 
   @Test
@@ -1268,6 +1273,7 @@ public class ParserTest {
     assertEquals("riker", n.getSubjectUser());
     assertEquals("127.0.0.1", n.getSourceAddress());
     assertEquals("XXXXXXXX", n.getObject());
+    assertEquals("000000000-000000", n.getReferenceID());
   }
 
   @Test
@@ -1305,6 +1311,7 @@ public class ParserTest {
     assertTrue(n.isOfType(Normalized.Type.AUTH));
     assertEquals("127.0.0.1", n.getSourceAddress());
     assertEquals("123456789", n.getObject());
+    assertEquals("55555555-3998-4e79-abdc-4c67df8bd013", n.getReferenceID());
   }
 
   @Test
@@ -1353,6 +1360,7 @@ public class ParserTest {
     assertEquals("10.0.0.1", n.getSourceAddress());
     assertEquals("1234567890", n.getObject());
     assertFalse(n.hasStatusTag(Normalized.StatusTag.REQUIRES_SUBJECT_USER_FIXUP));
+    assertEquals("5555555-3f0d-4cc3-b979", n.getReferenceID());
 
     // AssumeRole account from another aws account
     buf =
@@ -1366,7 +1374,7 @@ public class ParserTest {
             + "\"userIdentity\":{\"accountId\": \"000000000000\", \"principalId\": \"PRINCIPALID\", \"type\": \"AWSAccount\"},"
             + "\"sourceIPAddress\": \"127.0.0.1\", \"sharedEventID\": \"1bfc7fd0-0c12-441d-b155-fe2442532683\", \"eventVersion\":\"1.05 \","
             + "\"awsRegion\": \"us-east-1\", \"eventName\": \"AssumeRole\", \"eventType\": \"AwsApiCall\", "
-            + "\"eventID\": \"fa1b3d9a-7070-4f5a-bd44-01572f488268 \", \"recipientAccountId\": \"999999999999\", "
+            + "\"eventID\": \"fa1b3d9a-7070-4f5a-bd44-01572f488268\", \"recipientAccountId\": \"999999999999\", "
             + "\"resources\": [{\"type\": \"AWS::IAM::Role\", \"ARN \": \"arn:aws:iam::999999999999:role/role-name\", "
             + "\"accountId\": \"999999999999\"}]}, \"resource\":{\"type\": \"project \", \"labels\":{\"project_id\": \"project-name\"}},"
             + "\"timestamp\": \"2020-10-20T15:36:11.328745600Z \", \"logName\": \"projects/project-name/logs/cloudtrail-streamer\", "
@@ -1386,6 +1394,7 @@ public class ParserTest {
     assertEquals("127.0.0.1", n.getSourceAddress());
     assertEquals("999999999999", n.getObject());
     assertTrue(n.hasStatusTag(Normalized.StatusTag.REQUIRES_SUBJECT_USER_FIXUP));
+    assertEquals("fa1b3d9a-7070-4f5a-bd44-01572f488268", n.getReferenceID());
   }
 
   @Test
@@ -1421,6 +1430,7 @@ public class ParserTest {
     assertEquals("riker", n.getSubjectUser());
     assertEquals("127.0.0.1", n.getSourceAddress());
     assertEquals("XXXXXXXX", n.getObject());
+    assertEquals("000000000-000000", n.getReferenceID());
   }
 
   @Test
@@ -1454,6 +1464,9 @@ public class ParserTest {
     assertNotNull(ct);
     assertEquals("uhura", ct.getUser());
     assertEquals("127.0.0.1", ct.getSourceAddress());
+    Normalized n = e.getNormalized();
+    assertNotNull(n);
+    assertEquals("55555343-132e-43bb-8d5d-23d0ef81178e", n.getReferenceID());
   }
 
   @Test
@@ -1490,6 +1503,7 @@ public class ParserTest {
     assertEquals("uhura", n.getSubjectUser());
     assertEquals("127.0.0.1", n.getSourceAddress());
     assertEquals("999999999999", n.getObject());
+    assertEquals("fdbb2209-3fc9-4304-bcde-00634c0b7889", n.getReferenceID());
 
     // This is the SwitchRole event from the trusted account.
     buf =
@@ -1519,6 +1533,7 @@ public class ParserTest {
     assertEquals("uhura", n.getSubjectUser());
     assertEquals("127.0.0.1", n.getSourceAddress());
     assertEquals("000000000000", n.getObject());
+    assertEquals("60fdb466-fbf7-4da0-b521-0e9979e73c5d", n.getReferenceID());
   }
 
   @Test


### PR DESCRIPTION
Adds a field to the normalized event to store the original id for events that have it.
Adds this to authprofile alerts for cloudtrail events.

Adds the alert id to critical object messages to help make alert lookup easier.