### PR TITLE
Do not error on not allowed for slack commands

### DIFF
--- a/contrib/slackbot-background/handlers.go
+++ b/contrib/slackbot-background/handlers.go
@@ -68,7 +68,7 @@ func handleUnblockCmd(ctx context.Context, cmd common.SlashCommandData, db *comm
 		err = fmt.Errorf("User (%s) is not allowed to use this slack command.", userProfile.Email)
 		log.Error(err)
 		msg.Text = "You are not authorized to perform that command."
-		return msg, err
+		return msg, nil
 	}
 
 	exemptedObject.CreatedBy = userProfile.Email
@@ -137,7 +137,7 @@ func handleCheckCmd(ctx context.Context, cmd common.SlashCommandData, client *ht
 		err = fmt.Errorf("User (%s) is not allowed to use this slack command.", userProfile.Email)
 		log.Error(err)
 		msg.Text = "You are not authorized to perform that command."
-		return msg, err
+		return msg, nil
 	}
 
 	objectValue = cmd.Text


### PR DESCRIPTION
Currently, if a user isn't allowed to run a slack command, we return
an error. The problem here is that the cloud function will automatically
retry (with a limit) a number of times. This can cause some slow downs
and eat up resources unnecessarily.