### PR TITLE
Revert "Merge pull request #536 from mozilla-services/update-beam"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,9 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         
-        <beam.version>2.31.0</beam.version>
+        <beam.version>2.25.0</beam.version>
+
+        <google-cloud.version>1.62.0</google-cloud.version>
         <aws-java-sdk.version>1.11.571</aws-java-sdk.version>
 
         <jackson.version>2.12.1</jackson.version>
@@ -155,13 +157,6 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.apache.beam</groupId>
-                <artifactId>beam-sdks-java-google-cloud-platform-bom</artifactId>
-                <version>${beam.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>29.0-jre</version>
@@ -206,22 +201,27 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-logging</artifactId>
+            <version>${google-cloud.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-pubsub</artifactId>
+            <version>${google-cloud.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-datastore</artifactId>
+            <version>${google-cloud.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-kms</artifactId>
+            <version>0.80.0-beta</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-storage</artifactId>
+            <version>${google-cloud.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/src/main/java/com/mozilla/secops/parser/Auth0.java
+++ b/src/main/java/com/mozilla/secops/parser/Auth0.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.api.client.json.JsonParser;
-import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.logging.v2.model.LogEntry;
 import com.mozilla.secops.identity.IdentityManager;
 import com.mozilla.secops.parser.models.auth0.LogEvent;
@@ -25,7 +25,7 @@ public class Auth0 extends SourcePayloadBase implements Serializable {
   private LogEvent event;
 
   private static ArrayList<String> AuthTypes;
-  private static GsonFactory jfmatcher = new GsonFactory();
+  private static JacksonFactory jfmatcher = new JacksonFactory();
 
   // List of auth0 type codes that are auth events
   // https://auth0.com/docs/logs#log-data-event-listing

--- a/src/main/java/com/mozilla/secops/parser/Cloudtrail.java
+++ b/src/main/java/com/mozilla/secops/parser/Cloudtrail.java
@@ -3,7 +3,7 @@ package com.mozilla.secops.parser;
 import com.amazonaws.arn.Arn;
 import com.amazonaws.arn.ArnResource;
 import com.google.api.client.json.JsonParser;
-import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.logging.v2.model.LogEntry;
 import com.mozilla.secops.identity.IdentityManager;
 import com.mozilla.secops.parser.Normalized.StatusTag;
@@ -115,7 +115,7 @@ public class Cloudtrail extends SourcePayloadBase implements Serializable {
   }
 
   private CloudtrailEvent parseInput(String input, ParserState state) throws IOException {
-    GsonFactory jfmatcher = state.getGoogleJacksonFactory();
+    JacksonFactory jfmatcher = state.getGoogleJacksonFactory();
     try (JsonParser jp = jfmatcher.createJsonParser(input); ) {
       LogEntry entry = jp.parse(LogEntry.class);
       Map<String, Object> m = entry.getJsonPayload();

--- a/src/main/java/com/mozilla/secops/parser/GLB.java
+++ b/src/main/java/com/mozilla/secops/parser/GLB.java
@@ -1,7 +1,7 @@
 package com.mozilla.secops.parser;
 
 import com.google.api.client.json.JsonParser;
-import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.logging.v2.model.HttpRequest;
 import com.google.api.services.logging.v2.model.LogEntry;
 import java.io.IOException;
@@ -13,6 +13,8 @@ import org.joda.time.DateTime;
 /** Payload parser for Google Load Balancer log data. */
 public class GLB extends SourcePayloadBase implements Serializable {
   private static final long serialVersionUID = 1L;
+
+  private static final JacksonFactory jfmatcher = new JacksonFactory();
 
   private String requestMethod;
   private String userAgent;
@@ -49,10 +51,13 @@ public class GLB extends SourcePayloadBase implements Serializable {
     LogEntry entry = state.getLogEntryHint();
     if (entry == null) {
       // Reuse JacksonFactory from parser state
-      GsonFactory jf = state.getGoogleJacksonFactory();
+      JacksonFactory jf = state.getGoogleJacksonFactory();
       JsonParser jp = null;
-      jp = jf.createJsonParser(input);
-
+      try {
+        jp = jf.createJsonParser(input);
+      } catch (IOException exc) {
+        return;
+      }
       try {
         entry = jp.parse(LogEntry.class);
       } catch (IOException exc) {

--- a/src/main/java/com/mozilla/secops/parser/GcpAudit.java
+++ b/src/main/java/com/mozilla/secops/parser/GcpAudit.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.client.json.JsonParser;
-import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.logging.v2.model.LogEntry;
 import com.google.api.services.servicecontrol.v1.model.AuditLog;
 import com.google.api.services.servicecontrol.v1.model.AuthenticationInfo;
@@ -20,7 +20,7 @@ import java.util.Map;
 public class GcpAudit extends SourcePayloadBase implements Serializable {
   private static final long serialVersionUID = 1L;
 
-  private final GsonFactory jfmatcher;
+  private final JacksonFactory jfmatcher;
 
   private String principalEmail;
   private String resource;
@@ -118,7 +118,7 @@ public class GcpAudit extends SourcePayloadBase implements Serializable {
 
   /** Construct matcher object. */
   public GcpAudit() {
-    jfmatcher = new GsonFactory();
+    jfmatcher = new JacksonFactory();
   }
 
   /**
@@ -134,7 +134,7 @@ public class GcpAudit extends SourcePayloadBase implements Serializable {
     if (entry == null) {
       // Use method local JacksonFactory as the object is not serializable, and this event
       // may be passed around
-      GsonFactory jf = new GsonFactory();
+      JacksonFactory jf = new JacksonFactory();
       JsonParser jp = null;
       try {
         jp = jf.createJsonParser(input);
@@ -165,7 +165,7 @@ public class GcpAudit extends SourcePayloadBase implements Serializable {
     AuditLog auditLog;
     JsonParser jp = null;
     try {
-      jp = new GsonFactory().createJsonParser(pbuf);
+      jp = new JacksonFactory().createJsonParser(pbuf);
       auditLog = jp.parse(AuditLog.class);
     } catch (IOException exc) {
       return;

--- a/src/main/java/com/mozilla/secops/parser/GcpVpcFlow.java
+++ b/src/main/java/com/mozilla/secops/parser/GcpVpcFlow.java
@@ -2,7 +2,7 @@ package com.mozilla.secops.parser;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.api.client.json.JsonParser;
-import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.logging.v2.model.LogEntry;
 import java.io.IOException;
 import java.io.Serializable;
@@ -47,10 +47,13 @@ public class GcpVpcFlow extends SourcePayloadBase implements Serializable {
     LogEntry entry = state.getLogEntryHint();
     if (entry == null) {
       // Reuse JacksonFactory from parser state
-      GsonFactory jf = state.getGoogleJacksonFactory();
+      JacksonFactory jf = state.getGoogleJacksonFactory();
       JsonParser jp = null;
-      jp = jf.createJsonParser(input);
-
+      try {
+        jp = jf.createJsonParser(input);
+      } catch (IOException exc) {
+        return;
+      }
       try {
         entry = jp.parse(LogEntry.class);
       } catch (IOException exc) {

--- a/src/main/java/com/mozilla/secops/parser/Nginx.java
+++ b/src/main/java/com/mozilla/secops/parser/Nginx.java
@@ -3,7 +3,7 @@ package com.mozilla.secops.parser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.client.json.JsonParser;
-import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.logging.v2.model.LogEntry;
 import java.io.IOException;
 import java.io.Serializable;
@@ -19,7 +19,7 @@ import org.joda.time.DateTime;
 public class Nginx extends SourcePayloadBase implements Serializable {
   private static final long serialVersionUID = 1L;
 
-  private static final GsonFactory jfmatcher = new GsonFactory();
+  private static final JacksonFactory jfmatcher = new JacksonFactory();
 
   private String xForwardedProto;
   private String userAgent;
@@ -114,7 +114,7 @@ public class Nginx extends SourcePayloadBase implements Serializable {
     if (entry == null) {
       // Use method local JacksonFactory as the object is not serializable, and this event
       // may be passed around
-      GsonFactory jf = state.getGoogleJacksonFactory();
+      JacksonFactory jf = state.getGoogleJacksonFactory();
       JsonParser jp = null;
       try {
         jp = jf.createJsonParser(input);

--- a/src/main/java/com/mozilla/secops/parser/Parser.java
+++ b/src/main/java/com/mozilla/secops/parser/Parser.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.google.api.client.json.JsonParser;
-import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.logging.v2.model.LogEntry;
 import com.google.api.services.logging.v2.model.MonitoredResource;
 import com.google.common.base.Splitter;
@@ -39,9 +39,9 @@ public class Parser {
   private static final long serialVersionUID = 1L;
 
   private final List<PayloadBase> payloads;
-  private final GsonFactory jf;
+  private final JacksonFactory jf;
   private final ObjectMapper mapper;
-  private final GsonFactory googleJacksonFactory;
+  private final JacksonFactory googleJacksonFactory;
   private final Logger log;
   private final ParserCfg cfg;
   private final CidrUtil parserXffCidrUtil;
@@ -570,7 +570,7 @@ public class Parser {
    */
   public Parser(ParserCfg cfg) {
     log = LoggerFactory.getLogger(Parser.class);
-    jf = new GsonFactory();
+    jf = new JacksonFactory();
 
     mapper = new ObjectMapper();
     mapper.registerModule(new JodaModule());
@@ -582,7 +582,7 @@ public class Parser {
     // Allows for null values in the JsonPayload in a LogEntry
     mapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
 
-    googleJacksonFactory = new GsonFactory();
+    googleJacksonFactory = new JacksonFactory();
 
     // Cache a CidrUtil instance used for XFF address extraction if needed
     parserXffCidrUtil = cfg.getXffAddressSelectorAsCidrUtil();

--- a/src/main/java/com/mozilla/secops/parser/ParserState.java
+++ b/src/main/java/com/mozilla/secops/parser/ParserState.java
@@ -10,7 +10,7 @@ class ParserState {
   private LogEntry logEntryHint;
   private CloudWatchEvent cloudwatchEvent;
   private Mozlog mozLogHint;
-  private com.google.api.client.json.gson.GsonFactory googleJacksonFactory;
+  private com.google.api.client.json.jackson2.JacksonFactory googleJacksonFactory;
   private ObjectMapper mapper;
   private String stackdriverTypeValue;
   private GeoIP geoIp;
@@ -168,7 +168,7 @@ class ParserState {
    * @param googleJacksonFactory JacksonFactory
    */
   public void setGoogleJacksonFactory(
-      com.google.api.client.json.gson.GsonFactory googleJacksonFactory) {
+      com.google.api.client.json.jackson2.JacksonFactory googleJacksonFactory) {
     this.googleJacksonFactory = googleJacksonFactory;
   }
 
@@ -177,7 +177,7 @@ class ParserState {
    *
    * @return JacksonFactory, or null if unset
    */
-  public com.google.api.client.json.gson.GsonFactory getGoogleJacksonFactory() {
+  public com.google.api.client.json.jackson2.JacksonFactory getGoogleJacksonFactory() {
     return googleJacksonFactory;
   }
 


### PR DESCRIPTION
This reverts commit dfd6db11dc932705c6259550280ee00226d6e8eb, reversing
changes made to 5cfad11e977dca5d9f968e8d7fa7b1a725fb5aa6.

Pipeline construction fails on the Dataflow runner and I suspect this is because of changes to making splittable dofn's the default.
Backing this out so I can cut a release and then I'll work on debugging this further.