### PR TITLE
slackbotbackground: add object to result + fix intermittant test failure

### DIFF
--- a/contrib/slackbot-background/background_test.go
+++ b/contrib/slackbot-background/background_test.go
@@ -219,7 +219,7 @@ func TestCheckIprepdCommandWithReputation(t *testing.T) {
 	assert.Len(t, fakeTransport.Requests, 4)
 
 	msg, err := ioutil.ReadAll(fakeTransport.Requests[3].Body)
-	expectedMsg := "{\"text\":\"http://www.iprepd1.com - {\\\"object\\\":\\\"test@example.com\\\",\\\"type\\\":\\\"email\\\",\\\"reputation\\\":0,\\\"reviewed\\\":false,\\\"lastupdated\\\":\\\"2021-02-27T00:31:18.187326761Z\\\",\\\"decayafter\\\":\\\"2021-03-06T00:31:18.187324497Z\\\"}\\nhttp://www.iprepd2.com - {\\\"object\\\":\\\"test@example.com\\\",\\\"type\\\":\\\"email\\\",\\\"reputation\\\":0,\\\"reviewed\\\":false,\\\"lastupdated\\\":\\\"2021-02-27T00:31:18.187326761Z\\\",\\\"decayafter\\\":\\\"2021-03-06T00:31:18.187324497Z\\\"}\\n\",\"replace_original\":false,\"delete_original\":false,\"blocks\":null}"
+	expectedMsg := "{\"text\":\"object=test@example.com\\nhttp://www.iprepd1.com - {\\\"object\\\":\\\"test@example.com\\\",\\\"type\\\":\\\"email\\\",\\\"reputation\\\":0,\\\"reviewed\\\":false,\\\"lastupdated\\\":\\\"2021-02-27T00:31:18.187326761Z\\\",\\\"decayafter\\\":\\\"2021-03-06T00:31:18.187324497Z\\\"}\\nhttp://www.iprepd2.com - {\\\"object\\\":\\\"test@example.com\\\",\\\"type\\\":\\\"email\\\",\\\"reputation\\\":0,\\\"reviewed\\\":false,\\\"lastupdated\\\":\\\"2021-02-27T00:31:18.187326761Z\\\",\\\"decayafter\\\":\\\"2021-03-06T00:31:18.187324497Z\\\"}\\n\",\"replace_original\":false,\"delete_original\":false,\"blocks\":null}"
 	assert.Equal(t, expectedMsg, string(msg))
 }
 
@@ -261,7 +261,7 @@ func TestCheckIprepdCommandMissingReputation(t *testing.T) {
 	assert.Len(t, fakeTransport.RequestURLs, 4)
 
 	msg, err := ioutil.ReadAll(fakeTransport.Requests[3].Body)
-	expectedMsg := "{\"text\":\"http://www.iprepd1.com - Not found! (Assumed reputation: 100)\\nhttp://www.iprepd2.com - Not found! (Assumed reputation: 100)\\n\",\"replace_original\":false,\"delete_original\":false,\"blocks\":null}"
+	expectedMsg := "{\"text\":\"object=test@example.com\\nhttp://www.iprepd1.com - Not found! (Assumed reputation: 100)\\nhttp://www.iprepd2.com - Not found! (Assumed reputation: 100)\\n\",\"replace_original\":false,\"delete_original\":false,\"blocks\":null}"
 	assert.Equal(t, expectedMsg, string(msg))
 }
 
@@ -303,6 +303,6 @@ func TestCheckIprepdCommandError(t *testing.T) {
 	assert.Len(t, fakeTransport.RequestURLs, 4)
 
 	msg, err := ioutil.ReadAll(fakeTransport.Requests[3].Body)
-	expectedMsg := "{\"text\":\"http://www.iprepd1.com - Error retrieving results!\\nhttp://www.iprepd2.com - Error retrieving results!\\n\",\"replace_original\":false,\"delete_original\":false,\"blocks\":null}"
+	expectedMsg := "{\"text\":\"object=test@example.com\\nhttp://www.iprepd1.com - Error retrieving results!\\nhttp://www.iprepd2.com - Error retrieving results!\\n\",\"replace_original\":false,\"delete_original\":false,\"blocks\":null}"
 	assert.Equal(t, expectedMsg, string(msg))
 }

--- a/contrib/slackbot-background/handlers.go
+++ b/contrib/slackbot-background/handlers.go
@@ -1,7 +1,6 @@
 package slackbotbackground
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"net/http"
@@ -145,13 +144,7 @@ func handleCheckCmd(ctx context.Context, cmd common.SlashCommandData, client *ht
 	log.Infof("Checking reputation for %s by %s", objectValue, userProfile.Email)
 
 	results := checkObjFromIprepd(client, objectValue, objectType)
-
-	b := new(bytes.Buffer)
-	for k, v := range results {
-		fmt.Fprintf(b, "%s - %s\n", k, v)
-	}
-
-	msg.Text = b.String()
+	msg.Text = results
 	return msg, nil
 }
 

--- a/contrib/slackbot-background/utils.go
+++ b/contrib/slackbot-background/utils.go
@@ -155,36 +155,45 @@ func deleteObjFromIprepd(obj, typestr string) error {
 	return nil
 }
 
-func checkObjFromIprepd(client *http.Client, obj string, typestr string) map[string]string {
-	results := make(map[string]string)
+func checkObjFromIprepd(client *http.Client, obj string, typestr string) string {
+	b := new(bytes.Buffer)
+	fmt.Fprintf(b, "object=%s\n", obj)
 	for _, iprepdInstance := range config.IprepdInstances {
 		log.Infof("Sending CHECK request to %s for %s/%s", iprepdInstance.URL, typestr, obj)
-
-		req, err := http.NewRequest("GET", fmt.Sprintf("%s/type/%s/%s", iprepdInstance.URL, typestr, obj), nil)
+		url := fmt.Sprintf("%s/type/%s/%s", iprepdInstance.URL, typestr, obj)
+		result, err := checkObjHelper(client, url, iprepdInstance.APIKey)
 		if err != nil {
-			results[iprepdInstance.URL] = "Error retrieving results!"
+			result = "Error retrieving results!"
+			log.Errorf("Error retrieving results from %s: %s", iprepdInstance.URL, err)
 		}
-		req.Header.Add("Authorization", "APIKey "+iprepdInstance.APIKey)
-		resp, err := client.Do(req)
-		if err != nil {
-			log.Errorf("Error send request to %s: %s", iprepdInstance.URL, err)
-		}
-		if resp.StatusCode == http.StatusNotFound {
-			results[iprepdInstance.URL] = "Not found! (Assumed reputation: 100)"
-		} else if resp.StatusCode == http.StatusOK {
-			defer resp.Body.Close()
-			body, err := ioutil.ReadAll(resp.Body)
-			if err != nil {
-				results[iprepdInstance.URL] = "Error retrieving results!"
-			} else {
-				results[iprepdInstance.URL] = string(body)
-			}
-		} else {
-			results[iprepdInstance.URL] = "Error retrieving results!"
-			log.Errorf("Got response with status code %d from %s", resp.StatusCode, iprepdInstance.URL)
-		}
+		fmt.Fprintf(b, "%s - %s\n", iprepdInstance.URL, result)
 	}
-	return results
+
+	return b.String()
+}
+
+func checkObjHelper(client *http.Client, url string, apiKey string) (string, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Add("Authorization", "APIKey "+apiKey)
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		return "Not found! (Assumed reputation: 100)", nil
+	} else if resp.StatusCode == http.StatusOK {
+		defer resp.Body.Close()
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return "", err
+		}
+		return string(body), nil
+	} else {
+		return "", fmt.Errorf("Unexpected http response code %v", resp.StatusCode)
+	}
 }
 
 func getCallerDetails(userid string) string {


### PR DESCRIPTION
1) add the object as part of the result as slack doesn't display the slash command you called.
2) refactor to avoid using a map as its order is unstable and causes unit tests to fail intermittently